### PR TITLE
docs: Clases de excepciones - Documentación JSDoc completa en español

### DIFF
--- a/src/shared/exceptions/AppError.ts
+++ b/src/shared/exceptions/AppError.ts
@@ -1,3 +1,14 @@
+/**
+ * Clase base para todas las excepciones personalizadas de la aplicación
+ * Extiende la clase Error nativa de JavaScript agregando información específica para APIs REST
+ */
+
+/**
+ * Crea una nueva instancia de error de aplicación
+ * @param message - Mensaje descriptivo del error para mostrar al usuario
+ * @param statusCode - Código de estado HTTP asociado al error (por defecto 500)
+ * @param code - Código interno del error para identificación programática (opcional)
+ */
 export class AppError extends Error {
   constructor(
     public readonly message: string,

--- a/src/shared/exceptions/ConflictError.ts
+++ b/src/shared/exceptions/ConflictError.ts
@@ -1,5 +1,23 @@
 import { AppError } from './AppError';
 
+/**
+ * Excepción para errores de conflicto cuando una operación no puede
+ *  completarse debido a conflictos con el estado actual
+ * Se utiliza para situaciones como recursos duplicados,
+ * violaciones de unicidad o estados incompatibles
+ * Mapea al código de estado HTTP 409 (Conflict)
+ */
+
+/**
+ * Crea una nueva instancia de error de conflicto
+ * @param message - Mensaje descriptivo del conflicto específico que ocurrió
+ * @example
+ * // Uso típico para recursos duplicados
+ * throw new ConflictError('A user with this email already exists')
+ *
+ * // Uso para estados incompatibles
+ * throw new ConflictError('Cannot delete status: 5 appointments are using this status')
+ */
 export class ConflictError extends AppError {
   constructor(message: string) {
     super(message, 409, 'CONFLICT');

--- a/src/shared/exceptions/ForbiddenError.ts
+++ b/src/shared/exceptions/ForbiddenError.ts
@@ -1,5 +1,23 @@
 import { AppError } from './AppError';
 
+/**
+ * Excepción para errores de acceso prohibido cuando el usuario
+ * está autenticado pero no tiene permisos
+ * Se utiliza cuando el usuario tiene credenciales válidas
+ * pero no está autorizado para realizar la acción
+ * Mapea al código de estado HTTP 403 (Forbidden)
+ */
+
+/**
+ * Crea una nueva instancia de error de acceso prohibido
+ * @param message - Mensaje descriptivo del acceso denegado (por defecto 'Forbidden')
+ * @example
+ * // Uso típico para permisos insuficientes
+ * throw new ForbiddenError('You do not have permission to delete this resource')
+ *
+ * // Uso para acceso a recursos de otros usuarios
+ * throw new ForbiddenError('You can only access your own appointments')
+ */
 export class ForbiddenError extends AppError {
   constructor(message: string = 'Forbidden') {
     super(message, 403);

--- a/src/shared/exceptions/NotFoundError.ts
+++ b/src/shared/exceptions/NotFoundError.ts
@@ -1,5 +1,25 @@
 import { AppError } from './AppError';
 
+/**
+ * Excepción para errores cuando un recurso solicitado no puede
+ * ser encontrado Se utiliza cuando se busca una entidad
+ * por ID, nombre u otro identificador y no existe Mapea
+ * al código de estado HTTP 404 (Not Found)
+ */
+
+/**
+ * Crea una nueva instancia de error de recurso no encontrado
+ * @param resource - Nombre del tipo de recurso que no se encontró (ej: 'User', 'Appointment', 'Service')
+ * @param identifier - Identificador específico que se buscó (ID, nombre, email, etc.)
+ * @example
+ * // Uso típico para entidades no encontradas
+ * throw new NotFoundError('User', userId)
+ * // Resultado: "User not found: 123e4567-e89b-12d3-a456-426614174000"
+ *
+ * // Uso para búsquedas por nombre
+ * throw new NotFoundError('AppointmentStatus', 'PENDING')
+ * // Resultado: "AppointmentStatus not found: PENDING"
+ */
 export class NotFoundError extends AppError {
   constructor(resource: string, identifier: string) {
     super(`${resource} not found: ${identifier}`, 404, 'NOT_FOUND');

--- a/src/shared/exceptions/UnauthorizedError.ts
+++ b/src/shared/exceptions/UnauthorizedError.ts
@@ -1,5 +1,25 @@
 import { AppError } from './AppError';
 
+/**
+ * Excepción para errores de autenticación cuando las credenciales
+ * son inválidas o faltan. Se utiliza cuando el usuario no está
+ * autenticado o sus credenciales son incorrectas
+ * Mapea al código de estado HTTP 401 (Unauthorized)
+ */
+
+/**
+ * Crea una nueva instancia de error de autenticación
+ * @param message - Mensaje descriptivo del error de autenticación (por defecto 'Unauthorized')
+ * @example
+ * // Uso típico para credenciales inválidas
+ * throw new UnauthorizedError('Invalid email or password')
+ *
+ * // Uso para tokens expirados
+ * throw new UnauthorizedError('Token has expired, please login again')
+ *
+ * // Uso para falta de autenticación
+ * throw new UnauthorizedError('Authentication required to access this resource')
+ */
 export class UnauthorizedError extends AppError {
   constructor(message: string = 'Unauthorized') {
     super(message, 401, 'UNAUTHORIZED');

--- a/src/shared/exceptions/ValidationError.ts
+++ b/src/shared/exceptions/ValidationError.ts
@@ -1,5 +1,20 @@
 import { AppError } from './AppError';
 
+/**
+ * Excepción para errores de validación cuando los datos
+ * de entrada no cumplen con los requisitos
+ * Se utiliza para validaciones de formato, rangos,
+ * campos requeridos y reglas de negocio
+ * Mapea al código de estado HTTP 400 (Bad Request)
+ */
+
+/**
+ * Crea una nueva instancia de error de validación
+ * @param message - Mensaje descriptivo específico de la validación que falló
+ * @example
+ * Uso típico para campos requeridos
+ * throw new ValidationError('Email is required')
+ */
 export class ValidationError extends AppError {
   constructor(message: string) {
     super(message, 400, 'VALIDATION_ERROR');


### PR DESCRIPTION
- AppError: Clase base documentada con propósito y parámetros del constructor
- ConflictError: JSDoc para errores de conflicto (409) con ejemplos de uso
- ForbiddenError: Documentación de errores de acceso prohibido (403)
- NotFoundError: JSDoc para recursos no encontrados (404) con ejemplos prácticos
- UnauthorizedError: Documentación de errores de autenticación (401)
- ValidationError: JSDoc para errores de validación (400) con casos de uso
- Ejemplos prácticos de uso para cada tipo de excepción
- Mapeo claro de códigos HTTP y propósitos específicos