### PR TITLE
test(services): reescribir y renombrar tests unitarios para use cases individuales

### DIFF
--- a/tests/unit/services/CategoryUseCases.unit.test.ts
+++ b/tests/unit/services/CategoryUseCases.unit.test.ts
@@ -1,12 +1,18 @@
-import { CategoryService } from '../../../src/modules/services/application/services/CategoryService';
+import { CreateCategory } from '../../../src/modules/services/application/use-cases/CreateCategory';
+import { UpdateCategory } from '../../../src/modules/services/application/use-cases/UpdateCategory';
+import { GetCategoryById } from '../../../src/modules/services/application/use-cases/GetCategoryById';
+import { GetAllCategories } from '../../../src/modules/services/application/use-cases/GetAllCategories';
+import { GetActiveCategories } from '../../../src/modules/services/application/use-cases/GetActiveCategories';
+import { ActivateCategory } from '../../../src/modules/services/application/use-cases/ActivateCategory';
+import { DeactivateCategory } from '../../../src/modules/services/application/use-cases/DeactivateCategory';
+import { DeleteCategory } from '../../../src/modules/services/application/use-cases/DeleteCategory';
 import { CategoryRepository } from '../../../src/modules/services/domain/repositories/CategoryRepository';
 import { Category } from '../../../src/modules/services/domain/entities/Category';
 import { ValidationError } from '../../../src/shared/exceptions/ValidationError';
 import { NotFoundError } from '../../../src/shared/exceptions/NotFoundError';
 import { ConflictError } from '../../../src/shared/exceptions/ConflictError';
 
-describe('CategoryService', () => {
-  let categoryService: CategoryService;
+describe('Category Use Cases', () => {
   let mockCategoryRepository: jest.Mocked<CategoryRepository>;
 
   beforeEach(() => {
@@ -21,23 +27,26 @@ describe('CategoryService', () => {
       existsById: jest.fn(),
       existsByName: jest.fn(),
     };
-
-    categoryService = new CategoryService(mockCategoryRepository);
   });
 
-  describe('createCategory', () => {
+  describe('CreateCategory', () => {
+    let createCategory: CreateCategory;
+
+    beforeEach(() => {
+      createCategory = new CreateCategory(mockCategoryRepository);
+    });
+
     const validCreateDto = {
       name: 'Hair Services',
       description: 'Professional hair styling services',
     };
 
-    // Debería crear categoría exitosamente
     it('should create category successfully', async () => {
       const mockCategory = Category.create(validCreateDto.name, validCreateDto.description);
       mockCategoryRepository.existsByName.mockResolvedValue(false);
       mockCategoryRepository.save.mockResolvedValue(mockCategory);
 
-      const result = await categoryService.createCategory(validCreateDto);
+      const result = await createCategory.execute(validCreateDto);
 
       expect(mockCategoryRepository.existsByName).toHaveBeenCalledWith(validCreateDto.name);
       expect(mockCategoryRepository.save).toHaveBeenCalled();
@@ -45,28 +54,29 @@ describe('CategoryService', () => {
       expect(result.description).toBe(validCreateDto.description);
     });
 
-    // Debería lanzar ValidationError para nombre vacío
     it('should throw ValidationError for empty name', async () => {
       const invalidDto = { ...validCreateDto, name: '' };
-
-      await expect(categoryService.createCategory(invalidDto)).rejects.toThrow(ValidationError);
+      await expect(createCategory.execute(invalidDto)).rejects.toThrow(ValidationError);
     });
 
-    // Debería lanzar ConflictError si el nombre ya existe
     it('should throw ConflictError if name already exists', async () => {
       mockCategoryRepository.existsByName.mockResolvedValue(true);
-
-      await expect(categoryService.createCategory(validCreateDto)).rejects.toThrow(ConflictError);
+      await expect(createCategory.execute(validCreateDto)).rejects.toThrow(ConflictError);
     });
   });
 
-  describe('updateCategory', () => {
+  describe('UpdateCategory', () => {
+    let updateCategory: UpdateCategory;
+
+    beforeEach(() => {
+      updateCategory = new UpdateCategory(mockCategoryRepository);
+    });
+
     const validUpdateDto = {
       name: 'Updated Hair Services',
       description: 'Updated description',
     };
 
-    // Debería actualizar categoría exitosamente
     it('should update category successfully', async () => {
       const existingCategory = Category.create('Hair Services', 'Original description');
       const updatedCategory = Category.create(validUpdateDto.name!, validUpdateDto.description);
@@ -75,84 +85,92 @@ describe('CategoryService', () => {
       mockCategoryRepository.existsByName.mockResolvedValue(false);
       mockCategoryRepository.update.mockResolvedValue(updatedCategory);
 
-      const result = await categoryService.updateCategory('test-id', validUpdateDto);
+      const result = await updateCategory.execute('test-id', validUpdateDto);
 
       expect(mockCategoryRepository.findById).toHaveBeenCalledWith('test-id');
       expect(mockCategoryRepository.update).toHaveBeenCalled();
       expect(result.name).toBe(validUpdateDto.name);
     });
 
-    // Debería lanzar NotFoundError si la categoría no se encuentra
     it('should throw NotFoundError if category not found', async () => {
       mockCategoryRepository.findById.mockResolvedValue(null);
-
-      await expect(
-        categoryService.updateCategory('non-existent-id', validUpdateDto),
-      ).rejects.toThrow(NotFoundError);
+      await expect(updateCategory.execute('non-existent-id', validUpdateDto)).rejects.toThrow(NotFoundError);
     });
 
-    // Debería lanzar ConflictError si el nuevo nombre ya existe
     it('should throw ConflictError if new name already exists', async () => {
       const existingCategory = Category.create('Hair Services');
       mockCategoryRepository.findById.mockResolvedValue(existingCategory);
       mockCategoryRepository.existsByName.mockResolvedValue(true);
-
-      await expect(categoryService.updateCategory('test-id', validUpdateDto)).rejects.toThrow(
-        ConflictError,
-      );
+      await expect(updateCategory.execute('test-id', validUpdateDto)).rejects.toThrow(ConflictError);
     });
   });
 
-  describe('getCategoryById', () => {
-    // Debería devolver categoría cuando se encuentra
+  describe('GetCategoryById', () => {
+    let getCategoryById: GetCategoryById;
+
+    beforeEach(() => {
+      getCategoryById = new GetCategoryById(mockCategoryRepository);
+    });
+
     it('should return category when found', async () => {
       const mockCategory = Category.create('Hair Services');
       mockCategoryRepository.findById.mockResolvedValue(mockCategory);
 
-      const result = await categoryService.getCategoryById('test-id');
+      const result = await getCategoryById.execute('test-id');
 
       expect(mockCategoryRepository.findById).toHaveBeenCalledWith('test-id');
       expect(result.id).toBe(mockCategory.id);
     });
 
-    // Debería lanzar NotFoundError cuando la categoría no se encuentra
     it('should throw NotFoundError when category not found', async () => {
       mockCategoryRepository.findById.mockResolvedValue(null);
-
-      await expect(categoryService.getCategoryById('non-existent-id')).rejects.toThrow(
-        NotFoundError,
-      );
+      await expect(getCategoryById.execute('non-existent-id')).rejects.toThrow(NotFoundError);
     });
   });
 
-  describe('getAllCategories', () => {
-    // Debería devolver todas las categorías
+  describe('GetAllCategories', () => {
+    let getAllCategories: GetAllCategories;
+
+    beforeEach(() => {
+      getAllCategories = new GetAllCategories(mockCategoryRepository);
+    });
+
     it('should return all categories', async () => {
       const mockCategories = [Category.create('Hair Services'), Category.create('Nail Services')];
       mockCategoryRepository.findAll.mockResolvedValue(mockCategories);
 
-      const result = await categoryService.getAllCategories();
+      const result = await getAllCategories.execute();
 
       expect(mockCategoryRepository.findAll).toHaveBeenCalled();
       expect(result).toHaveLength(2);
     });
   });
 
-  describe('getActiveCategories', () => {
-    // Debería devolver solo las categorías activas
+  describe('GetActiveCategories', () => {
+    let getActiveCategories: GetActiveCategories;
+
+    beforeEach(() => {
+      getActiveCategories = new GetActiveCategories(mockCategoryRepository);
+    });
+
     it('should return only active categories', async () => {
       const mockCategories = [Category.create('Hair Services'), Category.create('Nail Services')];
       mockCategoryRepository.findActive.mockResolvedValue(mockCategories);
 
-      const result = await categoryService.getActiveCategories();
+      const result = await getActiveCategories.execute();
 
       expect(mockCategoryRepository.findActive).toHaveBeenCalled();
       expect(result).toHaveLength(2);
     });
   });
 
-  describe('activateCategory', () => {
-    // Debería activar categoría exitosamente
+  describe('ActivateCategory', () => {
+    let activateCategory: ActivateCategory;
+
+    beforeEach(() => {
+      activateCategory = new ActivateCategory(mockCategoryRepository);
+    });
+
     it('should activate category successfully', async () => {
       const category = Category.create('Hair Services');
       category.deactivate();
@@ -160,32 +178,33 @@ describe('CategoryService', () => {
       mockCategoryRepository.findById.mockResolvedValue(category);
       mockCategoryRepository.update.mockResolvedValue(category);
 
-      const result = await categoryService.activateCategory('test-id');
+      const result = await activateCategory.execute('test-id');
 
       expect(mockCategoryRepository.findById).toHaveBeenCalledWith('test-id');
       expect(mockCategoryRepository.update).toHaveBeenCalled();
       expect(result.isActive).toBe(true);
     });
 
-    //Debería lanzar NotFoundError si no se encuentra la categoría
     it('should throw NotFoundError if category not found', async () => {
       mockCategoryRepository.findById.mockResolvedValue(null);
-
-      await expect(categoryService.activateCategory('non-existent-id')).rejects.toThrow(
-        NotFoundError,
-      );
+      await expect(activateCategory.execute('non-existent-id')).rejects.toThrow(NotFoundError);
     });
   });
 
-  describe('deactivateCategory', () => {
-    // Debería desactivar categoría exitosamente
+  describe('DeactivateCategory', () => {
+    let deactivateCategory: DeactivateCategory;
+
+    beforeEach(() => {
+      deactivateCategory = new DeactivateCategory(mockCategoryRepository);
+    });
+
     it('should deactivate category successfully', async () => {
       const category = Category.create('Hair Services');
 
       mockCategoryRepository.findById.mockResolvedValue(category);
       mockCategoryRepository.update.mockResolvedValue(category);
 
-      const result = await categoryService.deactivateCategory('test-id');
+      const result = await deactivateCategory.execute('test-id');
 
       expect(mockCategoryRepository.findById).toHaveBeenCalledWith('test-id');
       expect(mockCategoryRepository.update).toHaveBeenCalled();
@@ -193,25 +212,26 @@ describe('CategoryService', () => {
     });
   });
 
-  describe('deleteCategory', () => {
-    // Debería eliminar categoría exitosamente
+  describe('DeleteCategory', () => {
+    let deleteCategory: DeleteCategory;
+
+    beforeEach(() => {
+      deleteCategory = new DeleteCategory(mockCategoryRepository);
+    });
+
     it('should delete category successfully', async () => {
       mockCategoryRepository.existsById.mockResolvedValue(true);
       mockCategoryRepository.delete.mockResolvedValue();
 
-      await categoryService.deleteCategory('test-id');
+      await deleteCategory.execute('test-id');
 
       expect(mockCategoryRepository.existsById).toHaveBeenCalledWith('test-id');
       expect(mockCategoryRepository.delete).toHaveBeenCalledWith('test-id');
     });
 
-    //Debería lanzar NotFoundError si no se encuentra la categoría
     it('should throw NotFoundError if category not found', async () => {
       mockCategoryRepository.existsById.mockResolvedValue(false);
-
-      await expect(categoryService.deleteCategory('non-existent-id')).rejects.toThrow(
-        NotFoundError,
-      );
+      await expect(deleteCategory.execute('non-existent-id')).rejects.toThrow(NotFoundError);
     });
   });
 });

--- a/tests/unit/services/ServiceUseCases.unit.test.ts
+++ b/tests/unit/services/ServiceUseCases.unit.test.ts
@@ -1,4 +1,9 @@
-import { ServiceManagementService } from '../../../src/modules/services/application/services/ServiceManagementService';
+import { CreateService } from '../../../src/modules/services/application/use-cases/CreateService';
+import { UpdateService } from '../../../src/modules/services/application/use-cases/UpdateService';
+import { GetServiceById } from '../../../src/modules/services/application/use-cases/GetServiceById';
+import { GetServicesByCategory } from '../../../src/modules/services/application/use-cases/GetServicesByCategory';
+import { ActivateService } from '../../../src/modules/services/application/use-cases/ActivateService';
+import { DeleteService } from '../../../src/modules/services/application/use-cases/DeleteService';
 import { ServiceRepository } from '../../../src/modules/services/domain/repositories/ServiceRepository';
 import { CategoryRepository } from '../../../src/modules/services/domain/repositories/CategoryRepository';
 import { Service } from '../../../src/modules/services/domain/entities/Service';
@@ -7,8 +12,7 @@ import { ValidationError } from '../../../src/shared/exceptions/ValidationError'
 import { NotFoundError } from '../../../src/shared/exceptions/NotFoundError';
 import { ConflictError } from '../../../src/shared/exceptions/ConflictError';
 
-describe('ServiceManagementService', () => {
-  let serviceManagementService: ServiceManagementService;
+describe('Service Use Cases', () => {
   let mockServiceRepository: jest.Mocked<ServiceRepository>;
   let mockCategoryRepository: jest.Mocked<CategoryRepository>;
 
@@ -38,14 +42,15 @@ describe('ServiceManagementService', () => {
       existsById: jest.fn(),
       existsByName: jest.fn(),
     };
-
-    serviceManagementService = new ServiceManagementService(
-      mockServiceRepository,
-      mockCategoryRepository,
-    );
   });
 
-  describe('createService', () => {
+  describe('CreateService', () => {
+    let createService: CreateService;
+
+    beforeEach(() => {
+      createService = new CreateService(mockServiceRepository, mockCategoryRepository);
+    });
+
     const validCreateDto = {
       categoryId: 'category-id',
       name: 'Hair Cut',
@@ -55,7 +60,6 @@ describe('ServiceManagementService', () => {
       price: 2500,
     };
 
-    // Debería crear servicio exitosamente
     it('should create service successfully', async () => {
       const mockCategory = Category.create('Hair Services');
       const mockService = Service.create(
@@ -71,7 +75,7 @@ describe('ServiceManagementService', () => {
       mockServiceRepository.existsByName.mockResolvedValue(false);
       mockServiceRepository.save.mockResolvedValue(mockService);
 
-      const result = await serviceManagementService.createService(validCreateDto);
+      const result = await createService.execute(validCreateDto);
 
       expect(mockCategoryRepository.findById).toHaveBeenCalledWith(validCreateDto.categoryId);
       expect(mockServiceRepository.existsByName).toHaveBeenCalledWith(validCreateDto.name);
@@ -79,41 +83,34 @@ describe('ServiceManagementService', () => {
       expect(result.name).toBe(validCreateDto.name);
     });
 
-    // Debería lanzar NotFoundError si la categoría no se encuentra
     it('should throw NotFoundError if category not found', async () => {
       mockCategoryRepository.findById.mockResolvedValue(null);
-
-      await expect(serviceManagementService.createService(validCreateDto)).rejects.toThrow(
-        NotFoundError,
-      );
+      await expect(createService.execute(validCreateDto)).rejects.toThrow(NotFoundError);
     });
 
-    // Debería lanzar ConflictError si el nombre del servicio ya existe
     it('should throw ConflictError if service name already exists', async () => {
       const mockCategory = Category.create('Hair Services');
       mockCategoryRepository.findById.mockResolvedValue(mockCategory);
       mockServiceRepository.existsByName.mockResolvedValue(true);
-
-      await expect(serviceManagementService.createService(validCreateDto)).rejects.toThrow(
-        ConflictError,
-      );
+      await expect(createService.execute(validCreateDto)).rejects.toThrow(ConflictError);
     });
 
-    // Debería lanzar ValidationError para variación de duración inválida
     it('should throw ValidationError for invalid duration variation', async () => {
-      const invalidDto = { ...validCreateDto, durationVariation: 60 }; // > duration
+      const invalidDto = { ...validCreateDto, durationVariation: 60 };
       const mockCategory = Category.create('Hair Services');
       mockCategoryRepository.findById.mockResolvedValue(mockCategory);
       mockServiceRepository.existsByName.mockResolvedValue(false);
-
-      await expect(serviceManagementService.createService(invalidDto)).rejects.toThrow(
-        ValidationError,
-      );
+      await expect(createService.execute(invalidDto)).rejects.toThrow(ValidationError);
     });
   });
 
-  describe('getServiceById', () => {
-    // Debería devolver servicio con categoría cuando se encuentra
+  describe('GetServiceById', () => {
+    let getServiceById: GetServiceById;
+
+    beforeEach(() => {
+      getServiceById = new GetServiceById(mockServiceRepository, mockCategoryRepository);
+    });
+
     it('should return service with category when found', async () => {
       const mockCategory = Category.create('Hair Services');
       const mockService = Service.create('category-id', 'Hair Cut', 'Description', 45, 15, 2500);
@@ -121,7 +118,7 @@ describe('ServiceManagementService', () => {
       mockServiceRepository.findById.mockResolvedValue(mockService);
       mockCategoryRepository.findById.mockResolvedValue(mockCategory);
 
-      const result = await serviceManagementService.getServiceById('service-id');
+      const result = await getServiceById.execute('service-id');
 
       expect(mockServiceRepository.findById).toHaveBeenCalledWith('service-id');
       expect(mockCategoryRepository.findById).toHaveBeenCalledWith('category-id');
@@ -129,18 +126,19 @@ describe('ServiceManagementService', () => {
       expect(result.category).toBeDefined();
     });
 
-    // Debería lanzar NotFoundError cuando el servicio no se encuentra
     it('should throw NotFoundError when service not found', async () => {
       mockServiceRepository.findById.mockResolvedValue(null);
-
-      await expect(serviceManagementService.getServiceById('non-existent-id')).rejects.toThrow(
-        NotFoundError,
-      );
+      await expect(getServiceById.execute('non-existent-id')).rejects.toThrow(NotFoundError);
     });
   });
 
-  describe('getServicesByCategory', () => {
-    // Debería devolver servicios para categoría existente
+  describe('GetServicesByCategory', () => {
+    let getServicesByCategory: GetServicesByCategory;
+
+    beforeEach(() => {
+      getServicesByCategory = new GetServicesByCategory(mockServiceRepository, mockCategoryRepository);
+    });
+
     it('should return services for existing category', async () => {
       const mockCategory = Category.create('Hair Services');
       const mockServices = [
@@ -151,25 +149,26 @@ describe('ServiceManagementService', () => {
       mockCategoryRepository.findById.mockResolvedValue(mockCategory);
       mockServiceRepository.findByCategory.mockResolvedValue(mockServices);
 
-      const result = await serviceManagementService.getServicesByCategory('category-id');
+      const result = await getServicesByCategory.execute('category-id');
 
       expect(mockCategoryRepository.findById).toHaveBeenCalledWith('category-id');
       expect(mockServiceRepository.findByCategory).toHaveBeenCalledWith('category-id');
       expect(result).toHaveLength(2);
     });
 
-    //Debería lanzar NotFoundError si no se encuentra la categoría
     it('should throw NotFoundError if category not found', async () => {
       mockCategoryRepository.findById.mockResolvedValue(null);
-
-      await expect(
-        serviceManagementService.getServicesByCategory('non-existent-id'),
-      ).rejects.toThrow(NotFoundError);
+      await expect(getServicesByCategory.execute('non-existent-id')).rejects.toThrow(NotFoundError);
     });
   });
 
-  describe('activateService', () => {
-    // Debería activar servicio exitosamente
+  describe('ActivateService', () => {
+    let activateService: ActivateService;
+
+    beforeEach(() => {
+      activateService = new ActivateService(mockServiceRepository, mockCategoryRepository);
+    });
+
     it('should activate service successfully', async () => {
       const mockCategory = Category.create('Hair Services');
       const mockService = Service.create('category-id', 'Hair Cut', 'Description', 45, 15, 2500);
@@ -179,31 +178,49 @@ describe('ServiceManagementService', () => {
       mockServiceRepository.update.mockResolvedValue(mockService);
       mockCategoryRepository.findById.mockResolvedValue(mockCategory);
 
-      const result = await serviceManagementService.activateService('service-id');
+      const result = await activateService.execute('service-id');
 
       expect(result.isActive).toBe(true);
     });
   });
 
-  describe('deleteService', () => {
-    // Debería eliminar servicio exitosamente
+  describe('DeleteService', () => {
+    let deleteService: DeleteService;
+
+    beforeEach(() => {
+      deleteService = new DeleteService(mockServiceRepository);
+    });
+
     it('should delete service successfully', async () => {
       mockServiceRepository.existsById.mockResolvedValue(true);
       mockServiceRepository.delete.mockResolvedValue();
 
-      await serviceManagementService.deleteService('service-id');
+      await deleteService.execute('service-id');
 
       expect(mockServiceRepository.existsById).toHaveBeenCalledWith('service-id');
       expect(mockServiceRepository.delete).toHaveBeenCalledWith('service-id');
     });
 
-    // Debería lanzar NotFoundError si el servicio no se encuentra
     it('should throw NotFoundError if service not found', async () => {
       mockServiceRepository.existsById.mockResolvedValue(false);
+      await expect(deleteService.execute('non-existent-id')).rejects.toThrow(NotFoundError);
+    });
+  });
 
-      await expect(serviceManagementService.deleteService('non-existent-id')).rejects.toThrow(
-        NotFoundError,
-      );
+  describe('UpdateService', () => {
+    let updateService: UpdateService;
+
+    beforeEach(() => {
+      updateService = new UpdateService(mockServiceRepository, mockCategoryRepository);
+    });
+
+    it('should throw NotFoundError if service not found', async () => {
+      mockServiceRepository.findById.mockResolvedValue(null);
+      await expect(updateService.execute('non-existent-id', { name: 'New Name' })).rejects.toThrow(NotFoundError);
+    });
+
+    it('should throw ValidationError if no fields provided', async () => {
+      await expect(updateService.execute('service-id', {})).rejects.toThrow(ValidationError);
     });
   });
 });

--- a/tests/unit/services/StylistServiceUseCases.unit.test.ts
+++ b/tests/unit/services/StylistServiceUseCases.unit.test.ts
@@ -1,4 +1,10 @@
-import { StylistServiceService } from '../../../src/modules/services/application/services/StylistServiceService';
+import { AssignServiceToStylist } from '../../../src/modules/services/application/use-cases/AssignServiceToStylist';
+import { UpdateStylistService } from '../../../src/modules/services/application/use-cases/UpdateStylistService';
+import { RemoveServiceFromStylist } from '../../../src/modules/services/application/use-cases/RemoveServiceFromStylist';
+import { GetStylistServices } from '../../../src/modules/services/application/use-cases/GetStylistServices';
+import { GetStylistsOfferingService } from '../../../src/modules/services/application/use-cases/GetStylistsOfferingService';
+import { GetStylistWithServices } from '../../../src/modules/services/application/use-cases/GetStylistWithServices';
+import { GetServiceWithStylists } from '../../../src/modules/services/application/use-cases/GetServiceWithStylists';
 import { StylistServiceRepository } from '../../../src/modules/services/domain/repositories/StylistServiceRepository';
 import { ServiceRepository } from '../../../src/modules/services/domain/repositories/ServiceRepository';
 import { StylistRepository } from '../../../src/modules/services/domain/repositories/StylistRepository';
@@ -11,8 +17,7 @@ import { ValidationError } from '../../../src/shared/exceptions/ValidationError'
 import { NotFoundError } from '../../../src/shared/exceptions/NotFoundError';
 import { ConflictError } from '../../../src/shared/exceptions/ConflictError';
 
-describe('StylistServiceService', () => {
-  let stylistServiceService: StylistServiceService;
+describe('StylistService Use Cases', () => {
   let mockStylistServiceRepository: jest.Mocked<StylistServiceRepository>;
   let mockServiceRepository: jest.Mocked<ServiceRepository>;
   let mockUserRepository: jest.Mocked<UserRepository>;
@@ -67,39 +72,30 @@ describe('StylistServiceService', () => {
       delete: jest.fn(),
       existsById: jest.fn(),
     };
-
-    stylistServiceService = new StylistServiceService(
-      mockStylistServiceRepository,
-      mockServiceRepository,
-      mockUserRepository,
-      mockStylistRepository,
-    );
   });
 
-  describe('assignServiceToStylist', () => {
-    const assignDto = {
-      serviceId: 'service-id',
-      customPrice: 3000,
-    };
+  describe('AssignServiceToStylist', () => {
+    let assignServiceToStylist: AssignServiceToStylist;
 
-    // Debería asignar servicio al estilista exitosamente
+    beforeEach(() => {
+      assignServiceToStylist = new AssignServiceToStylist(
+        mockStylistServiceRepository,
+        mockServiceRepository,
+        mockUserRepository,
+        mockStylistRepository,
+      );
+    });
+
+    const assignDto = { serviceId: 'service-id', customPrice: 3000 };
+
     it('should assign service to stylist successfully', async () => {
       const mockStylist = Stylist.create('user-id');
       Object.defineProperty(mockStylist, 'id', { value: 'stylist-id', writable: false });
 
       const mockUserWithRole = {
-        id: 'user-id',
-        roleId: 'stylist-role-id',
-        name: 'Test User',
-        email: 'test@example.com',
-        phone: '+1234567890',
-        password: 'password',
-        isActive: true,
-        role: {
-          id: 'stylist-role-id',
-          name: 'STYLIST',
-          description: 'Estilista que ofrece servicios',
-        },
+        id: 'user-id', roleId: 'stylist-role-id', name: 'Test User',
+        email: 'test@example.com', phone: '+1234567890', password: 'password',
+        isActive: true, role: { id: 'stylist-role-id', name: 'STYLIST', description: 'Estilista' },
       };
       const mockService = Service.create('category-id', 'Hair Cut', 'Description', 45, 15, 2500);
       const mockStylistService = StylistService.create('stylist-id', 'service-id', 3000);
@@ -110,104 +106,56 @@ describe('StylistServiceService', () => {
       mockStylistServiceRepository.existsAssignment.mockResolvedValue(false);
       mockStylistServiceRepository.save.mockResolvedValue(mockStylistService);
 
-      const result = await stylistServiceService.assignServiceToStylist('stylist-id', assignDto);
+      const result = await assignServiceToStylist.execute('stylist-id', assignDto);
 
       expect(mockStylistRepository.findById).toHaveBeenCalledWith('stylist-id');
       expect(mockUserRepository.findByIdWithRole).toHaveBeenCalledWith('user-id');
       expect(mockServiceRepository.findById).toHaveBeenCalledWith('service-id');
-      expect(mockStylistServiceRepository.existsAssignment).toHaveBeenCalledWith(
-        'stylist-id',
-        'service-id',
-      );
+      expect(mockStylistServiceRepository.existsAssignment).toHaveBeenCalledWith('stylist-id', 'service-id');
       expect(mockStylistServiceRepository.save).toHaveBeenCalled();
       expect(result.stylistId).toBe('stylist-id');
       expect(result.serviceId).toBe('service-id');
     });
 
-    // Debería lanzar NotFoundError si el estilista no se encuentra
     it('should throw NotFoundError if stylist not found', async () => {
       mockStylistRepository.findById.mockResolvedValue(null);
-
-      await expect(
-        stylistServiceService.assignServiceToStylist('non-existent-stylist', assignDto),
-      ).rejects.toThrow(NotFoundError);
+      await expect(assignServiceToStylist.execute('non-existent-stylist', assignDto)).rejects.toThrow(NotFoundError);
     });
 
-    // Debería lanzar NotFoundError si el servicio no se encuentra
     it('should throw NotFoundError if service not found', async () => {
       const mockStylist = Stylist.create('user-id');
       Object.defineProperty(mockStylist, 'id', { value: 'stylist-id', writable: false });
-
       const mockUserWithRole = {
-        id: 'user-id',
-        roleId: 'stylist-role-id',
-        name: 'Test User',
-        email: 'test@example.com',
-        phone: '+1234567890',
-        password: 'password',
-        isActive: true,
-        role: {
-          id: 'stylist-role-id',
-          name: 'STYLIST',
-          description: 'Estilista que ofrece servicios',
-        },
+        id: 'user-id', roleId: 'stylist-role-id', name: 'Test User',
+        email: 'test@example.com', phone: '+1234567890', password: 'password',
+        isActive: true, role: { id: 'stylist-role-id', name: 'STYLIST', description: 'Estilista' },
       };
-
       mockStylistRepository.findById.mockResolvedValue(mockStylist);
       mockUserRepository.findByIdWithRole.mockResolvedValue(mockUserWithRole);
       mockServiceRepository.findById.mockResolvedValue(null);
-
-      await expect(
-        stylistServiceService.assignServiceToStylist('stylist-id', assignDto),
-      ).rejects.toThrow(NotFoundError);
+      await expect(assignServiceToStylist.execute('stylist-id', assignDto)).rejects.toThrow(NotFoundError);
     });
 
-    // Debería lanzar ValidationError si el usuario no es estilista
     it('should throw ValidationError if user is not a stylist', async () => {
       const mockStylist = Stylist.create('user-id');
       Object.defineProperty(mockStylist, 'id', { value: 'stylist-id', writable: false });
-
       const mockUserWithRole = {
-        id: 'user-id',
-        roleId: 'client-role-id',
-        name: 'Test User',
-        email: 'test@example.com',
-        phone: '+1234567890',
-        password: 'password',
-        isActive: true,
-        role: {
-          id: 'client-role-id',
-          name: 'CLIENT',
-          description: 'Cliente que puede agendar citas',
-        },
+        id: 'user-id', roleId: 'client-role-id', name: 'Test User',
+        email: 'test@example.com', phone: '+1234567890', password: 'password',
+        isActive: true, role: { id: 'client-role-id', name: 'CLIENT', description: 'Cliente' },
       };
-
       mockStylistRepository.findById.mockResolvedValue(mockStylist);
       mockUserRepository.findByIdWithRole.mockResolvedValue(mockUserWithRole);
-
-      await expect(
-        stylistServiceService.assignServiceToStylist('stylist-id', assignDto),
-      ).rejects.toThrow(ValidationError);
+      await expect(assignServiceToStylist.execute('stylist-id', assignDto)).rejects.toThrow(ValidationError);
     });
 
-    // Debería lanzar ConflictError si la asignación ya existe
     it('should throw ConflictError if assignment already exists', async () => {
       const mockStylist = Stylist.create('user-id');
       Object.defineProperty(mockStylist, 'id', { value: 'stylist-id', writable: false });
-
       const mockUserWithRole = {
-        id: 'user-id',
-        roleId: 'stylist-role-id',
-        name: 'Test User',
-        email: 'test@example.com',
-        phone: '+1234567890',
-        password: 'password',
-        isActive: true,
-        role: {
-          id: 'stylist-role-id',
-          name: 'STYLIST',
-          description: 'Estilista que ofrece servicios',
-        },
+        id: 'user-id', roleId: 'stylist-role-id', name: 'Test User',
+        email: 'test@example.com', phone: '+1234567890', password: 'password',
+        isActive: true, role: { id: 'stylist-role-id', name: 'STYLIST', description: 'Estilista' },
       };
       const mockService = Service.create('category-id', 'Hair Cut', 'Description', 45, 15, 2500);
 
@@ -216,14 +164,21 @@ describe('StylistServiceService', () => {
       mockServiceRepository.findById.mockResolvedValue(mockService);
       mockStylistServiceRepository.existsAssignment.mockResolvedValue(true);
 
-      await expect(
-        stylistServiceService.assignServiceToStylist('stylist-id', assignDto),
-      ).rejects.toThrow(ConflictError);
+      await expect(assignServiceToStylist.execute('stylist-id', assignDto)).rejects.toThrow(ConflictError);
     });
   });
 
-  describe('getStylistServices', () => {
-    // Debería devolver servicios del estilista exitosamente
+  describe('GetStylistServices', () => {
+    let getStylistServices: GetStylistServices;
+
+    beforeEach(() => {
+      getStylistServices = new GetStylistServices(
+        mockStylistServiceRepository,
+        mockServiceRepository,
+        mockStylistRepository,
+      );
+    });
+
     it('should return stylist services successfully', async () => {
       const mockStylist = Stylist.create('user-id');
       const mockStylistServices = [
@@ -234,44 +189,43 @@ describe('StylistServiceService', () => {
         Service.create('category-id', 'Hair Cut', 'Description', 45, 15, 2500),
         Service.create('category-id', 'Hair Wash', 'Description', 30, 10, 1500),
       ];
-
       Object.defineProperty(mockServices[0], 'id', { value: 'service-1', writable: false });
       Object.defineProperty(mockServices[1], 'id', { value: 'service-2', writable: false });
 
       mockStylistRepository.findById.mockResolvedValue(mockStylist);
       mockStylistServiceRepository.findByStylist.mockResolvedValue(mockStylistServices);
-
-      // Mock para que findById retorne los servicios correctos según el serviceId
       mockServiceRepository.findById.mockImplementation((serviceId: string) => {
         if (serviceId === 'service-1') return Promise.resolve(mockServices[0]);
         if (serviceId === 'service-2') return Promise.resolve(mockServices[1]);
         return Promise.resolve(null);
       });
 
-      const result = await stylistServiceService.getStylistServices('stylist-id');
+      const result = await getStylistServices.execute('stylist-id');
 
       expect(mockStylistRepository.findById).toHaveBeenCalledWith('stylist-id');
       expect(mockStylistServiceRepository.findByStylist).toHaveBeenCalledWith('stylist-id');
       expect(result).toHaveLength(2);
     });
 
-    //Debería lanzar NotFoundError si no se encuentra el estilista
     it('should throw NotFoundError if stylist not found', async () => {
       mockStylistRepository.findById.mockResolvedValue(null);
-
-      await expect(
-        stylistServiceService.getStylistServices('non-existent-stylist'),
-      ).rejects.toThrow(NotFoundError);
+      await expect(getStylistServices.execute('non-existent-stylist')).rejects.toThrow(NotFoundError);
     });
   });
 
-  describe('updateStylistService', () => {
-    const updateDto = {
-      customPrice: 3500,
-      isOffering: false,
-    };
+  describe('UpdateStylistService', () => {
+    let updateStylistService: UpdateStylistService;
 
-    // Debería actualizar servicio de estilista exitosamente
+    beforeEach(() => {
+      updateStylistService = new UpdateStylistService(
+        mockStylistServiceRepository,
+        mockServiceRepository,
+        mockStylistRepository,
+      );
+    });
+
+    const updateDto = { customPrice: 3500, isOffering: false };
+
     it('should update stylist service successfully', async () => {
       const mockStylistService = StylistService.create('stylist-id', 'service-id', 3000);
       const mockService = Service.create('category-id', 'Hair Cut', 'Description', 45, 15, 2500);
@@ -280,58 +234,53 @@ describe('StylistServiceService', () => {
       mockServiceRepository.findById.mockResolvedValue(mockService);
       mockStylistServiceRepository.update.mockResolvedValue(mockStylistService);
 
-      const result = await stylistServiceService.updateStylistService(
-        'stylist-id',
-        'service-id',
-        updateDto,
-      );
+      const result = await updateStylistService.execute('stylist-id', 'service-id', updateDto);
 
-      expect(mockStylistServiceRepository.findByStylistAndService).toHaveBeenCalledWith(
-        'stylist-id',
-        'service-id',
-      );
+      expect(mockStylistServiceRepository.findByStylistAndService).toHaveBeenCalledWith('stylist-id', 'service-id');
       expect(mockStylistServiceRepository.update).toHaveBeenCalled();
       expect(result.customPrice).toBe(3500);
       expect(result.isOffering).toBe(false);
     });
 
-    // Debería lanzar NotFoundError si la asignación no se encuentra
     it('should throw NotFoundError if assignment not found', async () => {
       mockStylistServiceRepository.findByStylistAndService.mockResolvedValue(null);
-
-      await expect(
-        stylistServiceService.updateStylistService('stylist-id', 'service-id', updateDto),
-      ).rejects.toThrow(NotFoundError);
+      await expect(updateStylistService.execute('stylist-id', 'service-id', updateDto)).rejects.toThrow(NotFoundError);
     });
   });
 
-  describe('removeServiceFromStylist', () => {
-    // Debería remover servicio del estilista exitosamente
+  describe('RemoveServiceFromStylist', () => {
+    let removeServiceFromStylist: RemoveServiceFromStylist;
+
+    beforeEach(() => {
+      removeServiceFromStylist = new RemoveServiceFromStylist(mockStylistServiceRepository);
+    });
+
     it('should remove service from stylist successfully', async () => {
       mockStylistServiceRepository.existsAssignment.mockResolvedValue(true);
       mockStylistServiceRepository.delete.mockResolvedValue();
 
-      await stylistServiceService.removeServiceFromStylist('stylist-id', 'service-id');
+      await removeServiceFromStylist.execute('stylist-id', 'service-id');
 
-      expect(mockStylistServiceRepository.existsAssignment).toHaveBeenCalledWith(
-        'stylist-id',
-        'service-id',
-      );
+      expect(mockStylistServiceRepository.existsAssignment).toHaveBeenCalledWith('stylist-id', 'service-id');
       expect(mockStylistServiceRepository.delete).toHaveBeenCalledWith('stylist-id', 'service-id');
     });
 
-    //Debería lanzar NotFoundError si no se encuentra la asignación
     it('should throw NotFoundError if assignment not found', async () => {
       mockStylistServiceRepository.existsAssignment.mockResolvedValue(false);
-
-      await expect(
-        stylistServiceService.removeServiceFromStylist('stylist-id', 'service-id'),
-      ).rejects.toThrow(NotFoundError);
+      await expect(removeServiceFromStylist.execute('stylist-id', 'service-id')).rejects.toThrow(NotFoundError);
     });
   });
 
-  describe('getStylistsOfferingService', () => {
-    // Debería devolver estilistas que ofrecen el servicio exitosamente
+  describe('GetStylistsOfferingService', () => {
+    let getStylistsOfferingService: GetStylistsOfferingService;
+
+    beforeEach(() => {
+      getStylistsOfferingService = new GetStylistsOfferingService(
+        mockStylistServiceRepository,
+        mockServiceRepository,
+      );
+    });
+
     it('should return stylists offering service successfully', async () => {
       const mockService = Service.create('category-id', 'Hair Cut', 'Description', 45, 15, 2500);
       const mockStylistServices = [
@@ -340,58 +289,51 @@ describe('StylistServiceService', () => {
       ];
 
       mockServiceRepository.findById.mockResolvedValue(mockService);
-      mockStylistServiceRepository.findStylistsOfferingService.mockResolvedValue(
-        mockStylistServices,
-      );
+      mockStylistServiceRepository.findStylistsOfferingService.mockResolvedValue(mockStylistServices);
 
-      const result = await stylistServiceService.getStylistsOfferingService('service-id');
+      const result = await getStylistsOfferingService.execute('service-id');
 
       expect(mockServiceRepository.findById).toHaveBeenCalledWith('service-id');
-      expect(mockStylistServiceRepository.findStylistsOfferingService).toHaveBeenCalledWith(
-        'service-id',
-      );
+      expect(mockStylistServiceRepository.findStylistsOfferingService).toHaveBeenCalledWith('service-id');
       expect(result).toHaveLength(2);
     });
 
-    //Debería lanzar NotFoundError si no se encuentra el servicio
     it('should throw NotFoundError if service not found', async () => {
       mockServiceRepository.findById.mockResolvedValue(null);
-
-      await expect(
-        stylistServiceService.getStylistsOfferingService('non-existent-service'),
-      ).rejects.toThrow(NotFoundError);
+      await expect(getStylistsOfferingService.execute('non-existent-service')).rejects.toThrow(NotFoundError);
     });
   });
 
-  describe('getStylistWithServices', () => {
-    // Debería devolver estilista con servicios exitosamente
+  describe('GetStylistWithServices', () => {
+    let getStylistWithServices: GetStylistWithServices;
+
+    beforeEach(() => {
+      getStylistWithServices = new GetStylistWithServices(
+        mockStylistServiceRepository,
+        mockServiceRepository,
+        mockStylistRepository,
+        mockUserRepository,
+      );
+    });
+
     it('should return stylist with services successfully', async () => {
       const mockStylist = Stylist.create('user-id');
       Object.defineProperty(mockStylist, 'id', { value: 'stylist-id', writable: false });
 
-      const mockUser = User.create(
-        'STYLIST', // roleId
-        'Test User', // name
-        'test@example.com', // email
-        '+1234567890', // phone
-        'password', // password
-      );
+      const mockUser = User.create('STYLIST', 'Test User', 'test@example.com', '+1234567890', 'password');
       const mockStylistServices = [StylistService.create('stylist-id', 'service-1', 3000)];
       const mockService = Service.create('category-id', 'Hair Cut', 'Description', 45, 15, 2500);
-
       Object.defineProperty(mockService, 'id', { value: 'service-1', writable: false });
 
       mockStylistRepository.findById.mockResolvedValue(mockStylist);
       mockUserRepository.findById.mockResolvedValue(mockUser);
       mockStylistServiceRepository.findByStylist.mockResolvedValue(mockStylistServices);
-
-      // Mock específico para el servicio
       mockServiceRepository.findById.mockImplementation((serviceId: string) => {
         if (serviceId === 'service-1') return Promise.resolve(mockService);
         return Promise.resolve(null);
       });
 
-      const result = await stylistServiceService.getStylistWithServices('stylist-id');
+      const result = await getStylistWithServices.execute('stylist-id');
 
       expect(result.stylistId).toBe('stylist-id');
       expect(result.stylistName).toBe('Test User');
@@ -401,8 +343,16 @@ describe('StylistServiceService', () => {
     });
   });
 
-  describe('getServiceWithStylists', () => {
-    // Debería devolver servicio con estilistas exitosamente
+  describe('GetServiceWithStylists', () => {
+    let getServiceWithStylists: GetServiceWithStylists;
+
+    beforeEach(() => {
+      getServiceWithStylists = new GetServiceWithStylists(
+        mockStylistServiceRepository,
+        mockServiceRepository,
+      );
+    });
+
     it('should return service with stylists successfully', async () => {
       const mockService = Service.create('category-id', 'Hair Cut', 'Description', 45, 15, 2500);
       Object.defineProperty(mockService, 'id', { value: 'service-id', writable: false });
@@ -415,7 +365,7 @@ describe('StylistServiceService', () => {
       mockServiceRepository.findById.mockResolvedValue(mockService);
       mockStylistServiceRepository.findByService.mockResolvedValue(mockStylistServices);
 
-      const result = await stylistServiceService.getServiceWithStylists('service-id');
+      const result = await getServiceWithStylists.execute('service-id');
 
       expect(result.serviceId).toBe('service-id');
       expect(result.serviceName).toBe('Hair Cut');


### PR DESCRIPTION
## ¿Qué se hizo?
Los tests unitarios del módulo `services` apuntaban a las clases de application 
services que fueron eliminadas. Se reescribieron completamente 
para probar los nuevos use cases individuales y se renombraron los archivos para 
reflejar con precisión qué están probando.

### Archivos nuevos
- `CategoryUseCases.unit.test.ts` — prueba CreateCategory, UpdateCategory,
  GetCategoryById, GetAllCategories, GetActiveCategories, ActivateCategory,
  DeactivateCategory, DeleteCategory
- `ServiceUseCases.unit.test.ts` — prueba CreateService, UpdateService,
  GetServiceById, GetServicesByCategory, ActivateService, DeleteService
- `StylistServiceUseCases.unit.test.ts` — prueba AssignServiceToStylist,
  UpdateStylistService, RemoveServiceFromStylist, GetStylistServices,
  GetStylistsOfferingService, GetStylistWithServices, GetServiceWithStylists
