### PR TITLE
feat(auth): implementar desactivación de usuario con cascada para estilistas (ISSUE-17)

### DIFF
--- a/src/modules/auth/AuthContainer.ts
+++ b/src/modules/auth/AuthContainer.ts
@@ -8,10 +8,19 @@ import { RefreshToken } from './application/use-cases/RefreshToken';
 import { GetUserProfile } from './application/use-cases/GetUserProfile';
 import { UpdateUserProfile } from './application/use-cases/UpdateUserProfile';
 import { ChangeUserPassword } from './application/use-cases/ChangeUserPassword';
+import { DeactivateUser } from './application/use-cases/DeactivateUser';
 import { PrismaUserRepository } from './infrastructure/persistence/PrismaUserRepository';
 import { PrismaRoleRepository } from './infrastructure/persistence/PrismaRolRepository';
+import { PrismaStylistRepository } from '../services/infrastructure/persistence/PrismaStylistRepository';
+import { PrismaStylistServiceRepository } from '../services/infrastructure/persistence/PrismaStylistServiceRepository';
+import { PrismaAppointmentRepository } from '../appointments/infrastructure/persistence/PrismaAppointmentRepository';
+import { PrismaAppointmentStatusRepository } from '../appointments/infrastructure/persistence/PrismaAppointmentStatusRepository';
 import { IUserRepository } from './domain/repositories/IUserRepository';
 import { IRoleRepository } from './domain/repositories/IRoleRepository';
+import { IStylistRepository } from '../services/domain/repositories/IStylistRepository';
+import { IStylistServiceRepository } from '../services/domain/repositories/IStylistServiceRepository';
+import { IAppointmentRepository } from '../appointments/domain/repositories/IAppointmentRepository';
+import { IAppointmentStatusRepository } from '../appointments/domain/repositories/IAppointmentStatusRepository';
 import { BcryptHashService } from './infrastructure/services/BcryptHashService';
 import { JwtTokenService } from './infrastructure/services/JwtTokenService';
 import { JwtService } from './application/services/JwtService';
@@ -35,6 +44,7 @@ export class AuthContainer {
   private _getUserProfile: GetUserProfile;
   private _updateUserProfile: UpdateUserProfile;
   private _changeUserPassword: ChangeUserPassword;
+  private _deactivateUser: DeactivateUser;
 
   /**
    * Constructor privado que inicializa todas las dependencias del módulo
@@ -64,9 +74,15 @@ export class AuthContainer {
    * @description Inyecta dependencias siguiendo el orden: repositories -> services -> use cases -> controllers
    */
   private setupDependencies(): void {
-    // Repositories
+    // Repositories - Auth
     const userRepository: IUserRepository = new PrismaUserRepository(this.prisma);
     const roleRepository: IRoleRepository = new PrismaRoleRepository(this.prisma);
+
+    // Repositories - Cross-module (para cascada en desactivación)
+    const stylistRepository: IStylistRepository = new PrismaStylistRepository(this.prisma);
+    const stylistServiceRepository: IStylistServiceRepository = new PrismaStylistServiceRepository(this.prisma);
+    const appointmentRepository: IAppointmentRepository = new PrismaAppointmentRepository(this.prisma);
+    const appointmentStatusRepository: IAppointmentStatusRepository = new PrismaAppointmentStatusRepository(this.prisma);
 
     // Services
     const hashService: HashService = new BcryptHashService();
@@ -79,6 +95,14 @@ export class AuthContainer {
     this._getUserProfile = new GetUserProfile(userRepository, roleRepository);
     this._updateUserProfile = new UpdateUserProfile(userRepository, roleRepository);
     this._changeUserPassword = new ChangeUserPassword(userRepository, hashService);
+    this._deactivateUser = new DeactivateUser(
+      userRepository,
+      roleRepository,
+      stylistRepository,
+      stylistServiceRepository,
+      appointmentRepository,
+      appointmentStatusRepository,
+    );
 
     // HTTP Layer - Inyectamos los casos de uso directamente
     this._authController = new AuthController(
@@ -88,6 +112,7 @@ export class AuthContainer {
       this._getUserProfile,
       this._updateUserProfile,
       this._changeUserPassword,
+      this._deactivateUser,
     );
 
     this._authMiddleware = new AuthMiddleware(jwtService);

--- a/src/modules/auth/application/dto/response/DeactivateUserResponseDto.ts
+++ b/src/modules/auth/application/dto/response/DeactivateUserResponseDto.ts
@@ -1,0 +1,21 @@
+/**
+ * DTO de respuesta para la desactivación de un usuario
+ * Incluye resumen de las acciones en cascada realizadas
+ */
+export interface DeactivateUserResponseDto {
+  /** ID del usuario desactivado */
+  userId: string;
+  /** Email del usuario desactivado */
+  email: string;
+  /** Nombre del usuario desactivado */
+  name: string;
+  /** Indica si se ejecutaron acciones en cascada (solo STYLIST) */
+  cascadeApplied: boolean;
+  /** Resumen de las acciones en cascada ejecutadas */
+  cascadeSummary?: {
+    /** Cantidad de citas canceladas automáticamente */
+    appointmentsCancelled: number;
+    /** Cantidad de asignaciones StylistService desactivadas */
+    servicesDeactivated: number;
+  };
+}

--- a/src/modules/auth/application/use-cases/DeactivateUser.ts
+++ b/src/modules/auth/application/use-cases/DeactivateUser.ts
@@ -1,0 +1,188 @@
+import { IUserRepository } from '../../domain/repositories/IUserRepository';
+import { IRoleRepository } from '../../domain/repositories/IRoleRepository';
+import { IStylistRepository } from '../../../services/domain/repositories/IStylistRepository';
+import { IStylistServiceRepository } from '../../../services/domain/repositories/IStylistServiceRepository';
+import { IAppointmentRepository } from '../../../appointments/domain/repositories/IAppointmentRepository';
+import { IAppointmentStatusRepository } from '../../../appointments/domain/repositories/IAppointmentStatusRepository';
+import { AppointmentStatusEnum } from '../../../appointments/domain/entities/AppointmentStatus';
+import { DeactivateUserResponseDto } from '../dto/response/DeactivateUserResponseDto';
+import { NotFoundError } from '../../../../shared/exceptions/NotFoundError';
+import { BusinessRuleError } from '../../../../shared/exceptions/BusinessRuleError';
+import { ValidationError } from '../../../../shared/exceptions/ValidationError';
+
+/**
+ * Caso de uso para desactivar un usuario del sistema
+ * Si el usuario es STYLIST, ejecuta acciones en cascada:
+ * - Cancela citas activas (PENDING/CONFIRMED) con razón "Stylist deactivated"
+ * - Desactiva asignaciones StylistService (isOffering = false)
+ */
+export class DeactivateUser {
+  constructor(
+    private userRepository: IUserRepository,
+    private roleRepository: IRoleRepository,
+    private stylistRepository: IStylistRepository,
+    private stylistServiceRepository: IStylistServiceRepository,
+    private appointmentRepository: IAppointmentRepository,
+    private appointmentStatusRepository: IAppointmentStatusRepository,
+  ) {}
+
+  /**
+   * Ejecuta la desactivación del usuario con cascada si es STYLIST
+   * @param userId - ID del usuario a desactivar
+   * @returns Resumen de la desactivación y acciones en cascada
+   * @throws ValidationError si el ID no es válido
+   * @throws NotFoundError si el usuario no existe
+   * @throws BusinessRuleError si el usuario ya está inactivo
+   */
+  async execute(userId: string): Promise<DeactivateUserResponseDto> {
+    // 1. Validar entrada
+    this.validateInput(userId);
+
+    // 2. Buscar usuario
+    const user = await this.userRepository.findById(userId);
+    if (!user) {
+      throw new NotFoundError('User', userId);
+    }
+
+    // 3. Verificar que el usuario está activo
+    if (!user.isActive) {
+      throw new BusinessRuleError('User is already deactivated');
+    }
+
+    // 4. Obtener el rol del usuario
+    const role = await this.roleRepository.findById(user.roleId);
+    if (!role) {
+      throw new NotFoundError('Role', user.roleId);
+    }
+
+    // 5. Desactivar usuario
+    user.deactivate();
+    await this.userRepository.update(user);
+
+    // 6. Ejecutar cascada si es STYLIST
+    let cascadeSummary: { appointmentsCancelled: number; servicesDeactivated: number } | undefined;
+
+    if (role.name === 'STYLIST') {
+      cascadeSummary = await this.executeStylistCascade(userId);
+    }
+
+    // 7. Retornar resumen
+    return {
+      userId: user.id,
+      email: user.email,
+      name: user.name,
+      cascadeApplied: role.name === 'STYLIST',
+      cascadeSummary,
+    };
+  }
+
+  /**
+   * Valida los datos de entrada
+   * @param userId - ID del usuario a validar
+   * @throws ValidationError si el ID no es válido
+   */
+  private validateInput(userId: string): void {
+    if (!userId || userId.trim().length === 0) {
+      throw new ValidationError('User ID is required');
+    }
+
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+    if (!uuidRegex.test(userId)) {
+      throw new ValidationError('User ID must be a valid UUID');
+    }
+  }
+
+  /**
+   * Ejecuta las acciones en cascada para un estilista desactivado
+   * - Cancela citas activas (PENDING/CONFIRMED)
+   * - Desactiva asignaciones StylistService
+   * @param userId - ID del usuario estilista
+   * @returns Resumen con conteo de citas canceladas y servicios desactivados
+   */
+  private async executeStylistCascade(
+    userId: string,
+  ): Promise<{ appointmentsCancelled: number; servicesDeactivated: number }> {
+    // Buscar estilista por userId
+    const stylist = await this.stylistRepository.findByUserId(userId);
+    if (!stylist) {
+      // El usuario tiene rol STYLIST pero no tiene registro en la tabla Stylist
+      // No hay cascada que ejecutar
+      return { appointmentsCancelled: 0, servicesDeactivated: 0 };
+    }
+
+    // Ejecutar ambas cascadas
+    const [appointmentsCancelled, servicesDeactivated] = await Promise.all([
+      this.cancelActiveAppointments(stylist.id),
+      this.deactivateStylistServices(stylist.id),
+    ]);
+
+    return { appointmentsCancelled, servicesDeactivated };
+  }
+
+  /**
+   * Cancela todas las citas activas (PENDING/CONFIRMED) del estilista
+   * @param stylistId - ID del estilista
+   * @returns Cantidad de citas canceladas
+   */
+  private async cancelActiveAppointments(stylistId: string): Promise<number> {
+    // Obtener el estado CANCELLED
+    const cancelledStatus = await this.appointmentStatusRepository.findByName(
+      AppointmentStatusEnum.CANCELLED,
+    );
+    if (!cancelledStatus) {
+      throw new NotFoundError('AppointmentStatus', AppointmentStatusEnum.CANCELLED);
+    }
+
+    // Obtener estados activos (PENDING y CONFIRMED)
+    const [pendingStatus, confirmedStatus] = await Promise.all([
+      this.appointmentStatusRepository.findByName(AppointmentStatusEnum.PENDING),
+      this.appointmentStatusRepository.findByName(AppointmentStatusEnum.CONFIRMED),
+    ]);
+
+    const activeStatusIds = [pendingStatus?.id, confirmedStatus?.id].filter(Boolean) as string[];
+
+    if (activeStatusIds.length === 0) {
+      return 0;
+    }
+
+    // Obtener todas las citas del estilista
+    const allAppointments = await this.appointmentRepository.findByStylistId(stylistId);
+
+    // Filtrar solo las activas (PENDING/CONFIRMED)
+    const activeAppointments = allAppointments.filter(a =>
+      activeStatusIds.includes(a.statusId),
+    );
+
+    // Cancelar cada cita activa
+    for (const appointment of activeAppointments) {
+      appointment.markAsCancelled(
+        cancelledStatus.id,
+        'Stylist deactivated',
+        'system',
+      );
+      await this.appointmentRepository.update(appointment);
+    }
+
+    return activeAppointments.length;
+  }
+
+  /**
+   * Desactiva todas las asignaciones StylistService del estilista
+   * @param stylistId - ID del estilista
+   * @returns Cantidad de asignaciones desactivadas
+   */
+  private async deactivateStylistServices(stylistId: string): Promise<number> {
+    const stylistServices = await this.stylistServiceRepository.findByStylist(stylistId);
+
+    // Filtrar solo las que están activas
+    const activeServices = stylistServices.filter(ss => ss.isOffering);
+
+    // Desactivar cada asignación
+    for (const stylistService of activeServices) {
+      stylistService.stopOffering();
+      await this.stylistServiceRepository.update(stylistService);
+    }
+
+    return activeServices.length;
+  }
+}

--- a/src/modules/auth/presentation/controllers/AuthController.ts
+++ b/src/modules/auth/presentation/controllers/AuthController.ts
@@ -6,6 +6,7 @@ import { RefreshToken } from '../../application/use-cases/RefreshToken';
 import { GetUserProfile } from '../../application/use-cases/GetUserProfile';
 import { UpdateUserProfile } from '../../application/use-cases/UpdateUserProfile';
 import { ChangeUserPassword } from '../../application/use-cases/ChangeUserPassword';
+import { DeactivateUser } from '../../application/use-cases/DeactivateUser';
 import { AuthenticatedRequest } from '../middleware/AuthMiddleware';
 import { RegisterDto } from '../../application/dto/request/RegisterDto';
 import { LoginDto } from '../../application/dto/request/LoginDto';
@@ -27,6 +28,7 @@ export class AuthController {
     private getUserProfile: GetUserProfile,
     private updateUserProfile: UpdateUserProfile,
     private changeUserPassword: ChangeUserPassword,
+    private deactivateUserUseCase: DeactivateUser,
   ) {}
 
   /**
@@ -171,6 +173,34 @@ export class AuthController {
     return res.status(200).json({
       success: true,
       message: 'Password changed successfully',
+    });
+  }
+
+  /**
+   * Desactiva un usuario del sistema
+   * Si el usuario es STYLIST, ejecuta cascada: cancela citas activas y desactiva servicios
+   * @route PATCH /auth/users/:id/deactivate
+   * @param req - Request de Express autenticado con userId del admin
+   * @param res - Response de Express
+   * @returns Promise<Response>
+   * @description Solo accesible por ADMIN. Desactiva usuario y ejecuta cascada si es STYLIST
+   * @responseStatus 200 - Usuario desactivado exitosamente con resumen de cascada
+   * @throws UnauthorizedError si el request no está autenticado
+   * @throws NotFoundError si el usuario no existe
+   * @throws BusinessRuleError si el usuario ya está inactivo
+   */
+  async deactivateUser(req: AuthenticatedRequest, res: Response): Promise<Response> {
+    if (!req.user?.userId) {
+      throw new UnauthorizedError('Authentication required');
+    }
+
+    const { id } = req.params;
+    const result = await this.deactivateUserUseCase.execute(id);
+
+    return res.status(200).json({
+      success: true,
+      data: result,
+      message: 'User deactivated successfully',
     });
   }
 }

--- a/src/modules/auth/presentation/routes/AuthRoutes.ts
+++ b/src/modules/auth/presentation/routes/AuthRoutes.ts
@@ -29,6 +29,7 @@ export class AuthRoutes {
    * - GET /auth/profile - Obtener perfil (requiere autenticación)
    * - PUT /auth/profile - Actualizar perfil (requiere autenticación)
    * - PUT /auth/change-password - Cambiar contraseña (requiere autenticación)
+   * - PATCH /auth/users/:id/deactivate - Desactivar usuario (solo ADMIN)
    */
   private setupRoutes(): void {
     // POST /login - Inicio de sesión (público)
@@ -89,6 +90,16 @@ export class AuthRoutes {
       ValidationMiddleware.handleValidationErrors,
       (req: Request, res: Response, next: NextFunction) => {
         this.authController.changePassword(req, res).catch(next);
+      },
+    );
+
+    // PATCH /users/:id/deactivate - Desactivar usuario (solo ADMIN)
+    this.router.patch(
+      '/users/:id/deactivate',
+      this.authMiddleware.authenticate.bind(this.authMiddleware),
+      this.authMiddleware.authorize(['ADMIN']),
+      (req: Request, res: Response, next: NextFunction) => {
+        this.authController.deactivateUser(req, res).catch(next);
       },
     );
   }


### PR DESCRIPTION
## Resumen

Resuelve ISSUE-17: al desactivar un usuario con rol STYLIST, sus citas activas y asignaciones de servicio quedaban huérfanas. Ahora se ejecuta una cascada automática.

## Problema

El sistema no tenía un endpoint de desactivación de usuarios. Al desactivar manualmente un estilista (cambiar `isActive` a `false`), sus citas PENDING/CONFIRMED seguían vigentes y sus asignaciones StylistService permanecían activas, causando inconsistencias en la disponibilidad del salón.

## Solución

### Nuevo endpoint

`PATCH /api/auth/users/:id/deactivate` — solo ADMIN

### Flujo de desactivación

1. Valida que el usuario exista y esté activo
2. Desactiva el usuario (`isActive = false`)
3. Si el rol es STYLIST, ejecuta cascada:
   - Cancela citas activas (PENDING/CONFIRMED) con razón `"Stylist deactivated"` y cancelledBy `"system"`
   - Desactiva asignaciones StylistService (`isOffering = false`)
4. Retorna resumen con conteo de acciones ejecutadas

### Response de ejemplo

```json
{
  "success": true,
  "data": {
    "userId": "uuid",
    "email": "stylist@salon.com",
    "name": "María García",
    "cascadeApplied": true,
    "cascadeSummary": {
      "appointmentsCancelled": 3,
      "servicesDeactivated": 5
    }
  }
}
```

### Decisiones técnicas

- **Cancelación directa** vía `markAsCancelled()` en lugar de reutilizar el flujo de `CancelAppointment`, para evitar re-validar reglas de negocio (política de 2h, ownership) que no aplican en una acción administrativa del sistema.
- **Dependencias cross-module** en `AuthContainer`: inyecta repositorios de appointments y services. Consistente con el patrón existente (ej: `CreateAppointment` ya depende de `IStylistRepository`).
- **Graceful degradation**: si el usuario tiene rol STYLIST pero no tiene registro en la tabla `Stylist`, la cascada retorna 0/0 sin error.