### PR TITLE
fix: auditoría de consistencia de reglas de negocio — Fase 1 fixes críticos y altos

### DIFF
--- a/src/docs/INTERVENTION_PLAN.md
+++ b/src/docs/INTERVENTION_PLAN.md
@@ -1,0 +1,685 @@
+# Plan de Intervención — Auditoría de Consistencia
+
+> Fecha: 2026-06-14 | Versión: 1.0
+> Alcance: 26 issues identificados cruzando los 9 documentos de business rules + código fuente
+> Objetivo: Definir la acción concreta para cada inconsistencia antes de implementar
+
+---
+
+## Tipos de intervención
+
+| Tipo | Significado |
+|------|-------------|
+| **FIX_CODE** | Requiere cambios en código fuente (use cases, entities, validations, routes) |
+| **FIX_DOCS** | Requiere actualizar documentación de business rules para reflejar el estado real |
+| **FIX_AMBOS** | Requiere cambios en código Y actualización de documentación |
+| **DOCUMENTAR** | No requiere cambio de código; se documenta como limitación conocida o decisión de diseño |
+| **DIFERIR** | Feature completa para una fase futura; se documenta la intención |
+
+---
+
+## Resumen ejecutivo
+
+| Tipo | Cantidad | IDs |
+|------|----------|-----|
+| FIX_CODE | 12 | 01, 02, 03, 04, 05, 06, 07, 13, 14, 15, 19, 25 |
+| FIX_DOCS | 4 | 08, 10, 11, 22 |
+| FIX_AMBOS | 1 | 09 |
+| DOCUMENTAR | 7 | 16, 17, 18, 20, 23, 24, 26 |
+| DIFERIR | 2 | 12, 21 |
+| **Total** | **26** | |
+
+---
+
+## Severidad
+
+| Nivel | Significado |
+|-------|-------------|
+| **CRÍTICA** | Bloquea funcionalidad core o produce errores en runtime |
+| **ALTA** | Permite estados de datos inconsistentes o viola lógica de negocio importante |
+| **MEDIA** | Inconsistencia que no produce errores pero degrada la calidad del sistema |
+| **BAJA** | Inconsistencia cosmética o de convenciones |
+
+---
+
+## Todos los issues
+
+---
+
+### ISSUE-01 — DeleteCategory no valida servicios asociados
+
+| Campo | Valor |
+|-------|-------|
+| Origen | Session Handoff #1 |
+| Archivo | `services/application/use-cases/DeleteCategory.ts` |
+| Severidad | **MEDIA** |
+| Intervención | **FIX_CODE** |
+| Dependencias | Ninguna |
+
+**Diagnóstico:** El use case solo verifica que la categoría exista (`existsById`) y la elimina. Si la categoría tiene servicios asociados, el FK constraint de Prisma produce un error 500 genérico en vez de un `BusinessRuleError` controlado.
+
+**Acción:** Inyectar `IServiceRepository`, consultar si existen servicios con ese `categoryId`, y lanzar `BusinessRuleError('Cannot delete a category with associated services')` si los hay. Agregar test para el caso de rechazo.
+
+---
+
+### ISSUE-02 — DeleteService no valida citas activas
+
+| Campo | Valor |
+|-------|-------|
+| Origen | Session Handoff #2 |
+| Archivo | `services/application/use-cases/DeleteService.ts` |
+| Severidad | **MEDIA** |
+| Intervención | **FIX_CODE** |
+| Dependencias | Ninguna |
+
+**Diagnóstico:** Mismo patrón que ISSUE-01. Solo verifica existencia y elimina. Si el servicio tiene citas pendientes/confirmadas, la eliminación deja citas huérfanas o falla por FK.
+
+**Acción:** Inyectar `IAppointmentRepository`, consultar citas no terminales (no COMPLETED, CANCELLED, NO_SHOW) que incluyan ese `serviceId`, y lanzar `BusinessRuleError('Cannot delete a service with active appointments')` si existen. Agregar test.
+
+---
+
+### ISSUE-03 — AssignServiceToStylist no valida isActive del servicio
+
+| Campo | Valor |
+|-------|-------|
+| Origen | Session Handoff #3 |
+| Archivo | `services/application/use-cases/AssignServiceToStylist.ts` |
+| Severidad | **BAJA** |
+| Intervención | **FIX_CODE** |
+| Dependencias | Ninguna |
+
+**Diagnóstico:** El use case verifica que el servicio exista (`findById`) pero no que esté activo. Permite asignar un servicio desactivado a un estilista.
+
+**Acción:** Después de `findById`, agregar check `if (!service.isActive) throw new BusinessRuleError('Cannot assign an inactive service')`. Agregar test.
+
+---
+
+### ISSUE-04 — CreateAppointment acepta clientId ambiguo
+
+| Campo | Valor |
+|-------|-------|
+| Origen | Session Handoff #4 |
+| Archivo | `appointments/application/use-cases/CreateAppointment.ts` |
+| Severidad | **MEDIA** |
+| Intervención | **FIX_CODE** |
+| Dependencias | Ninguna |
+
+**Diagnóstico:** `validateRelatedEntitiesAndGetClientId()` intenta buscar por `Client.id` primero, y si no encuentra, busca por `User.id` via `findByUserId()`. Esto crea un contrato ambiguo: el consumidor de la API no sabe si debe enviar `Client.id` o `User.id`, y el comportamiento varía silenciosamente.
+
+**Acción:** Definir un contrato claro. Recomendación: el `clientId` del DTO debe ser siempre el `User.id` (que es lo que el frontend conoce tras el login). El use case busca el Client por `findByUserId()` y si no existe lanza `NotFoundError`. Eliminar el fallback ambiguo. Actualizar business rules. Agregar/ajustar tests.
+
+---
+
+### ISSUE-05 — CreateNotification no verifica existencia del usuario
+
+| Campo | Valor |
+|-------|-------|
+| Origen | Session Handoff #5 |
+| Archivo | `notifications/application/use-cases/CreateNotification.ts` |
+| Severidad | **BAJA** |
+| Intervención | **FIX_CODE** |
+| Dependencias | Ninguna |
+
+**Diagnóstico:** Valida formato UUID del `userId` pero no verifica que el usuario exista en la BD. Crearía notificaciones huérfanas.
+
+**Acción:** Inyectar `IUserRepository`, consultar `findById(dto.userId)`, lanzar `NotFoundError('User', dto.userId)` si no existe. Agregar test.
+
+---
+
+### ISSUE-06 — CreatePayment sin validación de cita (existencia ni estado)
+
+| Campo | Valor |
+|-------|-------|
+| Origen | Session Handoff #6 + Auditoría B5 |
+| Archivo | `payments/application/use-cases/CreatePayment.ts` |
+| Severidad | **ALTA** |
+| Intervención | **FIX_CODE** |
+| Dependencias | Ninguna |
+
+**Diagnóstico:** Dos problemas combinados. Primero, solo valida formato UUID del `appointmentId`, no verifica que la cita exista — permite pagos para citas inexistentes. Segundo, no verifica el estado de la cita — permite crear pagos para citas CANCELLED o PENDING. Además, no hay restricción de unicidad: se pueden crear múltiples pagos para la misma cita sin control.
+
+**Acción (existencia):** Inyectar `IAppointmentRepository`, consultar `findById(dto.appointmentId)`, lanzar `NotFoundError('Appointment', dto.appointmentId)` si no existe. Agregar test.
+
+**Acción (estado):** Decidir qué estados permiten pago. Se permite crear pagos solo para citas en estado CONFIRMED o COMPLETED. Lanzar `BusinessRuleError('Cannot create a payment for an appointment with status X')` si el estado no es válido. Agregar test.
+
+**Acción (unicidad):** Documentar como decisión de diseño que se permiten múltiples pagos por cita (pagos parciales, split payments). No requiere código, solo documentación en `08-payments.md`.
+
+> **Nota:** Las validaciones de estado requieren inyectar también `IAppointmentStatusRepository` para resolver el nombre del estado desde el `statusId`.
+
+---
+
+### ISSUE-07 — DeleteHoliday usa Error genérico
+
+| Campo | Valor |
+|-------|-------|
+| Origen | Session Handoff #8 |
+| Archivo | `holidays/application/use-cases/DeleteHoliday.ts` |
+| Severidad | **BAJA** |
+| Intervención | **FIX_CODE** |
+| Dependencias | Ninguna |
+
+**Diagnóstico:** Usa `throw new Error('Feriado no encontrado')` en vez de `throw new NotFoundError('Holiday', id)`. Rompe la convención de excepciones tipadas y el mensaje está en español (la convención de dominio es inglés).
+
+**Acción:** Reemplazar por `throw new NotFoundError('Holiday', id)`. Ajustar import si no existe. Ajustar test existente si valida el mensaje exacto.
+
+---
+
+### ISSUE-08 — Precio en centavos (Services) vs float directo (Payments)
+
+| Campo | Valor |
+|-------|-------|
+| Origen | Auditoría A1 |
+| Archivos | `services/presentation/validations/ServiceValidations.ts`, `payments/presentation/validations/PaymentValidations.ts`, `payments/domain/entities/Payment.ts` |
+| Severidad | **MEDIA** |
+| Intervención | **FIX_DOCS** |
+| Dependencias | Ninguna |
+
+**Diagnóstico:** Services y StylistService almacenan precios en centavos (sanitizer `Math.round(value * 100)`). Payments almacena `amount` como float directo sin conversión. El consumidor de la API no tiene documentación que aclare esta diferencia.
+
+El monto del pago es intencionalmente independiente del precio de los servicios (permite descuentos, propinas, cobros parciales), así que no es un bug — es una decisión de diseño no documentada.
+
+**Acción:** Agregar sección en `08-payments.md` que documente explícitamente:
+- El `amount` del pago se expresa en la unidad monetaria base (ej: pesos, dólares), NO en centavos
+- El monto es independiente de los precios de servicios (permite flexibilidad operativa)
+- La conversión entre precio-servicio (centavos) y monto-pago (moneda base) es responsabilidad del consumidor de la API
+
+Agregar nota cruzada en `03-services.md` sección "Relaciones con Otros Módulos" explicando la diferencia de unidades.
+
+---
+
+### ISSUE-09 — Duración máxima inconsistente: 600 min (Services) vs 480 min (Appointments)
+
+| Campo | Valor |
+|-------|-------|
+| Origen | Auditoría A2 |
+| Archivos | `services/domain/entities/Service.ts`, `appointments/domain/entities/Appointment.ts`, `appointments/application/use-cases/GetAvailableSlots.ts` |
+| Severidad | **ALTA** |
+| Intervención | **FIX_AMBOS** |
+| Dependencias | Ninguna |
+
+**Diagnóstico:** Un servicio puede tener duración de hasta 600 minutos. Pero una cita tiene máximo 480 minutos, y GetAvailableSlots también limita a 480. Si se selecciona un servicio de 500 min al crear una cita, la duración auto-calculada sería 500, pero la validación de la entidad Appointment rechaza >480. Peor aún: la suma de múltiples servicios podría superar 480 fácilmente.
+
+**Acción (código):** Reducir la duración máxima de Service de 600 a 480 minutos. Cambiar en:
+- `Service.ts` → validación `this.duration > 600` → `this.duration > 480`
+- `ServiceValidations.ts` → `isInt({ min: 1, max: 600 })` → `isInt({ min: 1, max: 480 })`
+
+**Acción (docs):** Actualizar `03-services.md` → "Duración máxima: 480 minutos (8 horas)" en las secciones 2, 4.1 y 4.2.
+
+**Alternativa descartada:** Subir el máximo de Appointment a 600 no tiene sentido porque GetAvailableSlots no genera slots para duraciones >480 min, así que la cita no tendría slot disponible de todas formas.
+
+> **Nota:** Verificar si existen servicios en el seed/BD con duración >480 que necesiten ajuste.
+
+---
+
+### ISSUE-10 — Permisos de confirmación: tabla contradice regla textual y código
+
+| Campo | Valor |
+|-------|-------|
+| Origen | Auditoría A3 |
+| Archivo | `06-appointments.md`, `appointments/application/use-cases/ConfirmAppointment.ts` |
+| Severidad | **MEDIA** |
+| Intervención | **FIX_DOCS** |
+| Dependencias | Ninguna |
+
+**Diagnóstico:** Tres fuentes se contradicen:
+
+| Fuente | ¿ADMIN puede? | ¿CLIENT puede? |
+|--------|---------------|-----------------|
+| Tabla de permisos (doc) | ✅ | ❌ |
+| Regla 4.3 (doc) | No mencionado explícitamente | ✅ (como creador) |
+| Código (`ConfirmAppointment.ts`) | ❌ (salvo que sea el creador) | ✅ (si es el creador) |
+
+El modelo del código es **ownership-based**: puede confirmar quien creó la cita (`userId`) o el estilista asignado (`stylistId`). El rol es irrelevante. La tabla de permisos describe un modelo **role-based** que no está implementado.
+
+**Acción:** Reescribir la tabla de permisos en `06-appointments.md` sección 3 para reflejar el modelo real (ownership-based). Cambiar la columna de la tabla de roles a entidades participantes. Actualizar regla 4.3 para ser explícita:
+- Confirmar: El creador (`userId`) o el estilista asignado (`stylistId`). El rol no influye.
+- Agregar nota: "ADMIN override no está implementado actualmente — los permisos son por participación en la cita, no por rol."
+
+Repetir el mismo patrón para cancelación (regla 4.4), que tiene la misma discrepancia.
+
+---
+
+### ISSUE-11 — Permisos de consulta por estilista no restringidos
+
+| Campo | Valor |
+|-------|-------|
+| Origen | Auditoría A4 |
+| Archivo | `06-appointments.md`, `appointments/presentation/routes/AppointmentRoutes.ts` |
+| Severidad | **BAJA** |
+| Intervención | **FIX_DOCS** |
+| Dependencias | ISSUE-10 |
+
+**Diagnóstico:** La tabla dice CLIENT ❌ para "Ver citas por estilista", pero la ruta solo usa `authenticate` sin `authorize`. Cualquier autenticado puede acceder.
+
+**Acción:** Actualizar tabla de permisos en `06-appointments.md` para reflejar que todas las rutas de consulta son accesibles por cualquier usuario autenticado (ADMIN ✅, STYLIST ✅, CLIENT ✅). Esto es consistente con el hecho de que las rutas no usan `authorize`.
+
+**Alternativa (no recomendada ahora):** Agregar `authorize(['ADMIN', 'STYLIST'])` a la ruta. No se recomienda porque cambiaría el contrato actual sin necesidad funcional clara.
+
+---
+
+### ISSUE-12 — Feriados y excepciones no afectan disponibilidad ni creación de citas
+
+| Campo | Valor |
+|-------|-------|
+| Origen | Auditoría B1 |
+| Archivos | `appointments/application/use-cases/GetAvailableSlots.ts`, `appointments/application/use-cases/CreateAppointment.ts` |
+| Severidad | **ALTA** |
+| Intervención | **DIFERIR** |
+| Dependencias | Ninguna |
+
+**Diagnóstico:** `GetAvailableSlots` no inyecta ni consulta repositorios de holidays o schedule exceptions. Solo busca el `Schedule` por día de la semana. `CreateAppointment` tiene tres TODOs explícitos reconociendo la carencia:
+```
+// TODO: Validar horarios de trabajo del estilista
+// TODO: Validar días festivos
+// TODO: Validar horarios de la tienda
+```
+El documento `09-holidays.md` también reconoce: "Esta integración debe implementarse en el módulo de Appointments".
+
+**Razón para diferir:** Implementar esta integración requiere:
+1. Inyectar `IHolidayRepository` y `IScheduleExceptionRepository` en `GetAvailableSlots` y `CreateAppointment`
+2. Definir la lógica de prioridad: Schedule Exception > Holiday > Schedule regular
+3. Definir qué significa un Holiday sin ScheduleException (¿cerrado por defecto?)
+4. Ajustar tests existentes que mockean estos use cases
+5. Potencialmente re-diseñar el DI container de appointments
+
+Es una feature completa que afecta múltiples capas, no un fix puntual.
+
+**Acción:** Documentar como limitación conocida en `05-schedules.md` y `06-appointments.md`. Mantener los TODOs en el código. Agregar ticket/nota en el README como mejora planificada.
+
+---
+
+### ISSUE-13 — CreateAppointment no valida que los servicios estén activos
+
+| Campo | Valor |
+|-------|-------|
+| Origen | Auditoría B2 |
+| Archivo | `appointments/application/use-cases/CreateAppointment.ts` |
+| Severidad | **ALTA** |
+| Intervención | **FIX_CODE** |
+| Dependencias | Ninguna |
+
+**Diagnóstico:** En `validateRelatedEntitiesAndGetClientId()`, el loop de servicios solo verifica existencia (`findById`). No verifica `service.isActive`. Una cita puede incluir servicios desactivados.
+
+**Acción:** En el loop de servicios, después de `findById`, agregar:
+```typescript
+if (!service.isActive) {
+  throw new BusinessRuleError(`Service '${service.name}' is not currently active`);
+}
+```
+Agregar test para el caso de rechazo.
+
+---
+
+### ISSUE-14 — CreateAppointment no valida que el estilista ofrezca los servicios
+
+| Campo | Valor |
+|-------|-------|
+| Origen | Auditoría B3 |
+| Archivo | `appointments/application/use-cases/CreateAppointment.ts` |
+| Severidad | **ALTA** |
+| Intervención | **FIX_CODE** |
+| Dependencias | Ninguna |
+
+**Diagnóstico:** Cuando se crea una cita con `stylistId`, no se verifica que ese estilista tenga asignados los servicios seleccionados ni que los esté ofreciendo (`isOffering = true`). Se puede asignar un estilista a una cita con servicios que no ofrece.
+
+**Acción:** Inyectar `IStylistServiceRepository` en `CreateAppointment`. Cuando `stylistId` está presente, para cada `serviceId`:
+```typescript
+const assignment = await this.stylistServiceRepository.findByStylistAndService(stylistId, serviceId);
+if (!assignment) {
+  throw new BusinessRuleError(`Stylist does not offer service '${service.name}'`);
+}
+if (!assignment.isOffering) {
+  throw new BusinessRuleError(`Stylist is not currently offering service '${service.name}'`);
+}
+```
+Agregar tests. Actualizar `06-appointments.md` regla 4.1.
+
+> **Nota:** Requiere verificar que `IStylistServiceRepository` tenga el método `findByStylistAndService` o agregarlo.
+
+---
+
+### ISSUE-15 — CreateAppointment no valida que la hora esté dentro del horario laboral
+
+| Campo | Valor |
+|-------|-------|
+| Origen | Auditoría B4 |
+| Archivo | `appointments/application/use-cases/CreateAppointment.ts` |
+| Severidad | **ALTA** |
+| Intervención | **FIX_CODE** |
+| Dependencias | Ninguna |
+
+**Diagnóstico:** `getAppropriateSchedule()` obtiene el Schedule del día y lo usa para `scheduleId`, pero nunca valida que la hora de la cita caiga dentro de `startTime`-`endTime`. Una cita a las 3:00 AM de un lunes con horario 9:00-18:00 sería aceptada.
+
+**Acción:** En `validateAvailability()` o en un nuevo método, comparar la hora de la cita contra `schedule.startTime` y `schedule.endTime`. Verificar también que la cita completa (inicio + duración) termine antes de `endTime`:
+```typescript
+if (appointmentTime < schedule.startTime || appointmentEndTime > schedule.endTime) {
+  throw new BusinessRuleError('Appointment must be within working hours');
+}
+```
+Agregar test. Actualizar `06-appointments.md` regla 4.1.
+
+---
+
+### ISSUE-16 — Datos de cancelación, confirmación y reembolso se validan pero no se almacenan
+
+| Campo | Valor |
+|-------|-------|
+| Origen | Auditoría B6 + Session Handoff #7 |
+| Archivos | `CancelAppointment.ts`, `ConfirmAppointment.ts`, `RefundPayment.ts`, entidades `Appointment` y `Payment` |
+| Severidad | **MEDIA** |
+| Intervención | **DOCUMENTAR** |
+| Dependencias | Ninguna |
+
+**Diagnóstico:** Tres campos pasan por validación en la capa de presentación (express-validator) pero se descartan en la capa de aplicación:
+
+| Use Case | Campo validado | Qué pasa |
+|----------|---------------|----------|
+| CancelAppointment | `reason` (máx 500), `cancelledBy` (enum) | `addCancellationReason()` solo actualiza `updatedAt` |
+| ConfirmAppointment | `notes` (máx 500) | `addConfirmationNotes()` solo actualiza `updatedAt` |
+| RefundPayment | `reason` (máx 500) | El use case ignora el campo completamente |
+
+Las entidades Appointment y Payment no tienen campos para almacenar esta información.
+
+**Razón para no arreglar ahora:** Agregar campos requiere:
+1. Modificar las entidades de dominio
+2. Crear migración Prisma para nuevas columnas
+3. Actualizar mappers de infraestructura
+4. Actualizar DTOs de respuesta
+5. Ajustar tests existentes
+
+Es un cambio transversal que aporta valor pero no es crítico para la integridad del sistema.
+
+**Acción:** Documentar en `06-appointments.md` y `08-payments.md` como limitación conocida:
+> "Los campos `reason`, `cancelledBy` y `notes` son aceptados y validados por la API pero no se persisten actualmente. Serán almacenados en una futura iteración."
+
+---
+
+### ISSUE-17 — Desactivación de usuario estilista sin efecto cascada
+
+| Campo | Valor |
+|-------|-------|
+| Origen | Auditoría B7 |
+| Archivos | `01-auth.md`, `04-stylists.md`, `06-appointments.md` |
+| Severidad | **MEDIA** |
+| Intervención | **DOCUMENTAR** |
+| Dependencias | Ninguna |
+
+**Diagnóstico:** Si se desactiva un User con rol STYLIST (`isActive = false`):
+- No puede loguearse (correcto)
+- Sus asignaciones StylistService permanecen activas
+- Sus citas pendientes/confirmadas siguen vigentes
+- Sigue apareciendo en consultas de estilistas por servicio
+
+No hay documentación de este escenario ni del comportamiento esperado.
+
+**Acción:** Documentar en `01-auth.md` sección "Relaciones con Otros Módulos" y en `04-stylists.md`:
+> "La desactivación de un usuario no tiene efecto cascada sobre sus entidades asociadas (StylistService, Appointments). Las citas existentes permanecen en su estado actual. Se recomienda cancelar manualmente las citas pendientes antes de desactivar un estilista."
+
+---
+
+### ISSUE-18 — Desactivación de categoría sin impacto coherente en servicios
+
+| Campo | Valor |
+|-------|-------|
+| Origen | Auditoría B8 |
+| Archivo | `02-categories.md` |
+| Severidad | **BAJA** |
+| Intervención | **DOCUMENTAR** |
+| Dependencias | Ninguna |
+
+**Diagnóstico:** Al desactivar una categoría, sus servicios siguen activos. El servicio es reservable pero su categoría no aparece en listados públicos. Es una decisión de diseño válida pero no documentada como intencional.
+
+**Acción:** Agregar nota explícita en `02-categories.md` sección 4.4:
+> "Decisión de diseño: los servicios de una categoría inactiva permanecen accesibles individualmente (por ID, búsqueda, listado general). Solo la navegación por categoría se ve afectada."
+
+---
+
+### ISSUE-19 — Entidad Appointment valida fecha pasada en constructor (afecta fromPersistence)
+
+| Campo | Valor |
+|-------|-------|
+| Origen | Auditoría B9 |
+| Archivo | `appointments/domain/entities/Appointment.ts` |
+| Severidad | **CRÍTICA** |
+| Intervención | **FIX_CODE** |
+| Dependencias | Ninguna |
+
+**Diagnóstico:** El constructor de Appointment llama `this.validate()` → `validateDateTime()` → `if (this.dateTime < new Date()) throw ValidationError`. El método `fromPersistence()` usa el mismo constructor. Reconstruir una cita pasada desde la base de datos lanzaría un `ValidationError`, lo cual impediría listar o consultar citas históricas.
+
+> **Nota:** Es posible que los tests pasen porque los mocks del repositorio devuelven objetos planos o entidades pre-construidas sin pasar por `fromPersistence()`, enmascarando el bug.
+
+**Acción:** Mover la validación de fecha pasada FUERA del constructor. Solo debe ejecutarse en el factory method `create()` (nuevas citas), no en `fromPersistence()` (reconstrucción). Opciones:
+- Opción A: `fromPersistence()` llama al constructor sin validación (crear un flag interno o un constructor separado)
+- Opción B (recomendada): Separar `validate()` en `validateForCreation()` (incluye fecha futura) y `validateForPersistence()` (solo formato). `create()` llama a la primera, `fromPersistence()` a la segunda.
+
+Agregar test que verifique que `fromPersistence()` funciona con fechas pasadas.
+
+---
+
+### ISSUE-20 — No hay límite de citas por cliente por día
+
+| Campo | Valor |
+|-------|-------|
+| Origen | Auditoría C1 |
+| Archivo | `06-appointments.md` |
+| Severidad | **BAJA** |
+| Intervención | **DOCUMENTAR** |
+| Dependencias | Ninguna |
+
+**Diagnóstico:** Un cliente puede crear citas ilimitadas para el mismo día. No hay validación de cantidad.
+
+**Acción:** Documentar en `06-appointments.md` sección 4.1 como limitación conocida:
+> "No existe actualmente un límite de citas por cliente por día. La protección contra abuso depende de la validación de conflictos de horario."
+
+---
+
+### ISSUE-21 — No hay cancelación automática de citas al crear feriado
+
+| Campo | Valor |
+|-------|-------|
+| Origen | Auditoría C2 |
+| Archivos | `holidays/application/use-cases/CreateHoliday.ts`, `06-appointments.md` |
+| Severidad | **MEDIA** |
+| Intervención | **DIFERIR** |
+| Dependencias | ISSUE-12 |
+
+**Diagnóstico:** Si se crea un feriado para una fecha que ya tiene citas pendientes, esas citas no se cancelan automáticamente. Requiere integración entre módulos Holidays y Appointments.
+
+**Razón para diferir:** Depende de ISSUE-12 (integración holidays-appointments). Una vez que los feriados afecten la disponibilidad, la cancelación automática sería el siguiente paso lógico. Implementarlo antes no tiene sentido sin la base.
+
+**Acción:** Documentar en `09-holidays.md` como feature planificada:
+> "Actualmente, crear un feriado no afecta las citas existentes para esa fecha. En una futura iteración, se implementará notificación y/o cancelación automática de citas afectadas."
+
+---
+
+### ISSUE-22 — Feriado sin excepción: comportamiento indefinido
+
+| Campo | Valor |
+|-------|-------|
+| Origen | Auditoría C3 |
+| Archivo | `09-holidays.md` |
+| Severidad | **MEDIA** |
+| Intervención | **FIX_DOCS** |
+| Dependencias | ISSUE-12 |
+
+**Diagnóstico:** Un feriado puede existir sin una ScheduleException asociada. En ese caso, no está definido si el salón está cerrado, tiene horario normal, o tiene horario reducido. Como la integración holidays-appointments no está implementada (ISSUE-12), este vacío no tiene efecto en runtime ahora, pero debe documentarse para cuando se implemente.
+
+**Acción:** Agregar en `09-holidays.md` sección 4 una regla que defina la intención:
+> "Un feriado sin excepción de horario asociada se interpreta como día cerrado (sin disponibilidad). Si el salón opera en un feriado con horario especial, se debe crear una ScheduleException vinculada."
+
+---
+
+### ISSUE-23 — ScheduleException permite fechas pasadas
+
+| Campo | Valor |
+|-------|-------|
+| Origen | Auditoría C4 |
+| Archivo | `09-holidays.md` |
+| Severidad | **BAJA** |
+| Intervención | **DOCUMENTAR** |
+| Dependencias | Ninguna |
+
+**Diagnóstico:** No hay validación que impida crear una ScheduleException para una fecha pasada. Tampoco para Holiday.
+
+**Acción:** Documentar como decisión de diseño en `09-holidays.md`:
+> "Se permite crear feriados y excepciones para fechas pasadas para mantener un registro histórico. Las propiedades computadas `isPast`, `isToday` y `isFuture` permiten filtrar según necesidad."
+
+---
+
+### ISSUE-24 — Monto de pago no vinculado a precios de servicios
+
+| Campo | Valor |
+|-------|-------|
+| Origen | Auditoría C5 |
+| Archivo | `08-payments.md` |
+| Severidad | **BAJA** |
+| Intervención | **DOCUMENTAR** |
+| Dependencias | ISSUE-08 |
+
+**Diagnóstico:** El `amount` del pago es completamente arbitrario. No hay validación que lo vincule con la suma de precios de los servicios de la cita. Se pueden crear pagos con montos que no corresponden al costo real del servicio.
+
+**Acción:** Documentar en `08-payments.md` como decisión de diseño (complementa ISSUE-08):
+> "El monto del pago es definido por el operador (Admin o Stylist) y no se valida automáticamente contra los precios de los servicios de la cita. Esto permite flexibilidad para descuentos, propinas, pagos parciales y ajustes manuales."
+
+---
+
+### ISSUE-25 — Idioma mixto en mensajes de validación (presentation layer)
+
+| Campo | Valor |
+|-------|-------|
+| Origen | Auditoría D1 |
+| Archivo | `payments/presentation/validations/PaymentValidations.ts` |
+| Severidad | **BAJA** |
+| Intervención | **FIX_CODE** |
+| Dependencias | Ninguna |
+
+**Diagnóstico:** Los mensajes de validación de `PaymentValidations.ts` están en español ("El monto es requerido", "El ID de la cita debe ser un UUID válido"), mientras que todos los demás módulos usan inglés. La convención establecida es mensajes en inglés en todo el código.
+
+**Acción:** Traducir todos los mensajes de `PaymentValidations.ts` a inglés para alinear con la convención del proyecto. No afecta lógica, solo strings.
+
+---
+
+### ISSUE-26 — Paginación con defaults inconsistentes entre módulos
+
+| Campo | Valor |
+|-------|-------|
+| Origen | Auditoría D2 |
+| Archivos | `07-notifications.md`, `08-payments.md`, `09-holidays.md` |
+| Severidad | **BAJA** |
+| Intervención | **DOCUMENTAR** |
+| Dependencias | Ninguna |
+
+**Diagnóstico:**
+
+| Módulo | Default limit | Max limit |
+|--------|--------------|-----------|
+| Payments | 20 | 100 |
+| Holidays | 10 | 100 |
+| Exceptions | 10 | 100 |
+| Notifications | 20 | No documentado |
+
+**Acción:** Documentar en cada archivo de business rules los defaults reales. Agregar nota al SKILL.md:
+> "Los defaults de paginación varían por módulo según el volumen esperado de datos. Holidays usa 10 por defecto por bajo volumen; Payments y Notifications usan 20."
+
+No amerita estandarización forzada — los defaults diferentes están justificados por el uso de cada módulo.
+
+---
+
+## Dependencias entre issues
+
+```
+ISSUE-12 (Holidays ↔ Appointments)
+    ├── ISSUE-21 depende de 12 (auto-cancel al crear feriado)
+    └── ISSUE-22 complementa a 12 (definir holiday sin exception)
+
+ISSUE-08 (Precio centavos/float)
+    └── ISSUE-24 complementa a 08 (monto desvinculado)
+
+ISSUE-10 (Permisos confirmación)
+    └── ISSUE-11 sigue el mismo patrón (permisos consulta)
+```
+
+Todos los demás issues son independientes y pueden ejecutarse en cualquier orden.
+
+---
+
+## Orden de ejecución recomendado
+
+### Fase 1 — Fixes de código críticos y altos (7 items)
+
+Estos son los que más impactan la integridad del sistema.
+
+| Orden | Issue | Severidad | Estimación |
+|-------|-------|-----------|------------|
+| 1 | ISSUE-19 | CRÍTICA | Refactor entity, 2 archivos, +1 test |
+| 2 | ISSUE-09 | ALTA | 2 archivos código + 1 doc |
+| 3 | ISSUE-13 | ALTA | 1 archivo + 1 test |
+| 4 | ISSUE-14 | ALTA | 1 archivo + inyección + 2 tests |
+| 5 | ISSUE-15 | ALTA | 1 archivo + 1 test |
+| 6 | ISSUE-06 | ALTA | 1 archivo + inyección + 3 tests |
+| 7 | ISSUE-04 | MEDIA | 1 archivo + ajuste tests |
+
+### Fase 2 — Fixes de código medios y bajos (5 items)
+
+| Orden | Issue | Severidad | Estimación |
+|-------|-------|-----------|------------|
+| 8 | ISSUE-01 | MEDIA | 1 archivo + inyección + 1 test |
+| 9 | ISSUE-02 | MEDIA | 1 archivo + inyección + 1 test |
+| 10 | ISSUE-05 | BAJA | 1 archivo + inyección + 1 test |
+| 11 | ISSUE-03 | BAJA | 1 archivo + 1 test |
+| 12 | ISSUE-07 | BAJA | 1 línea + ajuste test |
+
+### Fase 3 — Fix de idioma (1 item)
+
+| Orden | Issue | Severidad | Estimación |
+|-------|-------|-----------|------------|
+| 13 | ISSUE-25 | BAJA | 1 archivo, solo strings |
+
+### Fase 4 — Actualización de documentación (11 items)
+
+Después de los fixes de código, actualizar todos los documentos de business rules en una sola pasada:
+
+| Issue | Doc afectado |
+|-------|-------------|
+| ISSUE-08 | `03-services.md`, `08-payments.md` |
+| ISSUE-10 | `06-appointments.md` (permisos) |
+| ISSUE-11 | `06-appointments.md` (permisos consulta) |
+| ISSUE-22 | `09-holidays.md` (holiday sin excepción) |
+| ISSUE-16 | `06-appointments.md`, `08-payments.md` (datos no almacenados) |
+| ISSUE-17 | `01-auth.md`, `04-stylists.md` (cascade) |
+| ISSUE-18 | `02-categories.md` (desactivación) |
+| ISSUE-20 | `06-appointments.md` (límite citas) |
+| ISSUE-23 | `09-holidays.md` (fechas pasadas) |
+| ISSUE-24 | `08-payments.md` (monto desvinculado) |
+| ISSUE-26 | `07-notifications.md`, `08-payments.md`, `09-holidays.md` (paginación) |
+
+### Fase 5 — Documentar diferidos (2 items)
+
+| Issue | Doc afectado |
+|-------|-------------|
+| ISSUE-12 | `05-schedules.md`, `06-appointments.md`, README |
+| ISSUE-21 | `09-holidays.md` |
+
+---
+
+## Commits sugeridos
+
+Cada fix de código es un commit individual con conventional commit:
+
+```
+fix(services): validate associated services before deleting category (ISSUE-01)
+fix(services): validate active appointments before deleting service (ISSUE-02)
+fix(services): validate service isActive in AssignServiceToStylist (ISSUE-03)
+fix(appointments): normalize clientId to always use User.id (ISSUE-04)
+fix(notifications): validate user existence in CreateNotification (ISSUE-05)
+fix(payments): validate appointment existence and status in CreatePayment (ISSUE-06)
+fix(holidays): use NotFoundError in DeleteHoliday (ISSUE-07)
+fix(services): align max duration with appointments limit (ISSUE-09)
+fix(appointments): validate service isActive in CreateAppointment (ISSUE-13)
+fix(appointments): validate stylist offers selected services (ISSUE-14)
+fix(appointments): validate appointment time within working hours (ISSUE-15)
+fix(appointments): separate creation and persistence validation in entity (ISSUE-19)
+fix(payments): standardize validation messages to English (ISSUE-25)
+docs(business-rules): update all modules to v2.2 (ISSUE-08,10,11,16-18,20,22-24,26)
+docs(business-rules): document deferred features (ISSUE-12,21)
+```

--- a/src/modules/appointments/AppointmentContainer.ts
+++ b/src/modules/appointments/AppointmentContainer.ts
@@ -16,9 +16,11 @@ import { PrismaScheduleRepository } from './infrastructure/persistence/PrismaSch
 // Repositorios de módulos externos
 import { IServiceRepository } from '../services/domain/repositories/IServiceRepository';
 import { IStylistRepository } from '../services/domain/repositories/IStylistRepository';
+import { IStylistServiceRepository } from '../services/domain/repositories/IStylistServiceRepository';
 import { IClientRepository } from '../auth/domain/repositories/IClientRepository';
 import { PrismaServiceRepository } from '../services/infrastructure/persistence/PrismaServiceRepository';
 import { PrismaStylistRepository } from '../services/infrastructure/persistence/PrismaStylistRepository';
+import { PrismaStylistServiceRepository } from '../services/infrastructure/persistence/PrismaStylistServiceRepository';
 import { PrismaClientRepository } from '../auth/infrastructure/persistence/PrismaClientRepository';
 
 // Casos de uso
@@ -61,6 +63,7 @@ export class AppointmentContainer {
   // Repositorios - Módulos externos
   private _serviceRepository: IServiceRepository;
   private _stylistRepository: IStylistRepository;
+  private _stylistServiceRepository: IStylistServiceRepository;
   private _clientRepository: IClientRepository;
 
   /**
@@ -104,6 +107,7 @@ export class AppointmentContainer {
     // Repositorios de módulos externos
     this._serviceRepository = new PrismaServiceRepository(this.prisma);
     this._stylistRepository = new PrismaStylistRepository(this.prisma);
+    this._stylistServiceRepository = new PrismaStylistServiceRepository(this.prisma);
     this._clientRepository = new PrismaClientRepository(this.prisma);
 
     // Casos de uso implementados
@@ -113,6 +117,7 @@ export class AppointmentContainer {
       this._scheduleRepository,
       this._serviceRepository,
       this._stylistRepository,
+      this._stylistServiceRepository,
       this._clientRepository,
     );
 

--- a/src/modules/appointments/application/use-cases/CreateAppointment.ts
+++ b/src/modules/appointments/application/use-cases/CreateAppointment.ts
@@ -4,12 +4,14 @@ import { IAppointmentStatusRepository } from '../../domain/repositories/IAppoint
 import { IScheduleRepository } from '../../domain/repositories/IScheduleRepository';
 import { IServiceRepository } from '../../../services/domain/repositories/IServiceRepository';
 import { IStylistRepository } from '../../../services/domain/repositories/IStylistRepository';
+import { IStylistServiceRepository } from '../../../services/domain/repositories/IStylistServiceRepository';
 import { IClientRepository } from '../../../auth/domain/repositories/IClientRepository';
 import { CreateAppointmentDto } from '../dto/request/CreateAppointmentDto';
 import { AppointmentDto } from '../dto/response/AppointmentDto';
 import { ValidationError } from '../../../../shared/exceptions/ValidationError';
 import { NotFoundError } from '../../../../shared/exceptions/NotFoundError';
 import { ConflictError } from '../../../../shared/exceptions/ConflictError';
+import { BusinessRuleError } from '../../../../shared/exceptions/BusinessRuleError';
 
 /**
  * Caso de uso para crear una nueva cita en el sistema
@@ -22,8 +24,43 @@ export class CreateAppointment {
     private scheduleRepository: IScheduleRepository,
     private serviceRepository: IServiceRepository,
     private stylistRepository: IStylistRepository,
+    private stylistServiceRepository: IStylistServiceRepository,
     private clientRepository: IClientRepository,
   ) {}
+
+  /**
+   * Valida que la cita completa (inicio + duración) esté dentro del horario laboral del día
+   * @param dateTimeStr - Fecha y hora de la cita en formato ISO string
+   * @param duration - Duración total de la cita en minutos
+   * @param schedule - Horario laboral del día
+   * @throws BusinessRuleError si la cita está fuera del horario laboral
+   */
+  private validateWorkingHours(dateTimeStr: string, duration: number, schedule: any): void {
+    const appointmentDate = new Date(dateTimeStr);
+    const appointmentHours = appointmentDate.getHours();
+    const appointmentMinutes = appointmentDate.getMinutes();
+
+    // Convertir horarios a minutos desde medianoche para comparación
+    const [startH, startM] = schedule.startTime.split(':').map(Number);
+    const [endH, endM] = schedule.endTime.split(':').map(Number);
+
+    const appointmentStartInMinutes = appointmentHours * 60 + appointmentMinutes;
+    const appointmentEndInMinutes = appointmentStartInMinutes + duration;
+    const scheduleStartInMinutes = startH * 60 + startM;
+    const scheduleEndInMinutes = endH * 60 + endM;
+
+    if (appointmentStartInMinutes < scheduleStartInMinutes) {
+      throw new BusinessRuleError(
+        `Appointment starts before working hours (${schedule.startTime})`,
+      );
+    }
+
+    if (appointmentEndInMinutes > scheduleEndInMinutes) {
+      throw new BusinessRuleError(
+        `Appointment ends after working hours (${schedule.endTime})`,
+      );
+    }
+  }
 
   /**
    * Ejecuta el caso de uso para crear una nueva cita
@@ -44,16 +81,19 @@ export class CreateAppointment {
     // 3. Calcular duración total si no se proporciona
     const totalDuration = await this.calculateTotalDuration(createDto);
 
-    // 4. Validar disponibilidad y conflictos
-    await this.validateAvailability(createDto, totalDuration);
-
-    // 5. Obtener estado inicial (pendiente)
-    const pendingStatus = await this.getPendingStatus();
-
-    // 6. Obtener horario apropiado
+    // 4. Obtener horario apropiado para el día
     const schedule = await this.getAppropriateSchedule(createDto.dateTime);
 
-    // 7. Crear la entidad de cita con el Client.id correcto
+    // 5. Validar que la cita esté dentro del horario laboral
+    this.validateWorkingHours(createDto.dateTime, totalDuration, schedule);
+
+    // 6. Validar disponibilidad y conflictos
+    await this.validateAvailability(createDto, totalDuration);
+
+    // 7. Obtener estado inicial (pendiente)
+    const pendingStatus = await this.getPendingStatus();
+
+    // 8. Crear la entidad de cita con el Client.id correcto
     const appointment = Appointment.create(
       new Date(createDto.dateTime),
       totalDuration,
@@ -65,10 +105,10 @@ export class CreateAppointment {
       createDto.serviceIds,
     );
 
-    // 8. Guardar en repositorio
+    // 9. Guardar en repositorio
     const savedAppointment = await this.appointmentRepository.save(appointment);
 
-    // 9. Mapear a DTO de respuesta
+    // 10. Mapear a DTO de respuesta
     return this.mapToAppointmentDto(savedAppointment);
   }
 
@@ -145,11 +185,30 @@ export class CreateAppointment {
       }
     }
 
-    // Validar que todos los servicios existen
+    // Validar que todos los servicios existen y están activos
     for (const serviceId of createDto.serviceIds) {
       const service = await this.serviceRepository.findById(serviceId);
       if (!service) {
         throw new NotFoundError('Service', serviceId);
+      }
+      if (!service.isActive) {
+        throw new BusinessRuleError(`Service '${service.name}' is not currently active`);
+      }
+    }
+
+    // Validar que el estilista ofrezca los servicios seleccionados (si se especifica estilista)
+    if (createDto.stylistId) {
+      for (const serviceId of createDto.serviceIds) {
+        const assignment = await this.stylistServiceRepository.findByStylistAndService(
+          createDto.stylistId,
+          serviceId,
+        );
+        if (!assignment) {
+          throw new BusinessRuleError('Stylist does not offer one of the selected services');
+        }
+        if (!assignment.isOffering) {
+          throw new BusinessRuleError('Stylist is not currently offering one of the selected services');
+        }
       }
     }
 
@@ -200,9 +259,7 @@ export class CreateAppointment {
       throw new ConflictError('There are conflicting appointments at this time');
     }
 
-    // TODO: Validar horarios de trabajo del estilista
-    // TODO: Validar días festivos
-    // TODO: Validar horarios de la tienda
+    // TODO: Validar días festivos (ISSUE-12: diferido)
   }
 
   /**

--- a/src/modules/appointments/domain/entities/Appointment.ts
+++ b/src/modules/appointments/domain/entities/Appointment.ts
@@ -42,7 +42,7 @@ export class Appointment {
     stylistId?: string,
     serviceIds: string[] = [],
   ): Appointment {
-    return new Appointment(
+    const appointment = new Appointment(
       generateUuid(),
       dateTime,
       duration,
@@ -54,6 +54,8 @@ export class Appointment {
       undefined,
       serviceIds,
     );
+    appointment.validateDateNotInPast();
+    return appointment;
   }
 
   /**
@@ -113,14 +115,21 @@ export class Appointment {
   }
 
   /**
-   * Valida que la fecha y hora de la cita sean válidas
-   * @throws ValidationError si la fecha es inválida o está en el pasado
+   * Valida que la fecha y hora de la cita estén presentes y sean válidas
+   * @throws ValidationError si la fecha es nula o inválida
    */
   private validateDateTime(): void {
     if (!this.dateTime) {
       throw new ValidationError('Appointment date and time is required');
     }
+  }
 
+  /**
+   * Valida que la fecha de la cita no esté en el pasado
+   * Solo se aplica en creación de nuevas citas, no en reconstrucción desde persistencia
+   * @throws ValidationError si la fecha es anterior a la fecha actual
+   */
+  private validateDateNotInPast(): void {
     if (this.dateTime < new Date()) {
       throw new ValidationError('Appointment cannot be scheduled in the past');
     }

--- a/src/modules/payments/PaymentContainer.ts
+++ b/src/modules/payments/PaymentContainer.ts
@@ -4,6 +4,12 @@ import { PrismaClient } from '@prisma/client';
 import { IPaymentRepository } from './domain/repositories/IPaymentRepository';
 import { PrismaPaymentRepository } from './infrastructure/persistence/PrismaPaymentRepository';
 
+// Repositorios de módulos externos
+import { IAppointmentRepository } from '../appointments/domain/repositories/IAppointmentRepository';
+import { IAppointmentStatusRepository } from '../appointments/domain/repositories/IAppointmentStatusRepository';
+import { PrismaAppointmentRepository } from '../appointments/infrastructure/persistence/PrismaAppointmentRepository';
+import { PrismaAppointmentStatusRepository } from '../appointments/infrastructure/persistence/PrismaAppointmentStatusRepository';
+
 // Use Cases
 import { CreatePayment } from './application/use-cases/CreatePayment';
 import { GetPaymentById } from './application/use-cases/GetPaymentById';
@@ -31,6 +37,10 @@ export class PaymentContainer {
 
   // Repository
   private _paymentRepository: IPaymentRepository;
+
+  // Repositorios externos
+  private _appointmentRepository: IAppointmentRepository;
+  private _appointmentStatusRepository: IAppointmentStatusRepository;
 
   // Use Cases
   private _createPayment: CreatePayment;
@@ -77,11 +87,17 @@ export class PaymentContainer {
    * @private
    */
   private setupDependencies(): void {
-    // 1. Inicializar repositorio
+    // 1. Inicializar repositorios
     this._paymentRepository = new PrismaPaymentRepository(this.prisma);
+    this._appointmentRepository = new PrismaAppointmentRepository(this.prisma);
+    this._appointmentStatusRepository = new PrismaAppointmentStatusRepository(this.prisma);
 
     // 2. Inicializar use cases
-    this._createPayment = new CreatePayment(this._paymentRepository);
+    this._createPayment = new CreatePayment(
+      this._paymentRepository,
+      this._appointmentRepository,
+      this._appointmentStatusRepository,
+    );
     this._getPaymentById = new GetPaymentById(this._paymentRepository);
     this._getPaymentsByAppointment = new GetPaymentsByAppointment(this._paymentRepository);
     this._getPayments = new GetPayments(this._paymentRepository);

--- a/src/modules/payments/application/use-cases/CreatePayment.ts
+++ b/src/modules/payments/application/use-cases/CreatePayment.ts
@@ -1,16 +1,24 @@
 import { generateUuid } from '../../../../shared/utils/uuid';
 import { Payment } from '../../domain/entities/Payment';
 import { IPaymentRepository } from '../../domain/repositories/IPaymentRepository';
+import { IAppointmentRepository } from '../../../appointments/domain/repositories/IAppointmentRepository';
+import { IAppointmentStatusRepository } from '../../../appointments/domain/repositories/IAppointmentStatusRepository';
 import { CreatePaymentDto } from '../dto/request/CreatePaymentDto';
 import { PaymentResponseDto } from '../dto/response/PaymentResponseDto';
 import { ValidationError } from '../../../../shared/exceptions/ValidationError';
+import { NotFoundError } from '../../../../shared/exceptions/NotFoundError';
+import { BusinessRuleError } from '../../../../shared/exceptions/BusinessRuleError';
 
 /**
  * Caso de uso para crear un pago
  * @description Crea un nuevo pago asociado a una cita
  */
 export class CreatePayment {
-  constructor(private paymentRepository: IPaymentRepository) {}
+  constructor(
+    private paymentRepository: IPaymentRepository,
+    private appointmentRepository: IAppointmentRepository,
+    private appointmentStatusRepository: IAppointmentStatusRepository,
+  ) {}
 
   /**
    * Ejecuta el caso de uso
@@ -21,6 +29,21 @@ export class CreatePayment {
     // Validar que el monto sea positivo
     if (dto.amount <= 0) {
       throw new ValidationError('Amount must be greater than 0');
+    }
+
+    // Validar que la cita exista
+    const appointment = await this.appointmentRepository.findById(dto.appointmentId);
+    if (!appointment) {
+      throw new NotFoundError('Appointment', dto.appointmentId);
+    }
+
+    // Validar que la cita esté en un estado válido para crear pago
+    const status = await this.appointmentStatusRepository.findById(appointment.statusId);
+    const allowedStatuses = ['CONFIRMED', 'COMPLETED'];
+    if (!status || !allowedStatuses.includes(status.name)) {
+      throw new BusinessRuleError(
+        `Cannot create a payment for an appointment with status ${status?.name || 'UNKNOWN'}. Allowed: ${allowedStatuses.join(', ')}`,
+      );
     }
 
     // Crear la entidad de pago

--- a/src/modules/services/domain/entities/Service.ts
+++ b/src/modules/services/domain/entities/Service.ts
@@ -112,9 +112,9 @@ export class Service {
       throw new ValidationError('Service duration must be positive');
     }
 
-    if (this.duration > 600) {
-      // 10 horas máximo
-      throw new ValidationError('Service duration is too long (max 10 hours)');
+    if (this.duration > 480) {
+      // 8 horas máximo (alineado con duración máxima de citas)
+      throw new ValidationError('Service duration is too long (max 8 hours)');
     }
 
     if (this.durationVariation < 0) {

--- a/src/modules/services/presentation/validations/ServiceValidations.ts
+++ b/src/modules/services/presentation/validations/ServiceValidations.ts
@@ -12,7 +12,7 @@ export class ServiceValidations {
    * - categoryId: UUID válido requerido
    * - name: string 1-150 caracteres
    * - description: string 1-1000 caracteres
-   * - duration: entero 1-600 minutos
+   * - duration: entero 1-480 minutos
    * - durationVariation: entero no negativo, no mayor que duration
    * - price: float no negativo, convertido a centavos
    */
@@ -34,8 +34,8 @@ export class ServiceValidations {
       .withMessage('Description must be between 1 and 1000 characters'),
 
     body('duration')
-      .isInt({ min: 1, max: 600 })
-      .withMessage('Duration must be an integer between 1 and 600 minutes'),
+      .isInt({ min: 1, max: 480 })
+      .withMessage('Duration must be an integer between 1 and 480 minutes'),
 
     body('durationVariation')
       .isInt({ min: 0 })
@@ -84,8 +84,8 @@ export class ServiceValidations {
 
     body('duration')
       .optional()
-      .isInt({ min: 1, max: 600 })
-      .withMessage('Duration must be an integer between 1 and 600 minutes'),
+      .isInt({ min: 1, max: 480 })
+      .withMessage('Duration must be an integer between 1 and 480 minutes'),
 
     body('durationVariation')
       .optional()

--- a/tests/e2e/payments-complete-flow.e2e.test.ts
+++ b/tests/e2e/payments-complete-flow.e2e.test.ts
@@ -1,7 +1,7 @@
 import request from 'supertest';
 import app from '../../src/app';
 import { loginAsAdmin, loginTestUser } from '../setup/helpers';
-import { createTestAppointment } from '../setup/appointments-helpers';
+import { createConfirmedTestAppointment } from '../setup/appointments-helpers';
 
 // Tests E2E para el flujo completo del módulo de Pagos
 describe('Payments Complete Flow E2E Tests', () => {
@@ -25,8 +25,8 @@ describe('Payments Complete Flow E2E Tests', () => {
     });
     stylistToken = stylistResponse.body.data.token;
 
-    // Crear una cita de prueba para los tests E2E
-    const appointment = await createTestAppointment();
+    // Crear una cita de prueba confirmada para los tests E2E de pagos
+    const appointment = await createConfirmedTestAppointment();
     testAppointmentId = appointment.id;
   });
 

--- a/tests/integration/appointments/repositories/AppointmentRepository.integration.test.ts
+++ b/tests/integration/appointments/repositories/AppointmentRepository.integration.test.ts
@@ -49,10 +49,10 @@ describe('AppointmentRepository Integration Tests', () => {
     testScheduleId = schedule.id;
 
     const status = await testPrisma.appointmentStatus.findFirst({
-      where: { name: 'Pendiente' },
+      where: { name: 'PENDING' },
     });
     if (!status) {
-      throw new Error('No se encontró el status "Pendiente" en el seed');
+      throw new Error('Status "PENDING" not found in seed data');
     }
     testStatusId = status.id;
   });

--- a/tests/integration/appointments/repositories/AppointmentStatusRepository.integration.test.ts
+++ b/tests/integration/appointments/repositories/AppointmentStatusRepository.integration.test.ts
@@ -29,9 +29,9 @@ describe('AppointmentStatusRepository Integration Tests', () => {
 
       // Verificar que incluye los estados principales del seed
       const statusNames = statuses.map((status) => status.name);
-      expect(statusNames).toContain('Pendiente');
-      expect(statusNames).toContain('Confirmada');
-      expect(statusNames).toContain('Completada');
+      expect(statusNames).toContain('PENDING');
+      expect(statusNames).toContain('CONFIRMED');
+      expect(statusNames).toContain('COMPLETED');
 
       // Verificar que todos tienen propiedades requeridas
       statuses.forEach((status) => {
@@ -46,7 +46,7 @@ describe('AppointmentStatusRepository Integration Tests', () => {
     it('should find status by existing id', async () => {
       // Obtener un estado del seed
       const seedStatus = await testPrisma.appointmentStatus.findFirst({
-        where: { name: 'Pendiente' },
+        where: { name: 'PENDING' },
       });
 
       expect(seedStatus).toBeDefined();
@@ -55,7 +55,7 @@ describe('AppointmentStatusRepository Integration Tests', () => {
 
       expect(foundStatus).toBeDefined();
       expect(foundStatus!.id).toBe(seedStatus!.id);
-      expect(foundStatus!.name).toBe('Pendiente');
+      expect(foundStatus!.name).toBe('PENDING');
     });
 
     it('should return null for non-existing id', async () => {
@@ -69,10 +69,10 @@ describe('AppointmentStatusRepository Integration Tests', () => {
 
   describe('findByName', () => {
     it('should find status by existing name', async () => {
-      const foundStatus = await repository.findByName('Pendiente');
+      const foundStatus = await repository.findByName('PENDING');
 
       expect(foundStatus).toBeDefined();
-      expect(foundStatus!.name).toBe('Pendiente');
+      expect(foundStatus!.name).toBe('PENDING');
       expect(foundStatus!.id).toBeDefined();
     });
 
@@ -83,7 +83,7 @@ describe('AppointmentStatusRepository Integration Tests', () => {
     });
 
     it('should be case-sensitive when finding by name', async () => {
-      const foundStatus = await repository.findByName('pendiente'); // minúscula
+      const foundStatus = await repository.findByName('pending'); // minúscula
 
       expect(foundStatus).toBeNull(); // No debería encontrar porque es case-sensitive
     });
@@ -210,7 +210,7 @@ describe('AppointmentStatusRepository Integration Tests', () => {
     it('should return true for existing id', async () => {
       // Usar estado del seed
       const seedStatus = await testPrisma.appointmentStatus.findFirst({
-        where: { name: 'Pendiente' },
+        where: { name: 'PENDING' },
       });
 
       expect(seedStatus).toBeDefined();
@@ -229,7 +229,7 @@ describe('AppointmentStatusRepository Integration Tests', () => {
 
   describe('existsByName', () => {
     it('should return true for existing name', async () => {
-      const exists = await repository.existsByName('Pendiente');
+      const exists = await repository.existsByName('PENDING');
       expect(exists).toBe(true);
     });
 
@@ -239,7 +239,7 @@ describe('AppointmentStatusRepository Integration Tests', () => {
     });
 
     it('should be case-sensitive', async () => {
-      const exists = await repository.existsByName('pendiente'); // minúscula
+      const exists = await repository.existsByName('pending'); // minúscula
       expect(exists).toBe(false);
     });
   });
@@ -248,21 +248,21 @@ describe('AppointmentStatusRepository Integration Tests', () => {
     it('should return terminal statuses', async () => {
       const terminalStatuses = await repository.findTerminalStatuses();
 
-      // Los estados terminales típicamente incluyen Completada, Cancelada
+      // Los estados terminales típicamente incluyen COMPLETED, CANCELLED
       expect(terminalStatuses.length).toBeGreaterThanOrEqual(1);
 
       // Verificar que incluye estados esperados
       const statusNames = terminalStatuses.map((status) => status.name);
-      expect(statusNames).toContain('Completada');
-      expect(statusNames).toContain('Cancelada');
+      expect(statusNames).toContain('COMPLETED');
+      expect(statusNames).toContain('CANCELLED');
     });
 
     it('should not include non-terminal statuses', async () => {
       const terminalStatuses = await repository.findTerminalStatuses();
 
       const statusNames = terminalStatuses.map((status) => status.name);
-      expect(statusNames).not.toContain('Pendiente');
-      expect(statusNames).not.toContain('Confirmada');
+      expect(statusNames).not.toContain('PENDING');
+      expect(statusNames).not.toContain('CONFIRMED');
     });
   });
 
@@ -270,16 +270,16 @@ describe('AppointmentStatusRepository Integration Tests', () => {
     it('should return active statuses', async () => {
       const activeStatuses = await repository.findActiveStatuses();
 
-      // Los estados activos no incluyen Cancelada ni Completada
+      // Los estados activos no incluyen CANCELLED ni COMPLETED
       expect(activeStatuses.length).toBeGreaterThanOrEqual(2);
 
       const statusNames = activeStatuses.map((status) => status.name);
-      expect(statusNames).toContain('Pendiente');
-      expect(statusNames).toContain('Confirmada');
+      expect(statusNames).toContain('PENDING');
+      expect(statusNames).toContain('CONFIRMED');
 
       // No debería incluir estados terminales
-      expect(statusNames).not.toContain('Completada');
-      expect(statusNames).not.toContain('Cancelada');
+      expect(statusNames).not.toContain('COMPLETED');
+      expect(statusNames).not.toContain('CANCELLED');
     });
   });
 

--- a/tests/integration/payments/payment-routes.integration.test.ts
+++ b/tests/integration/payments/payment-routes.integration.test.ts
@@ -1,7 +1,7 @@
 import request from 'supertest';
 import app from '../../../src/app';
 import { loginAsAdmin, loginTestUser } from '../../setup/helpers';
-import { createTestAppointment } from '../../setup/appointments-helpers';
+import { createConfirmedTestAppointment } from '../../setup/appointments-helpers';
 
 // Tests de integración para el módulo de Pagos
 describe('Payments Integration Tests', () => {
@@ -26,8 +26,8 @@ describe('Payments Integration Tests', () => {
     });
     stylistToken = stylistResponse.body.data.token;
 
-    // Crear una cita de prueba para los tests
-    const appointment = await createTestAppointment();
+    // Crear una cita de prueba confirmada para los tests de pagos
+    const appointment = await createConfirmedTestAppointment();
     testAppointmentId = appointment.id;
   });
 

--- a/tests/setup/appointments-helpers.ts
+++ b/tests/setup/appointments-helpers.ts
@@ -4,6 +4,31 @@ import { generateUuid } from '../../src/shared/utils/uuid';
 import { DayOfWeek } from '@prisma/client';
 
 /**
+ * Crea un appointment de prueba en estado confirmado para testing de pagos y otros flujos
+ * @param overrides - Propiedades opcionales para sobrescribir los valores por defecto
+ * @returns Promise que resuelve con el appointment confirmado creado en la base de datos
+ * @example
+ * ```typescript
+ * const appointment = await createConfirmedTestAppointment();
+ * ```
+ */
+export async function createConfirmedTestAppointment(overrides: Partial<any> = {}): Promise<any> {
+  const confirmedStatus = await testPrisma.appointmentStatus.findFirst({
+    where: { name: 'CONFIRMED' }
+  });
+
+  if (!confirmedStatus) {
+    throw new Error('Confirmed status not found in database. Ensure seed data is loaded.');
+  }
+
+  return createTestAppointment({
+    statusId: confirmedStatus.id,
+    confirmedAt: new Date(),
+    ...overrides,
+  });
+}
+
+/**
  * Interfaz para los datos del seed que retorna getSeedData
  */
 interface SeedData {
@@ -77,14 +102,14 @@ async function getOrCreateBaseData() {
 
   // Obtener o crear status
   let status = await testPrisma.appointmentStatus.findFirst({
-    where: { name: 'Pendiente' }
+    where: { name: 'PENDING' }
   });
 
   if (!status) {
     status = await testPrisma.appointmentStatus.create({
       data: {
         id: generateUuid(),
-        name: 'Pendiente',
+        name: 'PENDING',
         description: 'Appointment pending confirmation'
       }
     });
@@ -346,15 +371,15 @@ export async function cleanupAll(): Promise<void> {
  */
 export async function getSeedData(): Promise<SeedData> {
   const pendingStatus = await testPrisma.appointmentStatus.findFirst({
-    where: { name: 'Pendiente' }
+    where: { name: 'PENDING' }
   });
 
   const confirmedStatus = await testPrisma.appointmentStatus.findFirst({
-    where: { name: 'Confirmada' }
+    where: { name: 'CONFIRMED' }
   });
 
   const completedStatus = await testPrisma.appointmentStatus.findFirst({
-    where: { name: 'Completada' }
+    where: { name: 'COMPLETED' }
   });
 
   const mondaySchedule = await testPrisma.schedule.findFirst({

--- a/tests/unit/appointments/application/use-cases/CreateAppointment.unit.test.ts
+++ b/tests/unit/appointments/application/use-cases/CreateAppointment.unit.test.ts
@@ -4,6 +4,7 @@ import { AppointmentStatusRepository } from '../../../../../src/modules/appointm
 import { ScheduleRepository } from '../../../../../src/modules/appointments/domain/repositories/ScheduleRepository';
 import { ServiceRepository } from '../../../../../src/modules/services/domain/repositories/ServiceRepository';
 import { StylistRepository } from '../../../../../src/modules/services/domain/repositories/StylistRepository';
+import { IStylistServiceRepository } from '../../../../../src/modules/services/domain/repositories/IStylistServiceRepository';
 import { ClientRepository } from '../../../../../src/modules/auth/domain/repositories/Client';
 import { Appointment } from '../../../../../src/modules/appointments/domain/entities/Appointment';
 import { AppointmentStatus } from '../../../../../src/modules/appointments/domain/entities/AppointmentStatus';
@@ -15,6 +16,7 @@ import { CreateAppointmentDto } from '../../../../../src/modules/appointments/ap
 import { ValidationError } from '../../../../../src/shared/exceptions/ValidationError';
 import { NotFoundError } from '../../../../../src/shared/exceptions/NotFoundError';
 import { ConflictError } from '../../../../../src/shared/exceptions/ConflictError';
+import { BusinessRuleError } from '../../../../../src/shared/exceptions/BusinessRuleError';
 import { generateUuid } from '../../../../../src/shared/utils/uuid';
 
 describe('CreateAppointment Use Case', () => {
@@ -24,6 +26,7 @@ describe('CreateAppointment Use Case', () => {
   let mockScheduleRepository: jest.Mocked<ScheduleRepository>;
   let mockServiceRepository: jest.Mocked<ServiceRepository>;
   let mockStylistRepository: jest.Mocked<StylistRepository>;
+  let mockStylistServiceRepository: jest.Mocked<IStylistServiceRepository>;
   let mockClientRepository: jest.Mocked<ClientRepository>;
 
   // Utilidades de fecha dinámicas y mantenibles
@@ -35,6 +38,9 @@ describe('CreateAppointment Use Case', () => {
     while (future.getDay() !== 1) { // 1 = lunes
       future.setDate(future.getDate() + 1);
     }
+
+    // Fijar hora dentro del horario laboral del mock schedule (09:00-18:00)
+    future.setHours(10, 0, 0, 0);
     
     return future;
   };
@@ -195,12 +201,14 @@ describe('CreateAppointment Use Case', () => {
     const stylist = createMockStylist(validStylistId);
     const service = createMockService(validServiceId1, 60);
     const schedule = createMockSchedule('MONDAY');
+    const stylistService = { stylistId: validStylistId, serviceId: validServiceId1, isOffering: true, customPrice: null, createdAt: new Date(), updatedAt: new Date() };
 
     mockAppointmentStatusRepository.findByName.mockResolvedValue(pendingStatus);
     mockClientRepository.findById.mockResolvedValue(client);
     mockClientRepository.findByUserId.mockResolvedValue(null); // No necesario si findById encuentra
     mockStylistRepository.findById.mockResolvedValue(stylist);
     mockServiceRepository.findById.mockResolvedValue(service);
+    mockStylistServiceRepository.findByStylistAndService.mockResolvedValue(stylistService as any);
     mockScheduleRepository.findAll.mockResolvedValue([schedule]);
     mockAppointmentRepository.findConflictingAppointments.mockResolvedValue([]);
     mockAppointmentRepository.save.mockResolvedValue(appointment);
@@ -283,6 +291,18 @@ describe('CreateAppointment Use Case', () => {
       existsById: jest.fn(),
     } as unknown as jest.Mocked<StylistRepository>;
 
+    mockStylistServiceRepository = {
+      findByStylistAndService: jest.fn(),
+      findByStylist: jest.fn(),
+      findByService: jest.fn(),
+      findActiveOfferings: jest.fn(),
+      findStylistsOfferingService: jest.fn(),
+      save: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      existsAssignment: jest.fn(),
+    } as unknown as jest.Mocked<IStylistServiceRepository>;
+
     // Mock de ClientRepository
     mockClientRepository = {
       findById: jest.fn(),
@@ -301,6 +321,7 @@ describe('CreateAppointment Use Case', () => {
       mockScheduleRepository,
       mockServiceRepository,
       mockStylistRepository,
+      mockStylistServiceRepository,
       mockClientRepository,
     );
   });
@@ -453,6 +474,9 @@ describe('CreateAppointment Use Case', () => {
       mockClientRepository.findByUserId.mockResolvedValue(client);
       mockStylistRepository.findById.mockResolvedValue(stylist);
       mockServiceRepository.findById.mockResolvedValue(service);
+      mockStylistServiceRepository.findByStylistAndService.mockResolvedValue(
+        { stylistId: validStylistId, serviceId: validServiceId1, isOffering: true } as any,
+      );
       mockAppointmentStatusRepository.findByName.mockResolvedValue(pendingStatus);
       mockScheduleRepository.findAll.mockResolvedValue([schedule]);
       mockAppointmentRepository.findConflictingAppointments.mockResolvedValue([]);
@@ -488,6 +512,94 @@ describe('CreateAppointment Use Case', () => {
         new NotFoundError('Service', validServiceId1),
       );
     });
+
+    // Debería lanzar BusinessRuleError cuando un servicio no está activo
+    it('should throw BusinessRuleError when service is not active', async () => {
+      const client = createMockClient(validClientId);
+      const stylist = createMockStylist(validStylistId);
+      const inactiveService = createMockService(validServiceId1, 60);
+      (inactiveService as any).isActive = false;
+
+      mockClientRepository.findById.mockResolvedValue(client);
+      mockStylistRepository.findById.mockResolvedValue(stylist);
+      mockServiceRepository.findById.mockResolvedValue(inactiveService);
+
+      await expect(useCase.execute(validCreateDto, validUserId)).rejects.toThrow(
+        BusinessRuleError,
+      );
+    });
+
+    // Debería lanzar BusinessRuleError cuando el estilista no tiene asignado el servicio
+    it('should throw BusinessRuleError when stylist does not offer service', async () => {
+      const client = createMockClient(validClientId);
+      const stylist = createMockStylist(validStylistId);
+      const service = createMockService(validServiceId1, 60);
+
+      mockClientRepository.findById.mockResolvedValue(client);
+      mockStylistRepository.findById.mockResolvedValue(stylist);
+      mockServiceRepository.findById.mockResolvedValue(service);
+      mockStylistServiceRepository.findByStylistAndService.mockResolvedValue(null);
+
+      await expect(useCase.execute(validCreateDto, validUserId)).rejects.toThrow(
+        BusinessRuleError,
+      );
+    });
+
+    // Debería lanzar BusinessRuleError cuando el estilista no está ofreciendo el servicio actualmente
+    it('should throw BusinessRuleError when stylist is not currently offering service', async () => {
+      const client = createMockClient(validClientId);
+      const stylist = createMockStylist(validStylistId);
+      const service = createMockService(validServiceId1, 60);
+      const notOfferingAssignment = { stylistId: validStylistId, serviceId: validServiceId1, isOffering: false };
+
+      mockClientRepository.findById.mockResolvedValue(client);
+      mockStylistRepository.findById.mockResolvedValue(stylist);
+      mockServiceRepository.findById.mockResolvedValue(service);
+      mockStylistServiceRepository.findByStylistAndService.mockResolvedValue(notOfferingAssignment as any);
+
+      await expect(useCase.execute(validCreateDto, validUserId)).rejects.toThrow(
+        BusinessRuleError,
+      );
+    });
+  });
+
+  describe('Working Hours Validation', () => {
+    // Debería lanzar BusinessRuleError cuando la cita empieza antes del horario laboral
+    it('should throw BusinessRuleError when appointment starts before working hours', async () => {
+      const earlyDate = getNextMonday(48);
+      earlyDate.setHours(7, 0, 0, 0); // 7:00 AM, antes de 09:00
+
+      const earlyDto: CreateAppointmentDto = {
+        ...validCreateDto,
+        dateTime: earlyDate.toISOString(),
+      };
+
+      const appointment = createMockAppointment();
+      setupBasicSuccessfulMocks(appointment);
+
+      await expect(useCase.execute(earlyDto, validUserId)).rejects.toThrow(
+        BusinessRuleError,
+      );
+    });
+
+    // Debería lanzar BusinessRuleError cuando la cita termina después del horario laboral
+    it('should throw BusinessRuleError when appointment ends after working hours', async () => {
+      const lateDate = getNextMonday(48);
+      lateDate.setHours(17, 30, 0, 0); // 17:30, una cita de 60 min terminaría a las 18:30
+
+      const lateDto: CreateAppointmentDto = {
+        ...validCreateDto,
+        dateTime: lateDate.toISOString(),
+        duration: 60,
+      };
+
+      const appointment = createMockAppointment();
+      setupBasicSuccessfulMocks(appointment);
+
+      await expect(useCase.execute(lateDto, validUserId)).rejects.toThrow(
+        BusinessRuleError,
+      );
+    });
   });
 
   describe('Conflict Detection', () => {
@@ -503,6 +615,9 @@ describe('CreateAppointment Use Case', () => {
       mockClientRepository.findById.mockResolvedValue(client);
       mockStylistRepository.findById.mockResolvedValue(stylist);
       mockServiceRepository.findById.mockResolvedValue(service);
+      mockStylistServiceRepository.findByStylistAndService.mockResolvedValue(
+        { stylistId: validStylistId, serviceId: validServiceId1, isOffering: true } as any,
+      );
       mockAppointmentStatusRepository.findByName.mockResolvedValue(pendingStatus);
       mockScheduleRepository.findAll.mockResolvedValue([schedule]);
       mockAppointmentRepository.findConflictingAppointments.mockResolvedValue([

--- a/tests/unit/appointments/domain/entities/Appointment.unit.test.ts
+++ b/tests/unit/appointments/domain/entities/Appointment.unit.test.ts
@@ -102,13 +102,12 @@ describe('Appointment Entity', () => {
   });
 
   describe('Appointment Validation', () => {
-    // Debería lanzar error para fecha en el pasado
-    it('should throw error for past date', () => {
+    // Debería lanzar error para fecha en el pasado al crear con create()
+    it('should throw error for past date via create()', () => {
       const pastDate = new Date('2020-01-01T10:00:00.000Z');
 
       expect(() => {
-        new Appointment(
-          validAppointmentData.id,
+        Appointment.create(
           pastDate,
           validAppointmentData.duration,
           validAppointmentData.userId,
@@ -117,6 +116,31 @@ describe('Appointment Entity', () => {
           validAppointmentData.statusId,
         );
       }).toThrow('Appointment cannot be scheduled in the past');
+    });
+
+    // Debería permitir fechas pasadas al reconstruir desde persistencia
+    it('should allow past dates via fromPersistence()', () => {
+      const pastDate = new Date('2020-01-01T10:00:00.000Z');
+      const createdAt = new Date('2019-12-01T10:00:00.000Z');
+      const updatedAt = new Date('2019-12-15T10:00:00.000Z');
+
+      const appointment = Appointment.fromPersistence(
+        validAppointmentData.id,
+        pastDate,
+        validAppointmentData.duration,
+        validAppointmentData.userId,
+        validAppointmentData.clientId,
+        validAppointmentData.scheduleId,
+        validAppointmentData.statusId,
+        validAppointmentData.stylistId,
+        undefined,
+        validAppointmentData.serviceIds,
+        createdAt,
+        updatedAt,
+      );
+
+      expect(appointment.dateTime).toEqual(pastDate);
+      expect(appointment.isInPast()).toBe(true);
     });
 
     // Debería lanzar error para duración cero
@@ -365,18 +389,17 @@ describe('Appointment Entity', () => {
 
       // Debería detectar si la cita está en el pasado
       it('should detect if appointment is in past', () => {
-        const pastAppointment = new Appointment(
+        const pastDate = new Date('2020-01-01T10:00:00.000Z');
+
+        const pastAppointment = Appointment.fromPersistence(
           generateUuid(),
-          getFutureDate(10), // Fecha futura para validación inicial
+          pastDate,
           60,
           validAppointmentData.userId,
           validAppointmentData.clientId,
           validAppointmentData.scheduleId,
           validAppointmentData.statusId,
         );
-
-        // Cambiar a fecha pasada después de la validación inicial
-        pastAppointment.dateTime = new Date('2020-01-01T10:00:00.000Z');
 
         expect(pastAppointment.isInPast()).toBe(true);
       });

--- a/tests/unit/payments/application/use-cases/CreatePayment.unit.test.ts
+++ b/tests/unit/payments/application/use-cases/CreatePayment.unit.test.ts
@@ -1,10 +1,36 @@
 import { CreatePayment } from '../../../../../src/modules/payments/application/use-cases/CreatePayment';
 import { IPaymentRepository } from '../../../../../src/modules/payments/domain/repositories/IPaymentRepository';
+import { IAppointmentRepository } from '../../../../../src/modules/appointments/domain/repositories/IAppointmentRepository';
+import { IAppointmentStatusRepository } from '../../../../../src/modules/appointments/domain/repositories/IAppointmentStatusRepository';
 import { Payment, PaymentStatusEnum } from '../../../../../src/modules/payments/domain/entities/Payment';
+import { NotFoundError } from '../../../../../src/shared/exceptions/NotFoundError';
+import { BusinessRuleError } from '../../../../../src/shared/exceptions/BusinessRuleError';
 
 describe('CreatePayment Use Case', () => {
   let createPayment: CreatePayment;
   let mockPaymentRepository: jest.Mocked<IPaymentRepository>;
+  let mockAppointmentRepository: jest.Mocked<IAppointmentRepository>;
+  let mockAppointmentStatusRepository: jest.Mocked<IAppointmentStatusRepository>;
+
+  const validAppointmentId = '123e4567-e89b-12d3-a456-426614174001';
+  const validStatusId = '123e4567-e89b-12d3-a456-426614174002';
+
+  const mockAppointment = {
+    id: validAppointmentId,
+    statusId: validStatusId,
+    dateTime: new Date(),
+    duration: 60,
+    userId: '123e4567-e89b-12d3-a456-426614174003',
+    clientId: '123e4567-e89b-12d3-a456-426614174004',
+    scheduleId: '123e4567-e89b-12d3-a456-426614174005',
+    serviceIds: [],
+  };
+
+  const mockConfirmedStatus = {
+    id: validStatusId,
+    name: 'CONFIRMED',
+    description: 'Confirmed appointment',
+  };
 
   beforeEach(() => {
     mockPaymentRepository = {
@@ -18,14 +44,58 @@ describe('CreatePayment Use Case', () => {
       getTotalByAppointment: jest.fn(),
     };
 
-    createPayment = new CreatePayment(mockPaymentRepository);
+    mockAppointmentRepository = {
+      findById: jest.fn(),
+      findAll: jest.fn(),
+      save: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      existsById: jest.fn(),
+      findByClientId: jest.fn(),
+      findByStylistId: jest.fn(),
+      findByUserId: jest.fn(),
+      findByStatusId: jest.fn(),
+      findByDateRange: jest.fn(),
+      findByClientAndDateRange: jest.fn(),
+      findByStylistAndDateRange: jest.fn(),
+      findConflictingAppointments: jest.fn(),
+      findByScheduleId: jest.fn(),
+      findByDate: jest.fn(),
+      countByStatus: jest.fn(),
+      countByDateRange: jest.fn(),
+      findUpcomingAppointments: jest.fn(),
+      findPendingConfirmation: jest.fn(),
+    } as unknown as jest.Mocked<IAppointmentRepository>;
+
+    mockAppointmentStatusRepository = {
+      findById: jest.fn(),
+      findByName: jest.fn(),
+      findAll: jest.fn(),
+      save: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      existsById: jest.fn(),
+      existsByName: jest.fn(),
+      findTerminalStatuses: jest.fn(),
+      findActiveStatuses: jest.fn(),
+    } as unknown as jest.Mocked<IAppointmentStatusRepository>;
+
+    // Configurar mocks por defecto para caso exitoso
+    mockAppointmentRepository.findById.mockResolvedValue(mockAppointment as any);
+    mockAppointmentStatusRepository.findById.mockResolvedValue(mockConfirmedStatus as any);
+
+    createPayment = new CreatePayment(
+      mockPaymentRepository,
+      mockAppointmentRepository,
+      mockAppointmentStatusRepository,
+    );
   });
 
   // Debería crear un pago exitosamente
   it('should create a payment successfully', async () => {
     const dto = {
       amount: 100.50,
-      appointmentId: '123e4567-e89b-12d3-a456-426614174001',
+      appointmentId: validAppointmentId,
     };
 
     mockPaymentRepository.save.mockImplementation(async (payment: Payment) => payment);
@@ -44,7 +114,7 @@ describe('CreatePayment Use Case', () => {
   it('should throw error if amount is 0', async () => {
     const dto = {
       amount: 0,
-      appointmentId: '123e4567-e89b-12d3-a456-426614174001',
+      appointmentId: validAppointmentId,
     };
 
     await expect(createPayment.execute(dto)).rejects.toThrow('Amount must be greater than 0');
@@ -55,7 +125,7 @@ describe('CreatePayment Use Case', () => {
   it('should throw error if amount is negative', async () => {
     const dto = {
       amount: -50,
-      appointmentId: '123e4567-e89b-12d3-a456-426614174001',
+      appointmentId: validAppointmentId,
     };
 
     await expect(createPayment.execute(dto)).rejects.toThrow('Amount must be greater than 0');
@@ -66,7 +136,7 @@ describe('CreatePayment Use Case', () => {
   it('should generate a unique ID for the payment', async () => {
     const dto = {
       amount: 75.00,
-      appointmentId: '123e4567-e89b-12d3-a456-426614174001',
+      appointmentId: validAppointmentId,
     };
 
     mockPaymentRepository.save.mockImplementation(async (payment: Payment) => payment);
@@ -81,7 +151,7 @@ describe('CreatePayment Use Case', () => {
   it('should set createdAt and updatedAt', async () => {
     const dto = {
       amount: 50.00,
-      appointmentId: '123e4567-e89b-12d3-a456-426614174001',
+      appointmentId: validAppointmentId,
     };
 
     mockPaymentRepository.save.mockImplementation(async (payment: Payment) => payment);
@@ -90,5 +160,60 @@ describe('CreatePayment Use Case', () => {
 
     expect(result.createdAt).toBeInstanceOf(Date);
     expect(result.updatedAt).toBeInstanceOf(Date);
+  });
+
+  // Debería lanzar NotFoundError cuando la cita no existe
+  it('should throw NotFoundError when appointment does not exist', async () => {
+    const dto = {
+      amount: 100,
+      appointmentId: validAppointmentId,
+    };
+
+    mockAppointmentRepository.findById.mockResolvedValue(null);
+
+    await expect(createPayment.execute(dto)).rejects.toThrow(NotFoundError);
+    expect(mockPaymentRepository.save).not.toHaveBeenCalled();
+  });
+
+  // Debería lanzar BusinessRuleError cuando la cita está en estado PENDING
+  it('should throw BusinessRuleError when appointment is PENDING', async () => {
+    const dto = {
+      amount: 100,
+      appointmentId: validAppointmentId,
+    };
+
+    mockAppointmentStatusRepository.findById.mockResolvedValue({ id: validStatusId, name: 'PENDING', description: '' } as any);
+
+    await expect(createPayment.execute(dto)).rejects.toThrow(BusinessRuleError);
+    expect(mockPaymentRepository.save).not.toHaveBeenCalled();
+  });
+
+  // Debería lanzar BusinessRuleError cuando la cita está en estado CANCELLED
+  it('should throw BusinessRuleError when appointment is CANCELLED', async () => {
+    const dto = {
+      amount: 100,
+      appointmentId: validAppointmentId,
+    };
+
+    mockAppointmentStatusRepository.findById.mockResolvedValue({ id: validStatusId, name: 'CANCELLED', description: '' } as any);
+
+    await expect(createPayment.execute(dto)).rejects.toThrow(BusinessRuleError);
+    expect(mockPaymentRepository.save).not.toHaveBeenCalled();
+  });
+
+  // Debería permitir crear pago para cita COMPLETED (pago posterior)
+  it('should allow payment for COMPLETED appointment', async () => {
+    const dto = {
+      amount: 100,
+      appointmentId: validAppointmentId,
+    };
+
+    mockAppointmentStatusRepository.findById.mockResolvedValue({ id: validStatusId, name: 'COMPLETED', description: '' } as any);
+    mockPaymentRepository.save.mockImplementation(async (payment: Payment) => payment);
+
+    const result = await createPayment.execute(dto);
+
+    expect(result.amount).toBe(100);
+    expect(mockPaymentRepository.save).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/services/Service.unit.test.ts
+++ b/tests/unit/services/Service.unit.test.ts
@@ -61,6 +61,20 @@ describe('Service Entity', () => {
       }).toThrow(ValidationError);
     });
 
+    // Debería lanzar error si la duración excede el máximo de 480 minutos
+    it('should throw error if duration exceeds 480 minutes', () => {
+      expect(() => {
+        Service.create(
+          validServiceData.categoryId,
+          validServiceData.name,
+          validServiceData.description,
+          481, // excede máximo de 8 horas
+          0,
+          validServiceData.price,
+        );
+      }).toThrow('Service duration is too long (max 8 hours)');
+    });
+
     // Debería lanzar error si la variación de duración excede la duración
     it('should throw error if duration variation exceeds duration', () => {
       expect(() => {


### PR DESCRIPTION
## Contexto

Auditoría de consistencia cruzada entre los 9 documentos de business rules y el código fuente.
Se identificaron 26 issues categorizados en el documento `INTERVENTION_PLAN.md`.
Este PR implementa los 6 fixes de severidad CRÍTICA y ALTA de la Fase 1, más la
unificación de nombres de estados de citas a inglés.

## Cambios

### ISSUE-19 (CRÍTICA) — Entidad Appointment: validación de fecha en constructor
La entidad validaba que la fecha no fuera pasada en el constructor, lo cual
también se ejecutaba en `fromPersistence()`. Esto impedía reconstruir citas
históricas desde la base de datos. Se separó la validación para que solo
aplique en `create()`.

### ISSUE-09 (ALTA) — Duración máxima de Service: 600 → 480 minutos
Un servicio podía tener duración de 600 min pero las citas limitan a 480 min,
creando un escenario imposible. Se alineó el límite de Service con Appointment.

### ISSUE-13 (ALTA) — CreateAppointment: validar isActive del servicio
Se podían crear citas con servicios desactivados. Ahora se verifica `isActive`.

### ISSUE-14 (ALTA) — CreateAppointment: validar que el estilista ofrezca los servicios
No se verificaba que el estilista tuviera asignados los servicios ni que los
estuviera ofreciendo. Se inyectó `IStylistServiceRepository` para validar
existencia de asignación y flag `isOffering`.

### ISSUE-15 (ALTA) — CreateAppointment: validar horario laboral
Se podían crear citas a las 3 AM aunque el horario fuera 9-18. Se agregó
`validateWorkingHours()` que compara inicio y fin de la cita contra el Schedule.

### ISSUE-06 (ALTA) — CreatePayment: validar existencia y estado de cita
Se podían crear pagos para citas inexistentes o canceladas. Ahora se valida
que la cita exista y esté en estado CONFIRMED (prepago) o COMPLETED (pago
posterior). Se inyectaron `IAppointmentRepository` e `IAppointmentStatusRepository`.

### Unificación de nombres de estados de citas a inglés
Los estados de citas en el seed usaban nombres en español (Pendiente, Confirmada,
Completada, Cancelada) mientras que los enums del dominio y los repositorios usaban
inglés (PENDING, CONFIRMED, COMPLETED, CANCELLED). Se unificó todo a inglés:
- `prisma/seed.ts` actualizado
- Tests de integración y E2E actualizados
- Helper `createConfirmedTestAppointment()` agregado para tests de pagos

## Tests
- 10 tests nuevos agregados
- 6 tests de integración/E2E actualizados
- Re-seed de BD necesario tras merge por cambio de nombres de estados
- Todos los tests pasan (1077)