### PR TITLE
fix(appointments): corregir búsqueda de estado PENDING en CreateAppointment

### DIFF
--- a/src/modules/appointments/presentation/routes/AppointmentRoutes.ts
+++ b/src/modules/appointments/presentation/routes/AppointmentRoutes.ts
@@ -30,9 +30,7 @@ export class AppointmentRoutes {
    * - POST /appointments/:id/cancel - Cancelar cita (requiere autenticación)
    * - GET /appointments/client/:clientId - Obtener citas de cliente (requiere autenticación)
    * - GET /appointments/stylist/:stylistId - Obtener citas de estilista (requiere autenticación)
-   * - GET /appointments/date-range - Obtener citas por rango de fechas (requiere autenticación)
    * - GET /appointments/available-slots - Obtener slots disponibles (público)
-   * - GET /appointments/statistics - Obtener estadísticas (requiere autenticación)
    */
   private setupRoutes(): void {
     // Ruta pública para consultar disponibilidad
@@ -53,24 +51,6 @@ export class AppointmentRoutes {
       ValidationMiddleware.handleValidationErrors,
       (req: Request, res: Response, next: NextFunction) => {
         this.appointmentController.createAppointment(req, res).catch(next);
-      },
-    );
-
-    this.router.get(
-      '/statistics',
-      this.authMiddleware.authenticate.bind(this.authMiddleware),
-      (req: Request, res: Response, next: NextFunction) => {
-        this.appointmentController.getAppointmentStatistics(req, res).catch(next);
-      },
-    );
-
-    this.router.get(
-      '/date-range',
-      this.authMiddleware.authenticate.bind(this.authMiddleware),
-      AppointmentValidations.appointmentsByDateRange,
-      ValidationMiddleware.handleValidationErrors,
-      (req: Request, res: Response, next: NextFunction) => {
-        this.appointmentController.getAppointmentsByDateRange(req, res).catch(next);
       },
     );
 

--- a/src/modules/holidays/application/use-cases/CreateHoliday.ts
+++ b/src/modules/holidays/application/use-cases/CreateHoliday.ts
@@ -1,8 +1,9 @@
-import { v4 as uuidv4 } from 'uuid';
+import { generateUuid } from '../../../../shared/utils/uuid';
 import { Holiday } from '../../domain/entities/Holiday';
 import { IHolidayRepository } from '../../domain/repositories/IHolidayRepository';
 import { CreateHolidayDto } from '../dto/request/CreateHolidayDto';
 import { HolidayResponseDto, HolidayResponseMapper } from '../dto/response/HolidayResponseDto';
+import { ConflictError } from '../../../../shared/exceptions/ConflictError';
 
 /**
  * Caso de uso: Crear feriado
@@ -23,12 +24,12 @@ export class CreateHoliday {
     // Verificar si ya existe un feriado en esa fecha
     const existingHoliday = await this.holidayRepository.existsByDate(date);
     if (existingHoliday) {
-      throw new Error('Ya existe un feriado en la fecha especificada');
+      throw new ConflictError('A holiday already exists on the specified date');
     }
 
     // Crear la entidad
     const holiday = Holiday.create(
-      uuidv4(),
+      generateUuid(),
       dto.name,
       date,
       dto.description,

--- a/src/modules/holidays/application/use-cases/CreateScheduleException.ts
+++ b/src/modules/holidays/application/use-cases/CreateScheduleException.ts
@@ -1,9 +1,11 @@
-import { v4 as uuidv4 } from 'uuid';
+import { generateUuid } from '../../../../shared/utils/uuid';
 import { ScheduleException } from '../../domain/entities/ScheduleException';
 import { IScheduleExceptionRepository } from '../../domain/repositories/IScheduleExceptionRepository';
 import { IHolidayRepository } from '../../domain/repositories/IHolidayRepository';
 import { CreateScheduleExceptionDto } from '../dto/request/CreateScheduleExceptionDto';
 import { ScheduleExceptionResponseDto, ScheduleExceptionResponseMapper } from '../dto/response/ScheduleExceptionResponseDto';
+import { ConflictError } from '../../../../shared/exceptions/ConflictError';
+import { NotFoundError } from '../../../../shared/exceptions/NotFoundError';
 
 /**
  * Caso de uso: Crear excepción de horario
@@ -28,20 +30,20 @@ export class CreateScheduleException {
     // Verificar si ya existe una excepción en esa fecha
     const existingException = await this.scheduleExceptionRepository.existsByDate(exceptionDate);
     if (existingException) {
-      throw new Error('Ya existe una excepción de horario en la fecha especificada');
+      throw new ConflictError('A schedule exception already exists on the specified date');
     }
 
     // Si se proporciona holidayId, verificar que exista
     if (dto.holidayId) {
       const holiday = await this.holidayRepository.findById(dto.holidayId);
       if (!holiday) {
-        throw new Error('El feriado especificado no existe');
+        throw new NotFoundError('Holiday', dto.holidayId);
       }
     }
 
     // Crear la entidad
     const exception = ScheduleException.create(
-      uuidv4(),
+      generateUuid(),
       exceptionDate,
       dto.startTimeException,
       dto.endTimeException,

--- a/src/modules/holidays/domain/entities/Holiday.ts
+++ b/src/modules/holidays/domain/entities/Holiday.ts
@@ -125,7 +125,7 @@ export class Holiday {
    */
   updateName(name: string): void {
     if (!name || name.trim().length === 0) {
-      throw new Error('El nombre del feriado no puede estar vacío');
+      throw new Error('Holiday name cannot be empty');
     }
     this._name = name.trim();
     this._updatedAt = new Date();
@@ -177,7 +177,7 @@ export class Holiday {
     description?: string | null,
   ): Holiday {
     if (!name || name.trim().length === 0) {
-      throw new Error('El nombre del feriado no puede estar vacío');
+      throw new Error('Holiday name cannot be empty');
     }
 
     return new Holiday({

--- a/src/modules/holidays/domain/entities/ScheduleException.ts
+++ b/src/modules/holidays/domain/entities/ScheduleException.ts
@@ -186,7 +186,7 @@ export class ScheduleException {
   private validateTimeFormat(time: string): void {
     const timeRegex = /^([01]?[0-9]|2[0-3]):[0-5][0-9]$/;
     if (!timeRegex.test(time)) {
-      throw new Error(`Formato de hora inválido: ${time}. Use HH:MM`);
+      throw new Error(`Invalid time format: ${time}. Use HH:MM`);
     }
   }
 
@@ -202,7 +202,7 @@ export class ScheduleException {
     const endMinutes = endHour * 60 + endMin;
 
     if (endMinutes <= startMinutes) {
-      throw new Error('La hora de fin debe ser posterior a la hora de inicio');
+      throw new Error('End time must be after start time');
     }
   }
 

--- a/src/modules/holidays/presentation/controllers/HolidayController.ts
+++ b/src/modules/holidays/presentation/controllers/HolidayController.ts
@@ -71,7 +71,7 @@ export class HolidayController {
       const { id } = req.params;
       const holiday = await this.getHolidayById.execute(id);
 
-      res.json({
+      res.status(200).json({
         success: true,
         message: 'Holiday retrieved successfully',
         data: holiday,
@@ -99,7 +99,7 @@ export class HolidayController {
 
       const result = await this.getHolidays.execute(filters);
 
-      res.json({
+      res.status(200).json({
         success: true,
         message: 'Holidays retrieved successfully',
         data: result,
@@ -118,7 +118,7 @@ export class HolidayController {
       const year = Number(req.params.year);
       const holidays = await this.getHolidaysByYear.execute(year);
 
-      res.json({
+      res.status(200).json({
         success: true,
         message: 'Holidays by year retrieved successfully',
         data: holidays,
@@ -137,7 +137,7 @@ export class HolidayController {
       const limit = req.query.limit ? Number(req.query.limit) : 5;
       const holidays = await this.getUpcomingHolidays.execute(limit);
 
-      res.json({
+      res.status(200).json({
         success: true,
         message: 'Upcoming holidays retrieved successfully',
         data: holidays,
@@ -156,7 +156,7 @@ export class HolidayController {
       const { date } = req.params;
       const result = await this.checkIsHoliday.execute(date);
 
-      res.json({
+      res.status(200).json({
         success: true,
         message: 'Date checked successfully',
         data: result,
@@ -175,7 +175,7 @@ export class HolidayController {
       const { id } = req.params;
       const holiday = await this.updateHoliday.execute(id, req.body);
 
-      res.json({
+      res.status(200).json({
         success: true,
         message: 'Holiday updated successfully',
         data: holiday,
@@ -194,7 +194,7 @@ export class HolidayController {
       const { id } = req.params;
       await this.deleteHoliday.execute(id);
 
-      res.json({
+      res.status(200).json({
         success: true,
         message: 'Holiday deleted successfully',
       });
@@ -234,7 +234,7 @@ export class HolidayController {
       const { id } = req.params;
       const exception = await this.getScheduleExceptionById.execute(id);
 
-      res.json({
+      res.status(200).json({
         success: true,
         message: 'Schedule exception retrieved successfully',
         data: exception,
@@ -261,7 +261,7 @@ export class HolidayController {
 
       const result = await this.getScheduleExceptions.execute(filters);
 
-      res.json({
+      res.status(200).json({
         success: true,
         message: 'Schedule exceptions retrieved successfully',
         data: result,
@@ -284,7 +284,7 @@ export class HolidayController {
       const { holidayId } = req.params;
       const exceptions = await this.getScheduleExceptionsByHoliday.execute(holidayId);
 
-      res.json({
+      res.status(200).json({
         success: true,
         message: 'Schedule exceptions by holiday retrieved successfully',
         data: exceptions,
@@ -307,7 +307,7 @@ export class HolidayController {
       const limit = req.query.limit ? Number(req.query.limit) : 5;
       const exceptions = await this.getUpcomingScheduleExceptions.execute(limit);
 
-      res.json({
+      res.status(200).json({
         success: true,
         message: 'Upcoming schedule exceptions retrieved successfully',
         data: exceptions,
@@ -326,7 +326,7 @@ export class HolidayController {
       const { id } = req.params;
       const exception = await this.updateScheduleException.execute(id, req.body);
 
-      res.json({
+      res.status(200).json({
         success: true,
         message: 'Schedule exception updated successfully',
         data: exception,
@@ -345,7 +345,7 @@ export class HolidayController {
       const { id } = req.params;
       await this.deleteScheduleException.execute(id);
 
-      res.json({
+      res.status(200).json({
         success: true,
         message: 'Schedule exception deleted successfully',
       });

--- a/tests/e2e/appointments-complete-flow.e2e.test.ts
+++ b/tests/e2e/appointments-complete-flow.e2e.test.ts
@@ -349,17 +349,4 @@ describe('Appointments Complete Flow E2E Tests', () => {
     });
   });
 
-  describe('Statistics Endpoint', () => {
-    // Debería retornar estadísticas del sistema
-    it('should return system statistics', async () => {
-      // 1. Consultar estadísticas como admin
-      const response = await request(app)
-        .get('/api/v1/appointments/statistics')
-        .set('Authorization', `Bearer ${adminToken}`)
-        .expect(200);
-
-      // 2. Verificar respuesta exitosa
-      expect(response.body.success).toBe(true);
-    });
-  });
 });

--- a/tests/integration/holidays/holiday-routes.integration.test.ts
+++ b/tests/integration/holidays/holiday-routes.integration.test.ts
@@ -126,7 +126,7 @@ describe('Holidays Integration Tests', () => {
           date: '2099-12-25',
         });
 
-      expect(response.status).toBe(500); // O 409 si se implementa ConflictError
+      expect(response.status).toBe(409);
       expect(response.body.success).toBe(false);
     });
 

--- a/tests/unit/appointments/application/use-cases/CreateAppointment.unit.test.ts
+++ b/tests/unit/appointments/application/use-cases/CreateAppointment.unit.test.ts
@@ -111,7 +111,7 @@ describe('CreateAppointment Use Case', () => {
   };
 
   const createMockAppointmentStatus = (
-    name: string = 'Pendiente',
+    name: string = 'PENDING',
     id: string = validPendingStatusId,
   ): AppointmentStatus => {
     return new AppointmentStatus(id, name, `Status: ${name}`);
@@ -196,7 +196,7 @@ describe('CreateAppointment Use Case', () => {
     const service = createMockService(validServiceId1, 60);
     const schedule = createMockSchedule('MONDAY');
 
-    mockAppointmentStatusRepository.findAll.mockResolvedValue([pendingStatus]);
+    mockAppointmentStatusRepository.findByName.mockResolvedValue(pendingStatus);
     mockClientRepository.findById.mockResolvedValue(client);
     mockClientRepository.findByUserId.mockResolvedValue(null); // No necesario si findById encuentra
     mockStylistRepository.findById.mockResolvedValue(stylist);
@@ -444,7 +444,7 @@ describe('CreateAppointment Use Case', () => {
       const client = createMockClient(validClientId);
       const stylist = createMockStylist(validStylistId);
       const service = createMockService(validServiceId1);
-      const pendingStatus = createMockAppointmentStatus('Pendiente');
+      const pendingStatus = createMockAppointmentStatus('PENDING');
       const schedule = createMockSchedule('MONDAY');
       const appointment = createMockAppointment();
 
@@ -453,7 +453,7 @@ describe('CreateAppointment Use Case', () => {
       mockClientRepository.findByUserId.mockResolvedValue(client);
       mockStylistRepository.findById.mockResolvedValue(stylist);
       mockServiceRepository.findById.mockResolvedValue(service);
-      mockAppointmentStatusRepository.findAll.mockResolvedValue([pendingStatus]);
+      mockAppointmentStatusRepository.findByName.mockResolvedValue(pendingStatus);
       mockScheduleRepository.findAll.mockResolvedValue([schedule]);
       mockAppointmentRepository.findConflictingAppointments.mockResolvedValue([]);
       mockAppointmentRepository.save.mockResolvedValue(appointment);
@@ -497,13 +497,13 @@ describe('CreateAppointment Use Case', () => {
       const client = createMockClient(validClientId);
       const stylist = createMockStylist(validStylistId);
       const service = createMockService(validServiceId1);
-      const pendingStatus = createMockAppointmentStatus('Pendiente');
+      const pendingStatus = createMockAppointmentStatus('PENDING');
       const schedule = createMockSchedule('MONDAY');
 
       mockClientRepository.findById.mockResolvedValue(client);
       mockStylistRepository.findById.mockResolvedValue(stylist);
       mockServiceRepository.findById.mockResolvedValue(service);
-      mockAppointmentStatusRepository.findAll.mockResolvedValue([pendingStatus]);
+      mockAppointmentStatusRepository.findByName.mockResolvedValue(pendingStatus);
       mockScheduleRepository.findAll.mockResolvedValue([schedule]);
       mockAppointmentRepository.findConflictingAppointments.mockResolvedValue([
         conflictingAppointment,
@@ -526,7 +526,7 @@ describe('CreateAppointment Use Case', () => {
       expect(mockClientRepository.findById).toHaveBeenCalledWith(validClientId);
       expect(mockStylistRepository.findById).toHaveBeenCalledWith(validStylistId);
       expect(mockServiceRepository.findById).toHaveBeenCalledWith(validServiceId1);
-      expect(mockAppointmentStatusRepository.findAll).toHaveBeenCalled();
+      expect(mockAppointmentStatusRepository.findByName).toHaveBeenCalledWith('PENDING');
       expect(mockScheduleRepository.findAll).toHaveBeenCalled();
       expect(mockAppointmentRepository.save).toHaveBeenCalled();
     });

--- a/tests/unit/holidays/application/use-cases/CreateHoliday.unit.test.ts
+++ b/tests/unit/holidays/application/use-cases/CreateHoliday.unit.test.ts
@@ -69,7 +69,7 @@ describe('CreateHoliday Use Case', () => {
     mockHolidayRepository.existsByDate.mockResolvedValue(true);
 
     await expect(createHoliday.execute(dto)).rejects.toThrow(
-      'Ya existe un feriado en la fecha especificada',
+      'A holiday already exists on the specified date',
     );
     expect(mockHolidayRepository.save).not.toHaveBeenCalled();
   });

--- a/tests/unit/holidays/application/use-cases/CreateScheduleException.unit.test.ts
+++ b/tests/unit/holidays/application/use-cases/CreateScheduleException.unit.test.ts
@@ -110,7 +110,7 @@ describe('CreateScheduleException Use Case', () => {
     mockScheduleExceptionRepository.existsByDate.mockResolvedValue(true);
 
     await expect(createScheduleException.execute(dto)).rejects.toThrow(
-      'Ya existe una excepción de horario en la fecha especificada',
+      'A schedule exception already exists on the specified date',
     );
     expect(mockScheduleExceptionRepository.save).not.toHaveBeenCalled();
   });
@@ -128,7 +128,7 @@ describe('CreateScheduleException Use Case', () => {
     mockHolidayRepository.findById.mockResolvedValue(null);
 
     await expect(createScheduleException.execute(dto)).rejects.toThrow(
-      'El feriado especificado no existe',
+      'Holiday not found: non-existent-id',
     );
     expect(mockScheduleExceptionRepository.save).not.toHaveBeenCalled();
   });

--- a/tests/unit/holidays/domain/entities/Holiday.unit.test.ts
+++ b/tests/unit/holidays/domain/entities/Holiday.unit.test.ts
@@ -147,14 +147,14 @@ describe('Holiday Entity', () => {
     it('should throw error if name is empty', () => {
       const holiday = new Holiday(validHolidayProps);
 
-      expect(() => holiday.updateName('')).toThrow('El nombre del feriado no puede estar vacío');
+      expect(() => holiday.updateName('')).toThrow('Holiday name cannot be empty');
     });
 
     // Debería lanzar error si el nombre es solo espacios
     it('should throw error if name is only whitespace', () => {
       const holiday = new Holiday(validHolidayProps);
 
-      expect(() => holiday.updateName('   ')).toThrow('El nombre del feriado no puede estar vacío');
+      expect(() => holiday.updateName('   ')).toThrow('Holiday name cannot be empty');
     });
   });
 
@@ -285,7 +285,7 @@ describe('Holiday Entity', () => {
           '',
           new Date('2025-01-01'),
         ),
-      ).toThrow('El nombre del feriado no puede estar vacío');
+      ).toThrow('Holiday name cannot be empty');
     });
 
     // Debería lanzar error si el nombre es solo espacios
@@ -296,7 +296,7 @@ describe('Holiday Entity', () => {
           '   ',
           new Date('2025-01-01'),
         ),
-      ).toThrow('El nombre del feriado no puede estar vacío');
+      ).toThrow('Holiday name cannot be empty');
     });
   });
 });

--- a/tests/unit/holidays/domain/entities/ScheduleException.unit.test.ts
+++ b/tests/unit/holidays/domain/entities/ScheduleException.unit.test.ts
@@ -178,7 +178,7 @@ describe('ScheduleException Entity', () => {
       const exception = new ScheduleException(validExceptionProps);
 
       expect(() => exception.updateTimes('25:00', '14:00')).toThrow(
-        'Formato de hora inválido: 25:00. Use HH:MM',
+        'Invalid time format: 25:00. Use HH:MM',
       );
     });
 
@@ -187,7 +187,7 @@ describe('ScheduleException Entity', () => {
       const exception = new ScheduleException(validExceptionProps);
 
       expect(() => exception.updateTimes('14:00', '09:00')).toThrow(
-        'La hora de fin debe ser posterior a la hora de inicio',
+        'End time must be after start time',
       );
     });
 
@@ -196,7 +196,7 @@ describe('ScheduleException Entity', () => {
       const exception = new ScheduleException(validExceptionProps);
 
       expect(() => exception.updateTimes('10:00', '10:00')).toThrow(
-        'La hora de fin debe ser posterior a la hora de inicio',
+        'End time must be after start time',
       );
     });
 
@@ -371,7 +371,7 @@ describe('ScheduleException Entity', () => {
           'invalid',
           '14:00',
         ),
-      ).toThrow('Formato de hora inválido');
+      ).toThrow('Invalid time format');
     });
 
     // Debería lanzar error si la hora de fin es anterior a la de inicio
@@ -383,7 +383,7 @@ describe('ScheduleException Entity', () => {
           '14:00',
           '09:00',
         ),
-      ).toThrow('La hora de fin debe ser posterior a la hora de inicio');
+      ).toThrow('End time must be after start time');
     });
   });
 });


### PR DESCRIPTION
## ¿Qué se hizo?
Corrección de un fallo detectado en los tests unitarios tras la auditoría 
del módulo `appointments`. La búsqueda del estado inicial de una cita 
estaba usando `findAll` + filtro en memoria con el nombre en español 
`'Pendiente'`. Se migró a `findByName('PENDING')` para ser consistente 
con el `AppointmentStatusEnum` del proyecto.

## Cambios realizados

### Use Case
- `CreateAppointment` — `getPendingStatus()` migrado de `findAll()` + 
  filtro en memoria a `findByName('PENDING')` directamente

### Test
- `CreateAppointment.unit.test.ts` — actualizado mock de 
  `findAll` a `findByName` en todos los escenarios
- Nombre del status en los mocks corregido de `'Pendiente'` a `'PENDING'`
- Assertion en `Repository Integration` actualizada para verificar 
  `findByName('PENDING')` en lugar de `findAll`
---
## holidays — Auditoría completa del módulo

### Use Cases
- `CreateHoliday` — reemplazado `new Error(...)` en español por `ConflictError`
  con mensaje en inglés; `uuidv4()` reemplazado por `generateUuid()` del shared
- `CreateScheduleException` — mismo fix: `new Error(...)` → `ConflictError` y 
  `NotFoundError`; `uuidv4()` → `generateUuid()`

### Entidades
- `Holiday` — mensajes de error traducidos al inglés
- `ScheduleException` — mensajes de error traducidos al inglés

### Controller
- `HolidayController` — agregado `res.status(200)` explícito en todos los 
  métodos GET para consistencia con el resto del proyecto

### Tests unitarios
- Actualizados mensajes esperados al inglés en `Holiday.unit.test.ts` y 
  `ScheduleException.unit.test.ts`
- Actualizados mensajes en `CreateHoliday.unit.test.ts` y 
  `CreateScheduleException.unit.test.ts`
- Corregido status esperado de `500` a `409` en test de integración de 
  feriado duplicado

### appointments — Limpieza adicional
- Eliminadas rutas `/statistics` y `/date-range` de `AppointmentRoutes.ts` 
  que apuntaban a métodos removidos del controller
- Eliminado test E2E de `statistics` que probaba endpoint no implementado
