### PR TITLE
docs(business-rules): actualizar los 9 módulos a v2.2 

### DIFF
--- a/src/docs/business-rules/01-auth.md
+++ b/src/docs/business-rules/01-auth.md
@@ -1,6 +1,6 @@
 # Autenticación y Usuarios - Reglas de Negocio
 
-> Última actualización: 2026-06-12 | Versión: 2.2
+> Última actualización: 2026-06-16 | Versión: 2.2
 
 ---
 
@@ -152,3 +152,12 @@ El `AuthMiddleware` protege las rutas que requieren autenticación. Expone dos m
 - **Appointments**: El `userId` se usa para identificar quién crea las citas
 - **Notifications**: Las notificaciones se envían a usuarios específicos
 - **Payments**: Los pagos están asociados a citas de usuarios
+- **Stylists**: Los usuarios con rol STYLIST tienen un perfil Stylist asociado automáticamente
+
+---
+
+## 9. Limitaciones Conocidas
+
+| ID | Descripción |
+|----|-------------|
+| ISSUE-17 | La desactivación de un usuario (`isActive = false`) no tiene efecto cascada sobre sus entidades asociadas. Si el usuario es un estilista, sus asignaciones de servicios (StylistService) permanecen activas, sus citas pendientes/confirmadas siguen vigentes, y sigue apareciendo en consultas de estilistas por servicio. Se recomienda cancelar manualmente las citas pendientes y desactivar las asignaciones antes de desactivar un estilista |

--- a/src/docs/business-rules/02-categories.md
+++ b/src/docs/business-rules/02-categories.md
@@ -1,6 +1,6 @@
 # Categorías - Reglas de Negocio
 
-> Última actualización: 2026-06-12 | Versión: 2.1
+> Última actualización: 2026-06-16 | Versión: 2.2
 
 ---
 
@@ -71,6 +71,8 @@ Las categorías agrupan los servicios ofrecidos por el salón (ej: "Cortes", "Co
 |-------|-------------|
 | Servicios asociados | Al desactivar una categoría, sus servicios siguen activos |
 | Filtrado | Las categorías inactivas no aparecen en listados públicos |
+
+> **Decisión de diseño (ISSUE-18):** Los servicios de una categoría inactiva permanecen accesibles individualmente (por ID, búsqueda, listado general). Solo la navegación por categoría se ve afectada. La desactivación de una categoría no tiene efecto cascada sobre el estado `isActive` de sus servicios.
 
 ---
 

--- a/src/docs/business-rules/03-services.md
+++ b/src/docs/business-rules/03-services.md
@@ -1,6 +1,6 @@
 # Servicios - Reglas de Negocio
 
-> Última actualización: 2026-06-12 | Versión: 2.1
+> Última actualización: 2026-06-15 | Versión: 2.2
 
 ---
 
@@ -19,7 +19,7 @@ Los servicios representan los tratamientos y procedimientos ofrecidos por el sal
 | id | UUID | Identificador único |
 | name | string | Nombre del servicio (requerido, máx 150 caracteres) |
 | description | string | Descripción detallada (requerido, máx 1000 caracteres) |
-| duration | number | Duración en minutos (1-600) |
+| duration | number | Duración en minutos (1-480) |
 | durationVariation | number | Variación permitida en minutos (≥ 0, no excede duration) |
 | price | number | Precio en centavos (≥ 0) |
 | isActive | boolean | Estado activo/inactivo (default: true) |
@@ -53,7 +53,7 @@ Los servicios representan los tratamientos y procedimientos ofrecidos por el sal
 | Nombre requerido | No puede estar vacío, máximo 150 caracteres, se trimea al guardar |
 | Nombre único | No pueden existir dos servicios con el mismo nombre |
 | Descripción requerida | Obligatoria, máximo 1000 caracteres, se trimea al guardar |
-| Duración válida | Debe ser mayor a 0 minutos, máximo 600 minutos (10 horas) |
+| Duración válida | Debe ser mayor a 0 minutos, máximo 480 minutos (8 horas) |
 | Variación de duración | No puede ser negativa, no puede exceder la duración base |
 | Precio válido | No puede ser negativo (≥ 0). Se almacena en centavos (el sanitizer convierte automáticamente) |
 | Categoría válida | El `categoryId` debe existir |
@@ -64,7 +64,7 @@ Los servicios representan los tratamientos y procedimientos ofrecidos por el sal
 | Regla | Valor |
 |-------|-------|
 | Duración mínima | 1 minuto |
-| Duración máxima | 600 minutos (10 horas) |
+| Duración máxima | 480 minutos (8 horas). Alineado con el máximo de duración de citas en el módulo Appointments |
 | Variación | Permite ajustar ± minutos según estilista. No puede ser negativa ni exceder la duración base |
 
 ### 4.3 Actualización
@@ -81,8 +81,16 @@ Los servicios representan los tratamientos y procedimientos ofrecidos por el sal
 
 | Regla | Descripción |
 |-------|-------------|
-| Sin citas activas | No eliminar servicios con citas pendientes |
+| Sin citas activas | No se puede eliminar un servicio que tenga citas en estado no terminal (PENDING, CONFIRMED). El use case `DeleteService` valida esto consultando `IAppointmentRepository.existsActiveByServiceId()` y lanza `BusinessRuleError` si existen |
 | Alternativa | Se recomienda desactivar en lugar de eliminar |
+
+### 4.5 Asignación a Estilistas (Stylist-Service)
+
+| Regla | Descripción |
+|-------|-------------|
+| Servicio activo requerido | Solo se pueden asignar servicios con `isActive = true`. `AssignServiceToStylist` valida el estado del servicio y lanza `BusinessRuleError` si está inactivo |
+| Estilista válido | El estilista debe existir en el sistema |
+| Asignación única | No se puede asignar el mismo servicio al mismo estilista más de una vez |
 
 ---
 
@@ -117,6 +125,7 @@ Los servicios representan los tratamientos y procedimientos ofrecidos por el sal
 
 ## 7. Relaciones con Otros Módulos
 
-- **Categories**: Cada servicio pertenece a una categoría
-- **Stylist-Service**: Los estilistas asignan servicios que ofrecen
-- **Appointments**: Las citas incluyen uno o más servicios
+- **Categories**: Cada servicio pertenece a una categoría. La eliminación de una categoría requiere que no tenga servicios asociados
+- **Stylist-Service**: Los estilistas asignan servicios que ofrecen. Solo se pueden asignar servicios activos
+- **Appointments**: Las citas incluyen uno o más servicios. La eliminación de un servicio requiere que no tenga citas activas. `CreateAppointment` valida que los servicios estén activos y que el estilista los ofrezca
+- **Payments**: Los precios de servicios se almacenan en **centavos** (conversión automática vía sanitizer). Los montos de pagos en el módulo Payments se expresan en la **unidad monetaria base** (ej: pesos, dólares). La conversión es responsabilidad del consumidor de la API

--- a/src/docs/business-rules/04-stylists.md
+++ b/src/docs/business-rules/04-stylists.md
@@ -1,6 +1,6 @@
 # Estilistas y Asignación de Servicios - Reglas de Negocio
 
-> Última actualización: 2026-06-12 | Versión: 2.1
+> Última actualización: 2026-06-16 | Versión: 2.2
 
 ---
 
@@ -142,6 +142,14 @@ Todos los endpoints están bajo el prefijo `/api/v1/services`.
 ## 7. Relaciones con Otros Módulos
 
 - **Auth**: Cada estilista tiene un User con rol STYLIST
-- **Services**: Los estilistas asignan servicios que ofrecen
-- **Appointments**: Las citas se asignan a estilistas específicos
+- **Services**: Los estilistas asignan servicios que ofrecen. Solo se pueden asignar servicios activos (`isActive = true`)
+- **Appointments**: Las citas se asignan a estilistas específicos. `CreateAppointment` valida que el estilista ofrezca los servicios seleccionados (`isOffering = true`)
 - **Schedules**: Cada estilista puede tener su propio horario
+
+---
+
+## 8. Limitaciones Conocidas
+
+| ID | Descripción |
+|----|-------------|
+| ISSUE-17 | La desactivación de un usuario con rol STYLIST (`isActive = false`) no tiene efecto cascada sobre las entidades del estilista. Sus asignaciones StylistService permanecen activas, sus citas pendientes/confirmadas siguen vigentes, y sigue apareciendo en consultas de estilistas por servicio. Se recomienda cancelar manualmente las citas pendientes y desactivar las asignaciones antes de desactivar un estilista |

--- a/src/docs/business-rules/05-schedules.md
+++ b/src/docs/business-rules/05-schedules.md
@@ -1,6 +1,6 @@
 # Horarios - Reglas de Negocio
 
-> Última actualización: 2026-06-12 | Versión: 2.1
+> Última actualización: 2026-06-15 | Versión: 2.2
 
 ---
 
@@ -88,6 +88,8 @@ Los horarios definen los días y horas de operación del salón. Cada día de la
 8. Retornar respuesta con slots y metadata
 ```
 
+> **Limitación conocida (ISSUE-12):** Actualmente, `GetAvailableSlots` solo consulta el `Schedule` regular por día de la semana. No consulta feriados (`IHolidayRepository`) ni excepciones de horario (`IScheduleExceptionRepository`). La lógica de prioridad `ScheduleException > Holiday > Schedule regular` está planificada como feature futura. Del mismo modo, `CreateAppointment` no valida contra feriados ni excepciones al crear una cita.
+
 ### 4.3 Detección de Conflictos
 
 | Regla | Descripción |
@@ -140,5 +142,5 @@ La entidad Schedule no tiene endpoints propios. Se accede a través del módulo 
 
 ## 7. Relaciones con Otros Módulos
 
-- **Appointments**: Los horarios determinan cuándo se pueden crear citas. GetAvailableSlots es el endpoint público.
-- **Holidays**: Los feriados pueden vincular horarios especiales via `holidayId`. Las ScheduleExceptions modifican días específicos.
+- **Appointments**: Los horarios determinan cuándo se pueden crear citas. `GetAvailableSlots` es el endpoint público. `CreateAppointment` valida que la hora de la cita caiga dentro del horario laboral del día (`startTime`-`endTime`)
+- **Holidays**: Los feriados pueden vincular horarios especiales via `holidayId`. Las ScheduleExceptions modifican días específicos. **Nota:** La integración entre feriados/excepciones y disponibilidad de citas está diferida como feature futura (ver ISSUE-12 en INTERVENTION_PLAN.md)

--- a/src/docs/business-rules/06-appointments.md
+++ b/src/docs/business-rules/06-appointments.md
@@ -1,6 +1,6 @@
 # Citas (Appointments) - Reglas de Negocio
 
-> Última actualización: 2026-06-12 | Versión: 2.1
+> Última actualización: 2026-06-15 | Versión: 2.2
 
 ---
 
@@ -56,18 +56,36 @@ Entidad completa con métodos de negocio, no solo un enum.
 
 ---
 
-## 3. Permisos por Rol
+## 3. Permisos
 
-| Acción | ADMIN | STYLIST | CLIENT | Público |
-|--------|-------|---------|--------|---------|
-| Ver slots disponibles | ✅ | ✅ | ✅ | ✅ |
-| Crear cita | ✅ | ✅ | ✅ | ❌ |
-| Ver cita por ID | ✅ | ✅ | ✅ | ❌ |
-| Actualizar cita | ✅ | ✅ | ✅ | ❌ |
-| Confirmar cita | ✅ | ✅ | ❌ | ❌ |
-| Cancelar cita | ✅ | ✅ | ✅ | ❌ |
-| Ver citas por cliente | ✅ | ✅ | ✅ | ❌ |
-| Ver citas por estilista | ✅ | ✅ | ❌ | ❌ |
+El modelo de permisos de este módulo es **ownership-based** (basado en participación), no role-based. Las acciones de mutación dependen de la relación del usuario con la cita, no de su rol.
+
+### 3.1 Acciones públicas
+
+| Acción | Acceso |
+|--------|--------|
+| Ver slots disponibles | Público (sin autenticación) |
+
+### 3.2 Acciones de consulta
+
+Todas las rutas de consulta requieren solo `authenticate` (sin `authorize`). Cualquier usuario autenticado puede acceder, independientemente de su rol.
+
+| Acción | ADMIN | STYLIST | CLIENT |
+|--------|-------|---------|--------|
+| Ver cita por ID | ✅ | ✅ | ✅ |
+| Ver citas por cliente | ✅ | ✅ | ✅ |
+| Ver citas por estilista | ✅ | ✅ | ✅ |
+
+### 3.3 Acciones de mutación (ownership-based)
+
+| Acción | ¿Quién puede? | Validación en código |
+|--------|--------------|---------------------|
+| Crear cita | Cualquier autenticado | Solo `authenticate` |
+| Confirmar cita | El creador (`userId`) o el estilista asignado (`stylistId`) | `ConfirmAppointment` valida participación |
+| Cancelar cita | El creador (`userId`), cliente (`clientId`), o estilista (`stylistId`) | `CancelAppointment` valida participación |
+| Actualizar cita | Cualquier autenticado | Solo `authenticate` |
+
+> **Nota:** No existe actualmente un override de ADMIN que permita confirmar/cancelar cualquier cita. Los permisos son estrictamente por participación en la cita.
 
 ---
 
@@ -77,12 +95,15 @@ Entidad completa con métodos de negocio, no solo un enum.
 
 | Regla | Descripción |
 |-------|-------------|
-| Fecha futura | No se pueden crear citas en el pasado |
+| Fecha futura | No se pueden crear citas en el pasado (validación solo en `create()`, no en `fromPersistence()`) |
 | Límite futuro | Máximo 6 meses de anticipación |
 | Servicio requerido | Al menos un `serviceId` debe proporcionarse |
-| Cliente válido | El `clientId` debe existir en la tabla Client |
+| Servicios activos | Todos los servicios deben tener `isActive = true`. Se lanza `BusinessRuleError` si algún servicio está inactivo |
+| Estilista ofrece servicios | Si se especifica `stylistId`, el estilista debe tener asignado cada servicio (`IStylistServiceRepository.findByStylistAndService`) y estar ofreciéndolo (`isOffering = true`) |
+| Cliente válido | El `clientId` del DTO es siempre el `User.id` (el ID que el frontend conoce tras login). El use case busca el Client vía `findByUserId()` y lanza `NotFoundError` si no existe |
 | Estilista válido | Si se especifica, el `stylistId` debe existir |
 | Día laboral | Debe existir un Schedule configurado para el día de la semana |
+| Horario laboral | La hora de la cita debe caer dentro del rango `startTime`-`endTime` del Schedule. La cita completa (inicio + duración) debe terminar antes de `endTime` |
 | Sin conflictos | No debe haber citas superpuestas en el mismo horario (validado por `findConflictingAppointments`) |
 | Estado inicial | Se crea con estado PENDING |
 | Duración auto-calculada | Si no se proporciona `duration`, se calcula sumando la duración de los servicios seleccionados (mínimo 15 min) |
@@ -110,6 +131,8 @@ Entidad completa con métodos de negocio, no solo un enum.
 | Registro | Se guarda `confirmedAt` con la fecha de confirmación |
 | Notas | Opcionales, máximo 500 caracteres |
 
+> **Limitación conocida (ISSUE-16):** El campo `notes` de confirmación es aceptado y validado por la API pero no se persiste actualmente. La entidad Appointment no tiene campo para almacenar esta información. Será almacenado en una futura iteración.
+
 ### 4.4 Cancelación de Citas
 
 | Regla | Descripción |
@@ -122,6 +145,8 @@ Entidad completa con métodos de negocio, no solo un enum.
 | Transición válida | Validada vía `canTransitionTo()` |
 | Razón opcional | Se puede incluir motivo de cancelación (máx 500 caracteres) |
 | Tipo de cancelación | `cancelledBy` validado contra valores: `client`, `stylist`, `admin`, `system` |
+
+> **Limitación conocida (ISSUE-16):** Los campos `reason` y `cancelledBy` de cancelación son aceptados y validados por la API pero no se persisten actualmente. La entidad Appointment no tiene campos para almacenar esta información. Serán almacenados en una futura iteración.
 
 ### 4.5 Modificación de Citas
 
@@ -207,11 +232,21 @@ NO_SHOW (No Se Presentó)
 
 ## 9. Relaciones con Otros Módulos
 
-- **Auth**: El `userId` identifica quién creó la cita
-- **Clients**: Cada cita está asociada a un cliente (`clientId`)
-- **Stylists**: Las citas pueden asignarse a estilistas (`stylistId`)
-- **Services**: Las citas incluyen uno o más servicios (`serviceIds`)
-- **Schedules**: Determina disponibilidad de horarios y vincula la cita a un horario (`scheduleId`)
-- **Holidays**: Los feriados afectan la disponibilidad
-- **Payments**: Las citas pueden tener pagos asociados
+- **Auth**: El `userId` identifica quién creó la cita. El `clientId` del DTO es siempre el `User.id`
+- **Clients**: Cada cita está asociada a un cliente (`clientId`). El use case resuelve el Client vía `findByUserId()`
+- **Stylists**: Las citas pueden asignarse a estilistas (`stylistId`). Se valida que el estilista ofrezca los servicios seleccionados (`isOffering = true`)
+- **Services**: Las citas incluyen uno o más servicios (`serviceIds`). Se valida que estén activos (`isActive = true`)
+- **Schedules**: Determina disponibilidad de horarios y vincula la cita a un horario (`scheduleId`). Se valida que la cita caiga dentro del horario laboral
+- **Holidays**: Los feriados deberían afectar la disponibilidad, pero la integración está diferida (ver ISSUE-12 en INTERVENTION_PLAN.md)
+- **Payments**: Las citas pueden tener pagos asociados. Solo se permiten pagos para citas en estado CONFIRMED o COMPLETED
 - **Notifications**: Se envían notificaciones sobre citas
+
+---
+
+## 10. Limitaciones Conocidas
+
+| ID | Descripción |
+|----|-------------|
+| ISSUE-12 | `GetAvailableSlots` y `CreateAppointment` no consultan feriados ni excepciones de horario. La lógica de prioridad `ScheduleException > Holiday > Schedule regular` está planificada como feature futura |
+| ISSUE-16 | Los campos `reason`, `cancelledBy` (cancelación) y `notes` (confirmación) son validados por la API pero no se persisten. Las entidades no tienen campos para esta información |
+| ISSUE-20 | No existe un límite de citas por cliente por día. La protección contra abuso depende de la validación de conflictos de horario |

--- a/src/docs/business-rules/07-notifications.md
+++ b/src/docs/business-rules/07-notifications.md
@@ -1,6 +1,6 @@
 # Notificaciones - Reglas de Negocio
 
-> Última actualización: 2026-06-12 | Versión: 2.1
+> Última actualización: 2026-06-15 | Versión: 2.2
 
 ---
 
@@ -82,7 +82,7 @@ Entidad completa con métodos de negocio, no solo un enum.
 | Regla | Descripción |
 |-------|-------------|
 | Solo Admin | Solo administradores pueden crear notificaciones |
-| userId requerido | Debe ser un UUID válido (formato validado, existencia del usuario no verificada) |
+| userId requerido | Debe ser un UUID válido. `CreateNotification` verifica que el usuario exista en la BD vía `IUserRepository.findById()` y lanza `NotFoundError` si no existe |
 | Tipo válido | Debe ser uno de los valores del `NotificationTypeEnum` |
 | Mensaje requerido | No puede estar vacío, máximo 1000 caracteres |
 | Estado inicial | Se crea con estado PENDING |
@@ -152,6 +152,8 @@ FAILED (Fallida)
 | type | string | Filtrar por tipo de notificación (valor del enum) |
 | unreadOnly | boolean | Solo notificaciones no leídas (filtra por statusId ≠ READ) |
 
+> **Nota (ISSUE-26):** El default de `limit` es 20, sin máximo documentado explícitamente. Otros módulos como Holidays usan 10 por menor volumen esperado.
+
 ---
 
 ## 8. Códigos de Error
@@ -167,5 +169,5 @@ FAILED (Fallida)
 
 ## 9. Relaciones con Otros Módulos
 
-- **Auth**: Las notificaciones se envían a usuarios específicos (`userId`)
+- **Auth**: Las notificaciones se envían a usuarios específicos (`userId`). Se verifica que el usuario exista antes de crear la notificación
 - **Appointments**: Notificaciones de confirmación, recordatorio y cancelación

--- a/src/docs/business-rules/08-payments.md
+++ b/src/docs/business-rules/08-payments.md
@@ -1,6 +1,6 @@
 # Pagos - Reglas de Negocio
 
-> Última actualización: 2026-06-12 | Versión: 2.1
+> Última actualización: 2026-06-15 | Versión: 2.2
 
 ---
 
@@ -70,10 +70,12 @@ El módulo de pagos gestiona el procesamiento de cobros asociados a las citas. S
 |-------|-------------|-------------|
 | Monto requerido | El campo `amount` es obligatorio | 400 |
 | Monto positivo | El monto debe ser mayor a 0 | 400 |
-| Cita válida | El `appointmentId` debe ser UUID válido (formato validado, existencia no verificada) | 400 |
+| Cita válida | El `appointmentId` debe ser UUID válido. `CreatePayment` verifica que la cita exista vía `IAppointmentRepository.findById()` y lanza `NotFoundError` si no existe | 400/404 |
+| Estado de cita permitido | Solo se pueden crear pagos para citas en estado **CONFIRMED** o **COMPLETED**. CONFIRMED = prepago, COMPLETED = pago posterior. Se lanza `BusinessRuleError` para otros estados | 422 |
 | UUID válido | Los IDs deben tener formato UUID | 400 |
 | Estado inicial | Los pagos se crean con estado PENDING | - |
 | Método nulo | El método de pago es null hasta procesarse | - |
+| Múltiples pagos | Se permiten múltiples pagos por cita (pagos parciales, split payments). No hay validación de unicidad | - |
 
 ### 4.2 Procesamiento de Pagos
 
@@ -93,6 +95,8 @@ El módulo de pagos gestiona el procesamiento de cobros asociados a las citas. S
 | Razón | La API acepta `reason` opcional (máx 500 chars) pero no se almacena en la entidad | - |
 | Estado final | El estado cambia a REFUNDED | - |
 | Solo Admin | Solo administradores pueden reembolsar | 403 |
+
+> **Limitación conocida (ISSUE-16):** El campo `reason` de reembolso es aceptado y validado por la API pero no se persiste actualmente. La entidad Payment no tiene campo para almacenar esta información. Será almacenado en una futura iteración.
 
 ### 4.4 Cancelación de Pagos
 
@@ -158,6 +162,8 @@ FAILED (Cancelado/Fallido)
 | startDate | date | Fecha inicio del rango |
 | endDate | date | Fecha fin del rango |
 
+> **Nota (ISSUE-26):** El default de `limit` es 20 con máximo 100. Consistente con Notifications (20). Holidays usa 10 por menor volumen esperado.
+
 ---
 
 ## 8. Estadísticas de Pagos
@@ -191,4 +197,24 @@ FAILED (Cancelado/Fallido)
 
 ## 10. Relaciones con Otros Módulos
 
-- **Appointments**: Cada pago está asociado a una cita
+- **Appointments**: Cada pago está asociado a una cita. Se verifica existencia y estado de la cita al crear el pago. Solo se permiten pagos para citas CONFIRMED (prepago) o COMPLETED (pago posterior)
+- **Services**: Los precios de servicios se almacenan en **centavos**. El `amount` del pago se expresa en la **unidad monetaria base** (ej: pesos, dólares), NO en centavos. La conversión es responsabilidad del consumidor de la API
+
+---
+
+## 11. Decisiones de Diseño
+
+| Decisión | Descripción |
+|----------|-------------|
+| Monto independiente (ISSUE-08, ISSUE-24) | El `amount` del pago es definido por el operador (Admin o Stylist) y no se valida automáticamente contra los precios de los servicios de la cita. Esto permite flexibilidad para descuentos, propinas, pagos parciales y ajustes manuales |
+| Unidad monetaria (ISSUE-08) | El `amount` se expresa en la unidad monetaria base (ej: pesos), a diferencia de los precios de servicios que se almacenan en centavos. La conversión es responsabilidad del consumidor de la API |
+| Múltiples pagos por cita | Se permiten múltiples pagos para la misma cita sin restricción de unicidad, permitiendo pagos parciales y split payments |
+| Estados permitidos | Solo CONFIRMED y COMPLETED permiten pagos: CONFIRMED = prepago antes del servicio, COMPLETED = cobro posterior al servicio |
+
+---
+
+## 12. Limitaciones Conocidas
+
+| ID | Descripción |
+|----|-------------|
+| ISSUE-16 | El campo `reason` de reembolso es validado por la API pero no se persiste. La entidad Payment no tiene campo para almacenar esta información |

--- a/src/docs/business-rules/09-holidays.md
+++ b/src/docs/business-rules/09-holidays.md
@@ -1,6 +1,6 @@
 # Feriados y Excepciones de Horario - Reglas de Negocio
 
-> Última actualización: 2026-06-12 | Versión: 2.1
+> Última actualización: 2026-06-16 | Versión: 2.2
 
 ---
 
@@ -62,14 +62,17 @@ El módulo de feriados gestiona los días especiales donde el salón puede tener
 |-------|-------------|
 | Nombre requerido | No puede estar vacío, máximo 100 caracteres, se trimea al guardar |
 | Fecha requerida | La fecha debe estar en formato ISO 8601 (YYYY-MM-DD) |
+| Fechas pasadas permitidas | Se permite crear feriados para fechas pasadas para mantener un registro histórico. Las propiedades computadas `isPast`, `isToday` y `isFuture` permiten filtrar según necesidad |
 | Unicidad de fecha | No pueden existir dos feriados en la misma fecha |
 | Descripción opcional | Puede ser null o string, máximo 500 caracteres, se trimea al guardar |
+| Sin efecto en citas | Crear un feriado no afecta las citas existentes para esa fecha (ver Limitaciones Conocidas) |
 
 ### 4.2 Creación de Excepciones
 
 | Regla | Descripción |
 |-------|-------------|
 | Fecha requerida | La fecha debe estar en formato ISO 8601 |
+| Fechas pasadas permitidas | Se permite crear excepciones para fechas pasadas para mantener un registro histórico |
 | Horarios requeridos | startTimeException y endTimeException en formato HH:MM |
 | Formato de hora válido | Regex `^([01]?[0-9]|2[0-3]):[0-5][0-9]$` |
 | Hora fin > hora inicio | La hora de fin debe ser posterior a la hora de inicio |
@@ -91,6 +94,15 @@ El módulo de feriados gestiona los días especiales donde el salón puede tener
 |-------|-------------|
 | Cascada | Al eliminar un feriado, se eliminan sus excepciones asociadas |
 | Irreversible | La eliminación es permanente |
+
+### 4.5 Feriados sin Excepción de Horario
+
+| Regla | Descripción |
+|-------|-------------|
+| Día cerrado por defecto | Un feriado sin excepción de horario asociada se interpreta como día cerrado (sin disponibilidad) |
+| Horario especial | Si el salón opera en un feriado con horario especial, se debe crear una `ScheduleException` vinculada al feriado |
+
+> **Nota (ISSUE-22):** Esta regla define la intención de diseño. Actualmente no tiene efecto en runtime porque la integración holidays↔appointments no está implementada (ISSUE-12).
 
 ---
 
@@ -173,6 +185,8 @@ El módulo de feriados gestiona los días especiales donde el salón puede tener
 | holidayId | UUID | Filtrar por feriado asociado |
 | reason | string | Filtrar por razón (búsqueda parcial) |
 
+> **Nota (ISSUE-26):** El default de `limit` es 10 tanto para Holidays como para ScheduleExceptions, por menor volumen esperado de datos. Otros módulos como Payments y Notifications usan 20.
+
 ---
 
 ## 8. Códigos de Error
@@ -189,15 +203,24 @@ El módulo de feriados gestiona los días especiales donde el salón puede tener
 
 ## 9. Relaciones con Otros Módulos
 
-### Con Appointments
+- **Appointments**: Los feriados y excepciones de horario deberían afectar la disponibilidad de citas. El sistema de disponibilidad debería consultar `CheckIsHoliday` antes de ofrecer slots. Las excepciones de horario modifican los horarios regulares para fechas específicas. **Nota:** Esta integración está diferida como feature futura (ver ISSUE-12 en INTERVENTION_PLAN.md)
+- **Schedules**: Las excepciones de horario (`ScheduleException`) actúan como modificadores temporales de los `Schedule` regulares. En una fecha con excepción, el horario de la excepción prevalece sobre el horario regular
 
-Los feriados y excepciones de horario afectan la disponibilidad de citas:
+---
 
-- El sistema de disponibilidad debería consultar `CheckIsHoliday` antes de ofrecer slots
-- Las excepciones de horario modifican los horarios regulares para fechas específicas
-- Esta integración debe implementarse en el módulo de Appointments
+## 10. Decisiones de Diseño
 
-### Con Schedules
+| Decisión | Descripción |
+|----------|-------------|
+| Fechas pasadas permitidas (ISSUE-23) | Se permite crear feriados y excepciones para fechas pasadas para mantener un registro histórico. Las propiedades computadas `isPast`, `isToday` y `isFuture` permiten filtrar según necesidad |
+| Feriado sin excepción = cerrado (ISSUE-22) | Un feriado sin excepción de horario asociada se interpreta como día cerrado. Si el salón opera ese día, se debe crear una ScheduleException vinculada |
 
-- Las excepciones de horario (`ScheduleException`) actúan como modificadores temporales de los `Schedule` regulares
-- En una fecha con excepción, el horario de la excepción prevalece sobre el horario regular
+---
+
+## 11. Limitaciones Conocidas
+
+| ID | Descripción |
+|----|-------------|
+| ISSUE-12 | `GetAvailableSlots` y `CreateAppointment` no consultan feriados ni excepciones de horario. La lógica de prioridad `ScheduleException > Holiday > Schedule regular` está planificada como feature futura |
+| ISSUE-21 | Crear un feriado no afecta las citas existentes para esa fecha. La notificación y/o cancelación automática de citas afectadas se implementará en una futura iteración, una vez que la integración holidays↔appointments esté completa (depende de ISSUE-12) |
+| ISSUE-23 | No hay validación que impida crear feriados o excepciones para fechas pasadas. Es intencional para mantener registro histórico |


### PR DESCRIPTION
- 01-auth: agregar limitación ISSUE-17 (desactivación sin cascada)
- 02-categories: documentar decisión de diseño ISSUE-18 (categoría inactiva)
- 03-services: duración máx 480 min, validaciones en Delete y Assign, nota centavos
- 04-stylists: agregar limitación ISSUE-17, enriquecer relaciones
- 05-schedules: documentar limitación ISSUE-12, validación horario laboral
- 06-appointments: modelo ownership-based, validaciones nuevas, limitaciones conocidas
- 07-notifications: validación de usuario, nota paginación ISSUE-26
- 08-payments: validación cita/estado, decisiones de diseño, limitaciones
- 09-holidays: ISSUE-21 (diferido), ISSUE-22, ISSUE-23, ISSUE-26