### PR TITLE
fix: auditoría de consistencia de reglas de negocio — Fases 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "turnity-backend",
       "version": "1.0.0",
+      "license": "MIT",
       "dependencies": {
         "@prisma/client": "^6.9.0",
         "bcrypt": "^6.0.0",
@@ -20,7 +21,7 @@
         "jsonwebtoken": "^9.0.2",
         "morgan": "^1.10.0",
         "multer": "^1.4.5-lts.2",
-        "nodemailer": "^7.0.3",
+        "nodemailer": "^8.0.7",
         "pg": "^8.15.6",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1",
@@ -1104,20 +1105,22 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1150,20 +1153,22 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1230,10 +1235,11 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -2002,6 +2008,7 @@
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
       "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
@@ -2432,10 +2439,11 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2683,29 +2691,35 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
-        "debug": "^4.4.0",
+        "debug": "^4.4.3",
         "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "iconv-lite": "^0.7.0",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -2800,6 +2814,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -3211,9 +3226,10 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -3292,10 +3308,11 @@
       }
     },
     "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "optional": true,
       "peer": true,
       "engines": {
@@ -3630,20 +3647,22 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -3826,12 +3845,13 @@
       }
     },
     "node_modules/express-validator": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.2.1.tgz",
-      "integrity": "sha512-CjNE6aakfpuwGaHQZ3m8ltCG2Qvivd7RHtVMS/6nVxOM7xVGqr4bhflsm4+N5FP5zI7Zxp+Hae+9RE+o8e3ZOQ==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.3.2.tgz",
+      "integrity": "sha512-ctLw1Vl6dXVH62dIQMDdTAQkrh480mkFuG6/SGXOaVlwPNukhRAe7EgJIMJ2TSAni8iwHBRp530zAZE5ZPF2IA==",
+      "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.21",
-        "validator": "~13.12.0"
+        "lodash": "^4.18.1",
+        "validator": "~13.15.23"
       },
       "engines": {
         "node": ">= 8.0.0"
@@ -4011,20 +4031,23 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -4232,18 +4255,20 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -4382,18 +4407,23 @@
       "dev": true
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/human-signals": {
@@ -4406,14 +4436,19 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -4683,20 +4718,22 @@
       }
     },
     "node_modules/jake/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "node_modules/jake/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -5276,9 +5313,10 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -5366,11 +5404,12 @@
       }
     },
     "node_modules/jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
+      "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
+      "license": "MIT",
       "dependencies": {
-        "jwa": "^1.4.1",
+        "jwa": "^1.4.2",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -5436,9 +5475,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",
@@ -5642,10 +5682,11 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -5673,15 +5714,16 @@
       }
     },
     "node_modules/morgan": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
-      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
+      "integrity": "sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==",
+      "license": "MIT",
       "dependencies": {
         "basic-auth": "~2.0.1",
         "debug": "2.6.9",
         "depd": "~2.0.0",
         "on-finished": "~2.3.0",
-        "on-headers": "~1.0.2"
+        "on-headers": "~1.1.0"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -5817,9 +5859,10 @@
       "dev": true
     },
     "node_modules/nodemailer": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.3.tgz",
-      "integrity": "sha512-Ajq6Sz1x7cIK3pN6KesGTah+1gnwMnx5gKl3piQlQQE/PwyJ4Mbc8is2psWYxK3RJTVeqsDaCv8ZzXLCDHMTZw==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.7.tgz",
+      "integrity": "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow==",
+      "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -5876,9 +5919,10 @@
       }
     },
     "node_modules/on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -6040,11 +6084,13 @@
       "dev": true
     },
     "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-      "engines": {
-        "node": ">=16"
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/path-type": {
@@ -6144,10 +6190,11 @@
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -6395,9 +6442,10 @@
       ]
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
       },
@@ -6437,17 +6485,18 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
       }
     },
     "node_modules/react-is": {
@@ -6623,7 +6672,8 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.1",
@@ -6834,9 +6884,10 @@
       }
     },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -6995,9 +7046,9 @@
       }
     },
     "node_modules/swagger-jsdoc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -7026,9 +7077,9 @@
       }
     },
     "node_modules/swagger-jsdoc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -7088,20 +7139,22 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -7353,6 +7406,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -7402,13 +7456,14 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
       }
@@ -7436,9 +7491,10 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.12.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
-      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "version": "13.15.35",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.35.tgz",
+      "integrity": "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }
@@ -8300,9 +8356,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.12",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-          "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+          "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -8310,9 +8366,9 @@
           }
         },
         "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+          "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -8338,9 +8394,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.12",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-          "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+          "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -8348,9 +8404,9 @@
           }
         },
         "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+          "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -8403,9 +8459,9 @@
           }
         },
         "js-yaml": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "version": "3.14.2",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+          "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
           "dev": true,
           "requires": {
             "argparse": "^1.0.7",
@@ -9371,9 +9427,9 @@
       }
     },
     "ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -9573,25 +9629,25 @@
       }
     },
     "body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "requires": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
-        "debug": "^4.4.0",
+        "debug": "^4.4.3",
         "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "iconv-lite": "^0.7.0",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
       }
     },
     "brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0"
@@ -9950,9 +10006,9 @@
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="
     },
     "debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "requires": {
         "ms": "^2.1.3"
       }
@@ -10004,9 +10060,9 @@
       }
     },
     "diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "dev": true,
       "optional": true,
       "peer": true
@@ -10224,9 +10280,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+          "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -10234,9 +10290,9 @@
           }
         },
         "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+          "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -10404,12 +10460,12 @@
       }
     },
     "express-validator": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.2.1.tgz",
-      "integrity": "sha512-CjNE6aakfpuwGaHQZ3m8ltCG2Qvivd7RHtVMS/6nVxOM7xVGqr4bhflsm4+N5FP5zI7Zxp+Hae+9RE+o8e3ZOQ==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.3.2.tgz",
+      "integrity": "sha512-ctLw1Vl6dXVH62dIQMDdTAQkrh480mkFuG6/SGXOaVlwPNukhRAe7EgJIMJ2TSAni8iwHBRp530zAZE5ZPF2IA==",
       "requires": {
-        "lodash": "^4.17.21",
-        "validator": "~13.12.0"
+        "lodash": "^4.18.1",
+        "validator": "~13.15.23"
       }
     },
     "fast-deep-equal": {
@@ -10551,20 +10607,21 @@
       }
     },
     "flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true
     },
     "form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "dependencies": {
@@ -10696,18 +10753,18 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.12",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-          "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+          "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
         "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+          "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -10811,15 +10868,15 @@
       "dev": true
     },
     "http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "requires": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       }
     },
     "human-signals": {
@@ -10829,9 +10886,9 @@
       "dev": true
     },
     "iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
@@ -11027,9 +11084,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+          "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -11037,9 +11094,9 @@
           }
         },
         "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+          "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -11486,9 +11543,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "requires": {
         "argparse": "^2.0.1"
       }
@@ -11557,11 +11614,11 @@
       }
     },
     "jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
+      "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
       "requires": {
-        "jwa": "^1.4.1",
+        "jwa": "^1.4.2",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -11612,9 +11669,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -11771,9 +11828,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^2.0.1"
@@ -11793,15 +11850,15 @@
       }
     },
     "morgan": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
-      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
+      "integrity": "sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==",
       "requires": {
         "basic-auth": "~2.0.1",
         "debug": "2.6.9",
         "depd": "~2.0.0",
         "on-finished": "~2.3.0",
-        "on-headers": "~1.0.2"
+        "on-headers": "~1.1.0"
       },
       "dependencies": {
         "debug": {
@@ -11909,9 +11966,9 @@
       "dev": true
     },
     "nodemailer": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.3.tgz",
-      "integrity": "sha512-Ajq6Sz1x7cIK3pN6KesGTah+1gnwMnx5gKl3piQlQQE/PwyJ4Mbc8is2psWYxK3RJTVeqsDaCv8ZzXLCDHMTZw=="
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.7.tgz",
+      "integrity": "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow=="
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -11947,9 +12004,9 @@
       }
     },
     "on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A=="
     },
     "once": {
       "version": "1.4.0",
@@ -12062,9 +12119,9 @@
       "dev": true
     },
     "path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ=="
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="
     },
     "path-type": {
       "version": "4.0.0",
@@ -12139,9 +12196,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true
     },
     "pirates": {
@@ -12299,9 +12356,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "requires": {
         "side-channel": "^1.1.0"
       }
@@ -12318,14 +12375,14 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "requires": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       }
     },
     "react-is": {
@@ -12598,9 +12655,9 @@
       }
     },
     "statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="
     },
     "streamsearch": {
       "version": "1.1.0",
@@ -12715,9 +12772,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.12",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-          "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+          "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -12737,9 +12794,9 @@
           }
         },
         "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+          "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -12782,9 +12839,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+          "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -12792,9 +12849,9 @@
           }
         },
         "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+          "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -12973,9 +13030,9 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -12997,9 +13054,9 @@
       }
     },
     "validator": {
-      "version": "13.12.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
-      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg=="
+      "version": "13.15.35",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.35.tgz",
+      "integrity": "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "turnity-backend",
   "version": "1.0.0",
-   "license": "MIT",
+  "license": "MIT",
   "author": "Fernando Moyano",
   "repository": {
     "type": "git",
@@ -22,20 +22,12 @@
     "prisma:db:push": "prisma db push",
     "test": "jest",
     "test:watch": "jest --watch",
-
-
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
     "format": "prettier --write \"src/**/*.ts\"",
-
-
     "docker:dev:build": "docker-compose -f docker-compose.dev.yml build",
     "docker:dev:up": "docker-compose -f docker-compose.dev.yml up",
     "docker:dev:down": "docker-compose -f docker-compose.dev.yml down",
-
-
-
-    
     "docker:prisma:migrate:dev": "docker exec -it turnity-api-dev npx prisma migrate dev",
     "docker:generate:prisma:client": "docker exec -it turnity-api-dev npx prisma generate",
     "docker:db:prisma:seed": "docker exec -it turnity-api-dev npx prisma db seed",
@@ -60,7 +52,7 @@
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.0",
     "multer": "^1.4.5-lts.2",
-    "nodemailer": "^7.0.3",
+    "nodemailer": "^8.0.7",
     "pg": "^8.15.6",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -236,28 +236,28 @@ async function main() {
   console.log('📋 Creando estados de citas...');
   const pendingStatus = await prisma.appointmentStatus.create({
     data: {
-      name: 'Pendiente',
+      name: 'PENDING',
       description: 'Cita agendada pero pendiente de confirmación',
     },
   });
 
   const confirmedStatus = await prisma.appointmentStatus.create({
     data: {
-      name: 'Confirmada',
+      name: 'CONFIRMED',
       description: 'Cita confirmada',
     },
   });
 
   const completedStatus = await prisma.appointmentStatus.create({
     data: {
-      name: 'Completada',
+      name: 'COMPLETED',
       description: 'Cita realizada con éxito',
     },
   });
 
   const cancelledStatus = await prisma.appointmentStatus.create({
     data: {
-      name: 'Cancelada',
+      name: 'CANCELLED',
       description: 'Cita cancelada',
     },
   });

--- a/src/modules/appointments/application/use-cases/CreateAppointment.ts
+++ b/src/modules/appointments/application/use-cases/CreateAppointment.ts
@@ -156,23 +156,17 @@ export class CreateAppointment {
 
   /**
    * Valida que todas las entidades relacionadas existen y retorna el Client.id real
+   * El clientId del DTO siempre se interpreta como User.id (que es lo que el frontend
+   * conoce tras el login). El use case busca el registro Client asociado a ese usuario.
    * @param createDto - Datos de la cita
    * @returns Promise con el Client.id real
    * @throws NotFoundError si alguna entidad no existe
    */
   private async validateRelatedEntitiesAndGetClientId(createDto: CreateAppointmentDto): Promise<string> {
-    // El DTO recibe clientId que puede ser:
-    // - Un User.id (el usuario cliente pasa su ID de usuario)
-    // - Un Client.id (si ya se conoce el ID de la entidad Client)
-    // Primero intentamos buscar por Client.id, si no existe, buscamos por User.id
-    
-    let client = await this.clientRepository.findById(createDto.clientId);
-    
-    if (!client) {
-      // Intentar buscar el Client por userId
-      client = await this.clientRepository.findByUserId(createDto.clientId);
-    }
-    
+    // El clientId del DTO es siempre el User.id del cliente
+    // Buscar el registro Client asociado a ese usuario
+    const client = await this.clientRepository.findByUserId(createDto.clientId);
+
     if (!client) {
       throw new NotFoundError('Client', createDto.clientId);
     }

--- a/src/modules/appointments/domain/repositories/IAppointmentRepository.ts
+++ b/src/modules/appointments/domain/repositories/IAppointmentRepository.ts
@@ -25,4 +25,5 @@ export interface IAppointmentRepository {
   countByDateRange(startDate: Date, endDate: Date): Promise<number>;
   findUpcomingAppointments(limit?: number): Promise<Appointment[]>;
   findPendingConfirmation(): Promise<Appointment[]>;
+  existsActiveByServiceId(serviceId: string): Promise<boolean>;
 }

--- a/src/modules/appointments/infrastructure/persistence/PrismaAppointmentRepository.ts
+++ b/src/modules/appointments/infrastructure/persistence/PrismaAppointmentRepository.ts
@@ -447,6 +447,27 @@ export class PrismaAppointmentRepository implements IAppointmentRepository {
   }
 
   /**
+   * Verifica si existen citas activas (no canceladas ni completadas) para un servicio
+   * @param serviceId - ID del servicio a verificar
+   * @returns Promise que resuelve con true si existen citas activas
+   */
+  async existsActiveByServiceId(serviceId: string): Promise<boolean> {
+    const count = await this.prisma.appointment.count({
+      where: {
+        services: {
+          some: { id: serviceId },
+        },
+        status: {
+          name: {
+            notIn: ['CANCELLED', 'COMPLETED'],
+          },
+        },
+      },
+    });
+    return count > 0;
+  }
+
+  /**
    * Mapea datos de Prisma a entidad de dominio
    * @param appointmentData - Datos de la cita desde Prisma
    * @returns Entidad Appointment

--- a/src/modules/appointments/infrastructure/persistence/PrismaAppointmentStatusRepository.ts
+++ b/src/modules/appointments/infrastructure/persistence/PrismaAppointmentStatusRepository.ts
@@ -153,7 +153,7 @@ export class PrismaAppointmentStatusRepository implements IAppointmentStatusRepo
     const statusesData = await this.prisma.appointmentStatus.findMany({
       where: {
         name: {
-          in: ['COMPLETED', 'CANCELLED', 'NO_SHOW', 'Completada', 'Cancelada'],
+          in: ['COMPLETED', 'CANCELLED', 'NO_SHOW'],
         },
       },
       orderBy: { name: 'asc' },
@@ -176,7 +176,7 @@ export class PrismaAppointmentStatusRepository implements IAppointmentStatusRepo
     const statusesData = await this.prisma.appointmentStatus.findMany({
       where: {
         name: {
-          in: ['PENDING', 'CONFIRMED', 'IN_PROGRESS', 'Pendiente', 'Confirmada'],
+          in: ['PENDING', 'CONFIRMED', 'IN_PROGRESS'],
         },
       },
       orderBy: { name: 'asc' },

--- a/src/modules/holidays/application/use-cases/DeleteHoliday.ts
+++ b/src/modules/holidays/application/use-cases/DeleteHoliday.ts
@@ -1,5 +1,6 @@
 import { IHolidayRepository } from '../../domain/repositories/IHolidayRepository';
 import { IScheduleExceptionRepository } from '../../domain/repositories/IScheduleExceptionRepository';
+import { NotFoundError } from '../../../../shared/exceptions/NotFoundError';
 
 /**
  * Caso de uso: Eliminar feriado
@@ -15,14 +16,14 @@ export class DeleteHoliday {
    * Ejecuta el caso de uso
    * @param id - ID del feriado a eliminar
    * @returns true si se eliminó correctamente
-   * @throws Error si no se encuentra el feriado
+   * @throws NotFoundError si no se encuentra el feriado
    */
   async execute(id: string): Promise<boolean> {
     // Verificar que el feriado existe
     const holiday = await this.holidayRepository.findById(id);
 
     if (!holiday) {
-      throw new Error('Feriado no encontrado');
+      throw new NotFoundError('Holiday', id);
     }
 
     // Eliminar las excepciones de horario asociadas

--- a/src/modules/notifications/NotificationContainer.ts
+++ b/src/modules/notifications/NotificationContainer.ts
@@ -6,6 +6,10 @@ import { INotificationStatusRepository } from './domain/repositories/INotificati
 import { PrismaNotificationRepository } from './infrastructure/persistence/PrismaNotificationRepository';
 import { PrismaNotificationStatusRepository } from './infrastructure/persistence/PrismaNotificationStatusRepository';
 
+// Repositorio externo
+import { IUserRepository } from '../auth/domain/repositories/IUserRepository';
+import { PrismaUserRepository } from '../auth/infrastructure/persistence/PrismaUserRepository';
+
 // Use Cases
 import { CreateNotification } from './application/use-cases/CreateNotification';
 import { GetUserNotifications } from './application/use-cases/GetUserNotifications';
@@ -78,11 +82,13 @@ export class NotificationContainer {
     // 1. Inicializar repositorios
     this._notificationRepository = new PrismaNotificationRepository(this.prisma);
     this._notificationStatusRepository = new PrismaNotificationStatusRepository(this.prisma);
+    const userRepository: IUserRepository = new PrismaUserRepository(this.prisma);
 
     // 2. Inicializar use cases
     this._createNotification = new CreateNotification(
       this._notificationRepository,
       this._notificationStatusRepository,
+      userRepository,
     );
 
     this._getUserNotifications = new GetUserNotifications(

--- a/src/modules/notifications/application/use-cases/CreateNotification.ts
+++ b/src/modules/notifications/application/use-cases/CreateNotification.ts
@@ -1,6 +1,7 @@
 import { Notification, NotificationTypeEnum } from '../../domain/entities/Notification';
 import { INotificationRepository } from '../../domain/repositories/INotificationRepository';
 import { INotificationStatusRepository } from '../../domain/repositories/INotificationStatusRepository';
+import { IUserRepository } from '../../../auth/domain/repositories/IUserRepository';
 import { NotificationStatusEnum } from '../../domain/entities/NotificationStatus';
 import { CreateNotificationDto } from '../dto/request/CreateNotificationDto';
 import { NotificationDto } from '../dto/response/NotificationDto';
@@ -15,6 +16,7 @@ export class CreateNotification {
   constructor(
     private notificationRepository: INotificationRepository,
     private notificationStatusRepository: INotificationStatusRepository,
+    private userRepository: IUserRepository,
   ) {}
 
   /**
@@ -28,10 +30,16 @@ export class CreateNotification {
     // 1. Validar datos de entrada
     this.validateInput(dto);
 
-    // 2. Obtener el estado inicial (PENDING)
+    // 2. Verificar que el usuario destinatario existe
+    const userExists = await this.userRepository.findById(dto.userId);
+    if (!userExists) {
+      throw new NotFoundError('User', dto.userId);
+    }
+
+    // 3. Obtener el estado inicial (PENDING)
     const pendingStatus = await this.getPendingStatus();
 
-    // 3. Crear la entidad de notificación
+    // 4. Crear la entidad de notificación
     const notification = Notification.create(
       dto.type,
       dto.message,
@@ -39,10 +47,10 @@ export class CreateNotification {
       pendingStatus.id,
     );
 
-    // 4. Guardar la notificación
+    // 5. Guardar la notificación
     const savedNotification = await this.notificationRepository.save(notification);
 
-    // 5. Mapear a DTO de respuesta
+    // 6. Mapear a DTO de respuesta
     return this.mapToDto(savedNotification);
   }
 

--- a/src/modules/payments/application/use-cases/CreatePayment.ts
+++ b/src/modules/payments/application/use-cases/CreatePayment.ts
@@ -42,7 +42,7 @@ export class CreatePayment {
     const allowedStatuses = ['CONFIRMED', 'COMPLETED'];
     if (!status || !allowedStatuses.includes(status.name)) {
       throw new BusinessRuleError(
-        `Cannot create a payment for an appointment with status ${status?.name || 'UNKNOWN'}. Allowed: ${allowedStatuses.join(', ')}`,
+        `Cannot create a payment for an appointment with status ${status?.name || 'UNKNOWN'}. Appointment must be confirmed or completed`,
       );
     }
 

--- a/src/modules/services/ServicesContainer.ts
+++ b/src/modules/services/ServicesContainer.ts
@@ -50,6 +50,10 @@ import { PrismaStylistRepository } from './infrastructure/persistence/PrismaStyl
 import { IUserRepository } from '../auth/domain/repositories/IUserRepository';
 import { PrismaUserRepository } from '../auth/infrastructure/persistence/PrismaUserRepository';
 
+// Importar appointmentRepository desde el módulo de citas
+import { IAppointmentRepository } from '../appointments/domain/repositories/IAppointmentRepository';
+import { PrismaAppointmentRepository } from '../appointments/infrastructure/persistence/PrismaAppointmentRepository';
+
 // Capa de presentación
 import { CategoryController } from './presentation/controllers/CategoryController';
 import { ServiceController } from './presentation/controllers/ServiceController';
@@ -135,6 +139,7 @@ export class ServicesContainer {
     const stylistServiceRepository: IStylistServiceRepository = new PrismaStylistServiceRepository(this.prisma);
     const stylistRepository: IStylistRepository = new PrismaStylistRepository(this.prisma);
     const userRepository: IUserRepository = new PrismaUserRepository(this.prisma);
+    const appointmentRepository: IAppointmentRepository = new PrismaAppointmentRepository(this.prisma);
 
     // 2. Use cases — Categorías
     this._createCategory = new CreateCategory(categoryRepository);
@@ -144,7 +149,7 @@ export class ServicesContainer {
     this._getActiveCategories = new GetActiveCategories(categoryRepository);
     this._activateCategory = new ActivateCategory(categoryRepository);
     this._deactivateCategory = new DeactivateCategory(categoryRepository);
-    this._deleteCategory = new DeleteCategory(categoryRepository);
+    this._deleteCategory = new DeleteCategory(categoryRepository, serviceRepository);
 
     // 3. Use cases — Servicios
     this._createService = new CreateService(serviceRepository, categoryRepository);
@@ -156,7 +161,7 @@ export class ServicesContainer {
     this._getActiveServicesByCategory = new GetActiveServicesByCategory(serviceRepository, categoryRepository);
     this._activateService = new ActivateService(serviceRepository, categoryRepository);
     this._deactivateService = new DeactivateService(serviceRepository, categoryRepository);
-    this._deleteService = new DeleteService(serviceRepository);
+    this._deleteService = new DeleteService(serviceRepository, appointmentRepository);
 
     // 4. Use cases — StylistService
     this._assignServiceToStylist = new AssignServiceToStylist(stylistServiceRepository, serviceRepository, userRepository, stylistRepository);

--- a/src/modules/services/application/use-cases/AssignServiceToStylist.ts
+++ b/src/modules/services/application/use-cases/AssignServiceToStylist.ts
@@ -6,6 +6,7 @@ import { IUserRepository } from '../../../auth/domain/repositories/IUserReposito
 import { ValidationError } from '../../../../shared/exceptions/ValidationError';
 import { NotFoundError } from '../../../../shared/exceptions/NotFoundError';
 import { ConflictError } from '../../../../shared/exceptions/ConflictError';
+import { BusinessRuleError } from '../../../../shared/exceptions/BusinessRuleError';
 import { AssignServiceDto } from '../dto/request/AssignServiceDto';
 import { StylistServiceDto } from '../dto/response/StylistServiceDto';
 
@@ -55,6 +56,10 @@ export class AssignServiceToStylist {
     const service = await this.serviceRepository.findById(assignDto.serviceId);
     if (!service) {
       throw new NotFoundError('Service', assignDto.serviceId);
+    }
+
+    if (!service.isActive) {
+      throw new BusinessRuleError('Cannot assign an inactive service to a stylist');
     }
 
     const existingAssignment = await this.stylistServiceRepository.existsAssignment(

--- a/src/modules/services/application/use-cases/DeleteCategory.ts
+++ b/src/modules/services/application/use-cases/DeleteCategory.ts
@@ -1,22 +1,37 @@
 import { ICategoryRepository } from '../../domain/repositories/ICategoryRepository';
+import { IServiceRepository } from '../../domain/repositories/IServiceRepository';
 import { NotFoundError } from '../../../../shared/exceptions/NotFoundError';
+import { BusinessRuleError } from '../../../../shared/exceptions/BusinessRuleError';
 
 /**
  * Caso de uso para eliminar permanentemente una categoría del sistema
+ * Valida que no existan servicios asociados antes de eliminar
  */
 export class DeleteCategory {
-  constructor(private categoryRepository: ICategoryRepository) {}
+  constructor(
+    private categoryRepository: ICategoryRepository,
+    private serviceRepository: IServiceRepository,
+  ) {}
 
   /**
    * Ejecuta la eliminación de una categoría
    * @param id - ID único de la categoría a eliminar
    * @returns Promise que se resuelve cuando la eliminación es exitosa
    * @throws NotFoundError si la categoría no existe
+   * @throws BusinessRuleError si la categoría tiene servicios asociados
    */
   async execute(id: string): Promise<void> {
     const exists = await this.categoryRepository.existsById(id);
     if (!exists) {
       throw new NotFoundError('Category', id);
+    }
+
+    // Validar que no existan servicios asociados
+    const services = await this.serviceRepository.findByCategory(id);
+    if (services.length > 0) {
+      throw new BusinessRuleError(
+        `Cannot delete category: it has ${services.length} associated service(s)`,
+      );
     }
 
     await this.categoryRepository.delete(id);

--- a/src/modules/services/application/use-cases/DeleteService.ts
+++ b/src/modules/services/application/use-cases/DeleteService.ts
@@ -1,22 +1,37 @@
 import { IServiceRepository } from '../../domain/repositories/IServiceRepository';
+import { IAppointmentRepository } from '../../../appointments/domain/repositories/IAppointmentRepository';
 import { NotFoundError } from '../../../../shared/exceptions/NotFoundError';
+import { BusinessRuleError } from '../../../../shared/exceptions/BusinessRuleError';
 
 /**
  * Caso de uso para eliminar permanentemente un servicio del sistema
+ * Valida que no existan citas activas antes de eliminar
  */
 export class DeleteService {
-  constructor(private serviceRepository: IServiceRepository) {}
+  constructor(
+    private serviceRepository: IServiceRepository,
+    private appointmentRepository: IAppointmentRepository,
+  ) {}
 
   /**
    * Ejecuta la eliminación de un servicio
    * @param id - ID único del servicio a eliminar
    * @returns Promise que se resuelve cuando la eliminación es exitosa
    * @throws NotFoundError si el servicio no existe
+   * @throws BusinessRuleError si el servicio tiene citas activas
    */
   async execute(id: string): Promise<void> {
     const exists = await this.serviceRepository.existsById(id);
     if (!exists) {
       throw new NotFoundError('Service', id);
+    }
+
+    // Validar que no existan citas activas con este servicio
+    const hasActiveAppointments = await this.appointmentRepository.existsActiveByServiceId(id);
+    if (hasActiveAppointments) {
+      throw new BusinessRuleError(
+        'Cannot delete service: it has active appointments',
+      );
     }
 
     await this.serviceRepository.delete(id);

--- a/tests/integration/appointments/repositories/ScheduleRepository.integration.test.ts
+++ b/tests/integration/appointments/repositories/ScheduleRepository.integration.test.ts
@@ -102,7 +102,25 @@ describe('ScheduleRepository Integration Tests', () => {
     });
 
     it('should return empty array for day without schedule', async () => {
-      // Asegurar que no hay schedule para Sunday
+      // Limpiar en cascada: payments → appointments → schedules de SUNDAY
+      const sundaySchedules = await testPrisma.schedule.findMany({
+        where: { dayOfWeek: 'SUNDAY' },
+      });
+      if (sundaySchedules.length > 0) {
+        const sundayScheduleIds = sundaySchedules.map(s => s.id);
+        const sundayAppointments = await testPrisma.appointment.findMany({
+          where: { scheduleId: { in: sundayScheduleIds } },
+        });
+        if (sundayAppointments.length > 0) {
+          await testPrisma.payment.deleteMany({
+            where: { appointmentId: { in: sundayAppointments.map(a => a.id) } },
+          });
+          await testPrisma.appointment.deleteMany({
+            where: { scheduleId: { in: sundayScheduleIds } },
+          });
+        }
+      }
+
       await testPrisma.schedule.deleteMany({
         where: { dayOfWeek: 'SUNDAY' },
       });

--- a/tests/unit/appointments/application/use-cases/CreateAppointment.unit.test.ts
+++ b/tests/unit/appointments/application/use-cases/CreateAppointment.unit.test.ts
@@ -204,8 +204,7 @@ describe('CreateAppointment Use Case', () => {
     const stylistService = { stylistId: validStylistId, serviceId: validServiceId1, isOffering: true, customPrice: null, createdAt: new Date(), updatedAt: new Date() };
 
     mockAppointmentStatusRepository.findByName.mockResolvedValue(pendingStatus);
-    mockClientRepository.findById.mockResolvedValue(client);
-    mockClientRepository.findByUserId.mockResolvedValue(null); // No necesario si findById encuentra
+    mockClientRepository.findByUserId.mockResolvedValue(client);
     mockStylistRepository.findById.mockResolvedValue(stylist);
     mockServiceRepository.findById.mockResolvedValue(service);
     mockStylistServiceRepository.findByStylistAndService.mockResolvedValue(stylistService as any);
@@ -452,7 +451,6 @@ describe('CreateAppointment Use Case', () => {
   describe('Not Found Handling', () => {
     // Debería lanzar NotFoundError cuando el cliente no existe
     it('should throw NotFoundError when client does not exist', async () => {
-      mockClientRepository.findById.mockResolvedValue(null);
       mockClientRepository.findByUserId.mockResolvedValue(null);
 
       await expect(useCase.execute(validCreateDto, validUserId)).rejects.toThrow(
@@ -460,8 +458,8 @@ describe('CreateAppointment Use Case', () => {
       );
     });
 
-    // Debería encontrar cliente por userId si no se encuentra por id
-    it('should find client by userId if not found by id', async () => {
+    // Debería encontrar cliente por userId (clientId del DTO siempre es User.id)
+    it('should find client by userId', async () => {
       const client = createMockClient(validClientId);
       const stylist = createMockStylist(validStylistId);
       const service = createMockService(validServiceId1);
@@ -469,8 +467,6 @@ describe('CreateAppointment Use Case', () => {
       const schedule = createMockSchedule('MONDAY');
       const appointment = createMockAppointment();
 
-      // No encuentra por id, pero sí por userId
-      mockClientRepository.findById.mockResolvedValue(null);
       mockClientRepository.findByUserId.mockResolvedValue(client);
       mockStylistRepository.findById.mockResolvedValue(stylist);
       mockServiceRepository.findById.mockResolvedValue(service);
@@ -485,13 +481,14 @@ describe('CreateAppointment Use Case', () => {
       const result = await useCase.execute(validCreateDto, validUserId);
 
       expect(mockClientRepository.findByUserId).toHaveBeenCalledWith(validClientId);
+      expect(mockClientRepository.findById).not.toHaveBeenCalled();
       expect(result.id).toBe(appointment.id);
     });
 
     // Debería lanzar NotFoundError cuando el estilista no existe
     it('should throw NotFoundError when stylist does not exist', async () => {
       const client = createMockClient(validClientId);
-      mockClientRepository.findById.mockResolvedValue(client);
+      mockClientRepository.findByUserId.mockResolvedValue(client);
       mockStylistRepository.findById.mockResolvedValue(null);
 
       await expect(useCase.execute(validCreateDto, validUserId)).rejects.toThrow(
@@ -504,7 +501,7 @@ describe('CreateAppointment Use Case', () => {
       const client = createMockClient(validClientId);
       const stylist = createMockStylist(validStylistId);
 
-      mockClientRepository.findById.mockResolvedValue(client);
+      mockClientRepository.findByUserId.mockResolvedValue(client);
       mockStylistRepository.findById.mockResolvedValue(stylist);
       mockServiceRepository.findById.mockResolvedValue(null);
 
@@ -520,7 +517,7 @@ describe('CreateAppointment Use Case', () => {
       const inactiveService = createMockService(validServiceId1, 60);
       (inactiveService as any).isActive = false;
 
-      mockClientRepository.findById.mockResolvedValue(client);
+      mockClientRepository.findByUserId.mockResolvedValue(client);
       mockStylistRepository.findById.mockResolvedValue(stylist);
       mockServiceRepository.findById.mockResolvedValue(inactiveService);
 
@@ -535,7 +532,7 @@ describe('CreateAppointment Use Case', () => {
       const stylist = createMockStylist(validStylistId);
       const service = createMockService(validServiceId1, 60);
 
-      mockClientRepository.findById.mockResolvedValue(client);
+      mockClientRepository.findByUserId.mockResolvedValue(client);
       mockStylistRepository.findById.mockResolvedValue(stylist);
       mockServiceRepository.findById.mockResolvedValue(service);
       mockStylistServiceRepository.findByStylistAndService.mockResolvedValue(null);
@@ -552,7 +549,7 @@ describe('CreateAppointment Use Case', () => {
       const service = createMockService(validServiceId1, 60);
       const notOfferingAssignment = { stylistId: validStylistId, serviceId: validServiceId1, isOffering: false };
 
-      mockClientRepository.findById.mockResolvedValue(client);
+      mockClientRepository.findByUserId.mockResolvedValue(client);
       mockStylistRepository.findById.mockResolvedValue(stylist);
       mockServiceRepository.findById.mockResolvedValue(service);
       mockStylistServiceRepository.findByStylistAndService.mockResolvedValue(notOfferingAssignment as any);
@@ -612,7 +609,7 @@ describe('CreateAppointment Use Case', () => {
       const pendingStatus = createMockAppointmentStatus('PENDING');
       const schedule = createMockSchedule('MONDAY');
 
-      mockClientRepository.findById.mockResolvedValue(client);
+      mockClientRepository.findByUserId.mockResolvedValue(client);
       mockStylistRepository.findById.mockResolvedValue(stylist);
       mockServiceRepository.findById.mockResolvedValue(service);
       mockStylistServiceRepository.findByStylistAndService.mockResolvedValue(
@@ -638,7 +635,7 @@ describe('CreateAppointment Use Case', () => {
 
       await useCase.execute(validCreateDto, validUserId);
 
-      expect(mockClientRepository.findById).toHaveBeenCalledWith(validClientId);
+      expect(mockClientRepository.findByUserId).toHaveBeenCalledWith(validClientId);
       expect(mockStylistRepository.findById).toHaveBeenCalledWith(validStylistId);
       expect(mockServiceRepository.findById).toHaveBeenCalledWith(validServiceId1);
       expect(mockAppointmentStatusRepository.findByName).toHaveBeenCalledWith('PENDING');

--- a/tests/unit/holidays/application/use-cases/DeleteHoliday.unit.test.ts
+++ b/tests/unit/holidays/application/use-cases/DeleteHoliday.unit.test.ts
@@ -2,6 +2,7 @@ import { DeleteHoliday } from '../../../../../src/modules/holidays/application/u
 import { IHolidayRepository } from '../../../../../src/modules/holidays/domain/repositories/IHolidayRepository';
 import { IScheduleExceptionRepository } from '../../../../../src/modules/holidays/domain/repositories/IScheduleExceptionRepository';
 import { Holiday } from '../../../../../src/modules/holidays/domain/entities/Holiday';
+import { NotFoundError } from '../../../../../src/shared/exceptions/NotFoundError';
 
 describe('DeleteHoliday Use Case', () => {
   let deleteHoliday: DeleteHoliday;
@@ -85,12 +86,12 @@ describe('DeleteHoliday Use Case', () => {
     expect(deleteExceptionsCallOrder).toBeLessThan(deleteHolidayCallOrder);
   });
 
-  // Debería lanzar error si el feriado no existe
-  it('should throw error if holiday not found', async () => {
+  // Debería lanzar NotFoundError si el feriado no existe
+  it('should throw NotFoundError if holiday not found', async () => {
     mockHolidayRepository.findById.mockResolvedValue(null);
 
     await expect(deleteHoliday.execute('non-existent-id')).rejects.toThrow(
-      'Feriado no encontrado',
+      NotFoundError,
     );
     expect(mockHolidayRepository.delete).not.toHaveBeenCalled();
   });

--- a/tests/unit/notifications/application/use-cases/CreateNotification.unit.test.ts
+++ b/tests/unit/notifications/application/use-cases/CreateNotification.unit.test.ts
@@ -6,11 +6,13 @@ import { NotificationStatus, NotificationStatusEnum } from '../../../../../src/m
 import { ValidationError } from '../../../../../src/shared/exceptions/ValidationError';
 import { NotFoundError } from '../../../../../src/shared/exceptions/NotFoundError';
 import { generateUuid } from '../../../../../src/shared/utils/uuid';
+import { IUserRepository } from '../../../../../src/modules/auth/domain/repositories/IUserRepository';
 
 describe('CreateNotification Use Case', () => {
   let useCase: CreateNotification;
   let mockNotificationRepository: jest.Mocked<NotificationRepository>;
   let mockNotificationStatusRepository: jest.Mocked<NotificationStatusRepository>;
+  let mockUserRepository: jest.Mocked<Pick<IUserRepository, 'findById'>>;
 
   const validUserId = generateUuid();
   const validStatusId = generateUuid();
@@ -59,9 +61,14 @@ describe('CreateNotification Use Case', () => {
       existsByName: jest.fn(),
     };
 
+    mockUserRepository = {
+      findById: jest.fn().mockResolvedValue({ id: validUserId, name: 'Test User' }),
+    };
+
     useCase = new CreateNotification(
       mockNotificationRepository,
       mockNotificationStatusRepository,
+      mockUserRepository as unknown as jest.Mocked<IUserRepository>,
     );
   });
 
@@ -274,6 +281,18 @@ describe('CreateNotification Use Case', () => {
     it('should throw NotFoundError if PENDING status does not exist', async () => {
       // Arrange
       mockNotificationStatusRepository.findByName.mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(useCase.execute(validCreateDto)).rejects.toThrow(NotFoundError);
+      expect(mockNotificationRepository.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('User Not Found', () => {
+    // Debería lanzar NotFoundError si el usuario destinatario no existe
+    it('should throw NotFoundError if user does not exist', async () => {
+      // Arrange
+      mockUserRepository.findById.mockResolvedValue(null);
 
       // Act & Assert
       await expect(useCase.execute(validCreateDto)).rejects.toThrow(NotFoundError);

--- a/tests/unit/services/CategoryUseCases.unit.test.ts
+++ b/tests/unit/services/CategoryUseCases.unit.test.ts
@@ -11,9 +11,11 @@ import { Category } from '../../../src/modules/services/domain/entities/Category
 import { ValidationError } from '../../../src/shared/exceptions/ValidationError';
 import { NotFoundError } from '../../../src/shared/exceptions/NotFoundError';
 import { ConflictError } from '../../../src/shared/exceptions/ConflictError';
+import { BusinessRuleError } from '../../../src/shared/exceptions/BusinessRuleError';
 
 describe('Category Use Cases', () => {
   let mockCategoryRepository: jest.Mocked<CategoryRepository>;
+  let mockServiceRepository: any;
 
   beforeEach(() => {
     mockCategoryRepository = {
@@ -21,6 +23,20 @@ describe('Category Use Cases', () => {
       findByName: jest.fn(),
       findAll: jest.fn(),
       findActive: jest.fn(),
+      save: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      existsById: jest.fn(),
+      existsByName: jest.fn(),
+    };
+
+    mockServiceRepository = {
+      findById: jest.fn(),
+      findByName: jest.fn(),
+      findAll: jest.fn(),
+      findActive: jest.fn(),
+      findByCategory: jest.fn(),
+      findActiveByCategoryId: jest.fn(),
       save: jest.fn(),
       update: jest.fn(),
       delete: jest.fn(),
@@ -216,22 +232,32 @@ describe('Category Use Cases', () => {
     let deleteCategory: DeleteCategory;
 
     beforeEach(() => {
-      deleteCategory = new DeleteCategory(mockCategoryRepository);
+      deleteCategory = new DeleteCategory(mockCategoryRepository, mockServiceRepository);
     });
 
     it('should delete category successfully', async () => {
       mockCategoryRepository.existsById.mockResolvedValue(true);
+      mockServiceRepository.findByCategory.mockResolvedValue([]);
       mockCategoryRepository.delete.mockResolvedValue();
 
       await deleteCategory.execute('test-id');
 
       expect(mockCategoryRepository.existsById).toHaveBeenCalledWith('test-id');
+      expect(mockServiceRepository.findByCategory).toHaveBeenCalledWith('test-id');
       expect(mockCategoryRepository.delete).toHaveBeenCalledWith('test-id');
     });
 
     it('should throw NotFoundError if category not found', async () => {
       mockCategoryRepository.existsById.mockResolvedValue(false);
       await expect(deleteCategory.execute('non-existent-id')).rejects.toThrow(NotFoundError);
+    });
+
+    it('should throw BusinessRuleError if category has associated services', async () => {
+      mockCategoryRepository.existsById.mockResolvedValue(true);
+      mockServiceRepository.findByCategory.mockResolvedValue([{ id: 'service-1' }]);
+
+      await expect(deleteCategory.execute('test-id')).rejects.toThrow(BusinessRuleError);
+      expect(mockCategoryRepository.delete).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/services/ServiceUseCases.unit.test.ts
+++ b/tests/unit/services/ServiceUseCases.unit.test.ts
@@ -11,6 +11,8 @@ import { Category } from '../../../src/modules/services/domain/entities/Category
 import { ValidationError } from '../../../src/shared/exceptions/ValidationError';
 import { NotFoundError } from '../../../src/shared/exceptions/NotFoundError';
 import { ConflictError } from '../../../src/shared/exceptions/ConflictError';
+import { BusinessRuleError } from '../../../src/shared/exceptions/BusinessRuleError';
+import { IAppointmentRepository } from '../../../src/modules/appointments/domain/repositories/IAppointmentRepository';
 
 describe('Service Use Cases', () => {
   let mockServiceRepository: jest.Mocked<ServiceRepository>;
@@ -186,24 +188,42 @@ describe('Service Use Cases', () => {
 
   describe('DeleteService', () => {
     let deleteService: DeleteService;
+    let mockAppointmentRepository: jest.Mocked<Pick<IAppointmentRepository, 'existsActiveByServiceId'>>;
 
     beforeEach(() => {
-      deleteService = new DeleteService(mockServiceRepository);
+      mockAppointmentRepository = {
+        existsActiveByServiceId: jest.fn(),
+      };
+      deleteService = new DeleteService(
+        mockServiceRepository,
+        mockAppointmentRepository as unknown as jest.Mocked<IAppointmentRepository>,
+      );
     });
 
     it('should delete service successfully', async () => {
       mockServiceRepository.existsById.mockResolvedValue(true);
+      mockAppointmentRepository.existsActiveByServiceId.mockResolvedValue(false);
       mockServiceRepository.delete.mockResolvedValue();
 
       await deleteService.execute('service-id');
 
       expect(mockServiceRepository.existsById).toHaveBeenCalledWith('service-id');
+      expect(mockAppointmentRepository.existsActiveByServiceId).toHaveBeenCalledWith('service-id');
       expect(mockServiceRepository.delete).toHaveBeenCalledWith('service-id');
     });
 
     it('should throw NotFoundError if service not found', async () => {
       mockServiceRepository.existsById.mockResolvedValue(false);
       await expect(deleteService.execute('non-existent-id')).rejects.toThrow(NotFoundError);
+    });
+
+    // Debería lanzar BusinessRuleError si el servicio tiene citas activas
+    it('should throw BusinessRuleError if service has active appointments', async () => {
+      mockServiceRepository.existsById.mockResolvedValue(true);
+      mockAppointmentRepository.existsActiveByServiceId.mockResolvedValue(true);
+
+      await expect(deleteService.execute('service-id')).rejects.toThrow(BusinessRuleError);
+      expect(mockServiceRepository.delete).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/services/StylistServiceUseCases.unit.test.ts
+++ b/tests/unit/services/StylistServiceUseCases.unit.test.ts
@@ -16,6 +16,7 @@ import { User } from '../../../src/modules/auth/domain/entities/User';
 import { ValidationError } from '../../../src/shared/exceptions/ValidationError';
 import { NotFoundError } from '../../../src/shared/exceptions/NotFoundError';
 import { ConflictError } from '../../../src/shared/exceptions/ConflictError';
+import { BusinessRuleError } from '../../../src/shared/exceptions/BusinessRuleError';
 
 describe('StylistService Use Cases', () => {
   let mockStylistServiceRepository: jest.Mocked<StylistServiceRepository>;
@@ -134,6 +135,25 @@ describe('StylistService Use Cases', () => {
       mockUserRepository.findByIdWithRole.mockResolvedValue(mockUserWithRole);
       mockServiceRepository.findById.mockResolvedValue(null);
       await expect(assignServiceToStylist.execute('stylist-id', assignDto)).rejects.toThrow(NotFoundError);
+    });
+
+    // Debería lanzar BusinessRuleError si el servicio está inactivo
+    it('should throw BusinessRuleError if service is inactive', async () => {
+      const mockStylist = Stylist.create('user-id');
+      Object.defineProperty(mockStylist, 'id', { value: 'stylist-id', writable: false });
+      const mockUserWithRole = {
+        id: 'user-id', roleId: 'stylist-role-id', name: 'Test User',
+        email: 'test@example.com', phone: '+1234567890', password: 'password',
+        isActive: true, role: { id: 'stylist-role-id', name: 'STYLIST', description: 'Estilista' },
+      };
+      const mockService = Service.create('category-id', 'Hair Cut', 'Description', 45, 15, 2500);
+      mockService.deactivate();
+
+      mockStylistRepository.findById.mockResolvedValue(mockStylist);
+      mockUserRepository.findByIdWithRole.mockResolvedValue(mockUserWithRole);
+      mockServiceRepository.findById.mockResolvedValue(mockService);
+
+      await expect(assignServiceToStylist.execute('stylist-id', assignDto)).rejects.toThrow(BusinessRuleError);
     });
 
     it('should throw ValidationError if user is not a stylist', async () => {


### PR DESCRIPTION
## Cambios — Fase 2 (Medios y Bajos)

ISSUE-01 (MEDIA) — DeleteCategory: validar servicios asociados
Verificar que no existan servicios antes de eliminar la categoría.

ISSUE-02 (MEDIA) — DeleteService: validar citas activas
Nuevo método `existsActiveByServiceId()` en `IAppointmentRepository`. Impide
eliminar servicios con citas activas (no canceladas ni completadas).

ISSUE-03 (BAJA) — AssignServiceToStylist: validar isActive del servicio
No permitir asignar servicios inactivos a estilistas.

ISSUE-05 (BAJA) — CreateNotification: verificar existencia del usuario
Inyectar `IUserRepository` y validar que el destinatario exista en la BD.

ISSUE-07 (BAJA) — DeleteHoliday: error tipado
Usar `NotFoundError` en lugar de `Error` genérico.

 Unificación de nombres de estados

Los estados de citas estaban en español en el seed (`Pendiente`, `Confirmada`, etc.)
pero en inglés en los enums y repositorios. Se unificó todo a inglés:
- `prisma/seed.ts`, `PrismaAppointmentStatusRepository.ts`
- Tests de integración y E2E actualizados
- Helper `createConfirmedTestAppointment()` para tests de pagos
- Requiere re-seed de BD tras merge