### PR TITLE
feat(appointments): implementar límite diario de citas por cliente (ISSUE-20)

### DIFF
--- a/src/modules/appointments/application/use-cases/CreateAppointment.ts
+++ b/src/modules/appointments/application/use-cases/CreateAppointment.ts
@@ -18,6 +18,9 @@ import { BusinessRuleError } from '../../../../shared/exceptions/BusinessRuleErr
  * Maneja todas las validaciones de negocio y coordinación entre servicios
  */
 export class CreateAppointment {
+  /** Máximo de citas activas por cliente por día */
+  private static readonly MAX_DAILY_APPOINTMENTS = 3;
+
   constructor(
     private appointmentRepository: IAppointmentRepository,
     private appointmentStatusRepository: IAppointmentStatusRepository,
@@ -90,10 +93,13 @@ export class CreateAppointment {
     // 6. Validar disponibilidad y conflictos
     await this.validateAvailability(createDto, totalDuration);
 
-    // 7. Obtener estado inicial (pendiente)
+    // 7. Validar límite diario de citas por cliente
+    await this.validateDailyAppointmentLimit(clientId, createDto.dateTime);
+
+    // 8. Obtener estado inicial (pendiente)
     const pendingStatus = await this.getPendingStatus();
 
-    // 8. Crear la entidad de cita con el Client.id correcto
+    // 9. Crear la entidad de cita con el Client.id correcto
     const appointment = Appointment.create(
       new Date(createDto.dateTime),
       totalDuration,
@@ -105,10 +111,10 @@ export class CreateAppointment {
       createDto.serviceIds,
     );
 
-    // 9. Guardar en repositorio
+    // 10. Guardar en repositorio
     const savedAppointment = await this.appointmentRepository.save(appointment);
 
-    // 10. Mapear a DTO de respuesta
+    // 11. Mapear a DTO de respuesta
     return this.mapToAppointmentDto(savedAppointment);
   }
 
@@ -254,6 +260,45 @@ export class CreateAppointment {
     }
 
     // TODO: Validar días festivos (ISSUE-12: diferido)
+  }
+
+  /**
+   * Valida que el cliente no exceda el límite diario de citas activas
+   * Solo cuenta citas no canceladas (PENDING, CONFIRMED, COMPLETED)
+   * @param clientId - ID del cliente (Client.id)
+   * @param dateTimeStr - Fecha y hora de la cita en formato ISO string
+   * @throws BusinessRuleError si el cliente alcanzó el límite diario
+   */
+  private async validateDailyAppointmentLimit(clientId: string, dateTimeStr: string): Promise<void> {
+    const appointmentDate = new Date(dateTimeStr);
+
+    // Obtener inicio y fin del día
+    const startOfDay = new Date(appointmentDate);
+    startOfDay.setHours(0, 0, 0, 0);
+
+    const endOfDay = new Date(appointmentDate);
+    endOfDay.setHours(23, 59, 59, 999);
+
+    // Buscar citas del cliente en ese día
+    const existingAppointments = await this.appointmentRepository.findByClientAndDateRange(
+      clientId,
+      startOfDay,
+      endOfDay,
+    );
+
+    // Obtener estado CANCELLED para excluirlo del conteo
+    const cancelledStatus = await this.appointmentStatusRepository.findByName('CANCELLED');
+
+    // Contar solo citas activas (no canceladas)
+    const activeAppointments = cancelledStatus
+      ? existingAppointments.filter(a => a.statusId !== cancelledStatus.id)
+      : existingAppointments;
+
+    if (activeAppointments.length >= CreateAppointment.MAX_DAILY_APPOINTMENTS) {
+      throw new BusinessRuleError(
+        `Maximum of ${CreateAppointment.MAX_DAILY_APPOINTMENTS} appointments per day has been reached`,
+      );
+    }
   }
 
   /**

--- a/tests/unit/appointments/application/use-cases/CreateAppointment.unit.test.ts
+++ b/tests/unit/appointments/application/use-cases/CreateAppointment.unit.test.ts
@@ -210,6 +210,7 @@ describe('CreateAppointment Use Case', () => {
     mockStylistServiceRepository.findByStylistAndService.mockResolvedValue(stylistService as any);
     mockScheduleRepository.findAll.mockResolvedValue([schedule]);
     mockAppointmentRepository.findConflictingAppointments.mockResolvedValue([]);
+    mockAppointmentRepository.findByClientAndDateRange.mockResolvedValue([]);
     mockAppointmentRepository.save.mockResolvedValue(appointment);
   };
 
@@ -476,6 +477,7 @@ describe('CreateAppointment Use Case', () => {
       mockAppointmentStatusRepository.findByName.mockResolvedValue(pendingStatus);
       mockScheduleRepository.findAll.mockResolvedValue([schedule]);
       mockAppointmentRepository.findConflictingAppointments.mockResolvedValue([]);
+      mockAppointmentRepository.findByClientAndDateRange.mockResolvedValue([]);
       mockAppointmentRepository.save.mockResolvedValue(appointment);
 
       const result = await useCase.execute(validCreateDto, validUserId);


### PR DESCRIPTION
## Resumen

Resuelve ISSUE-20: no existía protección contra abuso en la creación de citas. Un cliente podía crear citas ilimitadas en un mismo día.

## Problema

La única protección existente era la validación de conflictos de horario, que solo detecta solapamientos. Un cliente podía agendar múltiples citas en distintos horarios del mismo día sin restricción.

## Solución

Se agrega una validación en `CreateAppointment` (paso 7) que cuenta las citas activas del cliente para el día solicitado y rechaza la creación si alcanzó el límite.

- **Límite:** 3 citas activas por cliente por día (constante `MAX_DAILY_APPOINTMENTS`)
- **Conteo:** usa `findByClientAndDateRange` (ya existente en el repositorio) para buscar citas del día, filtrando las canceladas
- **Error:** `BusinessRuleError: Maximum of 3 appointments per day has been reached`

### Detalle técnico

El método `validateDailyAppointmentLimit` obtiene las citas del cliente entre `00:00:00` y `23:59:59` del día de la cita, excluye las que tienen status `CANCELLED`, y compara contra el límite. Solo se modificó un archivo de código y un archivo de test.

## Testing

- Todos los tests pasan (1102+)
- Mock de `findByClientAndDateRange` agregado al setup del test de `CreateAppointment`