### PR TITLE
feat: integrar holidays↔appointments con servicio de disponibilidad y auto-cancel (ISSUE-12, ISSUE-21)

### DIFF
--- a/src/modules/appointments/AppointmentContainer.ts
+++ b/src/modules/appointments/AppointmentContainer.ts
@@ -23,6 +23,15 @@ import { PrismaStylistRepository } from '../services/infrastructure/persistence/
 import { PrismaStylistServiceRepository } from '../services/infrastructure/persistence/PrismaStylistServiceRepository';
 import { PrismaClientRepository } from '../auth/infrastructure/persistence/PrismaClientRepository';
 
+// Repositorios de módulo holidays (para integración holidays↔appointments)
+import { IHolidayRepository } from '../holidays/domain/repositories/IHolidayRepository';
+import { IScheduleExceptionRepository } from '../holidays/domain/repositories/IScheduleExceptionRepository';
+import { PrismaHolidayRepository } from '../holidays/infrastructure/persistence/PrismaHolidayRepository';
+import { PrismaScheduleExceptionRepository } from '../holidays/infrastructure/persistence/PrismaScheduleExceptionRepository';
+
+// Servicios de dominio
+import { ScheduleAvailabilityService } from './domain/services/ScheduleAvailabilityService';
+
 // Casos de uso
 import { CreateAppointment } from './application/use-cases/CreateAppointment';
 import { GetAppointmentById } from './application/use-cases/GetAppointmentById';
@@ -110,6 +119,17 @@ export class AppointmentContainer {
     this._stylistServiceRepository = new PrismaStylistServiceRepository(this.prisma);
     this._clientRepository = new PrismaClientRepository(this.prisma);
 
+    // Repositorios de módulo holidays
+    const holidayRepository: IHolidayRepository = new PrismaHolidayRepository(this.prisma);
+    const scheduleExceptionRepository: IScheduleExceptionRepository = new PrismaScheduleExceptionRepository(this.prisma);
+
+    // Servicio de dominio de disponibilidad
+    const scheduleAvailabilityService = new ScheduleAvailabilityService(
+      holidayRepository,
+      scheduleExceptionRepository,
+      this._scheduleRepository,
+    );
+
     // Casos de uso implementados
     this._createAppointment = new CreateAppointment(
       this._appointmentRepository,
@@ -119,6 +139,7 @@ export class AppointmentContainer {
       this._stylistRepository,
       this._stylistServiceRepository,
       this._clientRepository,
+      scheduleAvailabilityService,
     );
 
     this._getAppointmentById = new GetAppointmentById(this._appointmentRepository);
@@ -135,6 +156,7 @@ export class AppointmentContainer {
     this._getAvailableSlots = new GetAvailableSlots(
       this._appointmentRepository,
       this._scheduleRepository,
+      scheduleAvailabilityService,
     );
 
     this._confirmAppointment = new ConfirmAppointment(

--- a/src/modules/appointments/application/use-cases/CreateAppointment.ts
+++ b/src/modules/appointments/application/use-cases/CreateAppointment.ts
@@ -11,6 +11,7 @@ import { AppointmentDto } from '../dto/response/AppointmentDto';
 import { ValidationError } from '../../../../shared/exceptions/ValidationError';
 import { NotFoundError } from '../../../../shared/exceptions/NotFoundError';
 import { ConflictError } from '../../../../shared/exceptions/ConflictError';
+import { ScheduleAvailabilityService } from '../../domain/services/ScheduleAvailabilityService';
 import { BusinessRuleError } from '../../../../shared/exceptions/BusinessRuleError';
 
 /**
@@ -29,6 +30,7 @@ export class CreateAppointment {
     private stylistRepository: IStylistRepository,
     private stylistServiceRepository: IStylistServiceRepository,
     private clientRepository: IClientRepository,
+    private scheduleAvailabilityService: ScheduleAvailabilityService,
   ) {}
 
   /**
@@ -84,22 +86,34 @@ export class CreateAppointment {
     // 3. Calcular duración total si no se proporciona
     const totalDuration = await this.calculateTotalDuration(createDto);
 
-    // 4. Obtener horario apropiado para el día
+    // 4. Obtener horario efectivo del día (prioridad: Exception > Holiday > Regular)
+    const effectiveSchedule = await this.scheduleAvailabilityService.getEffectiveSchedule(
+      new Date(createDto.dateTime),
+    );
+
+    // 5. Validar que el día no esté cerrado (feriado sin excepción o sin horario)
+    if (!effectiveSchedule) {
+      throw new BusinessRuleError(
+        'The salon is closed on the selected date (holiday or no schedule available)',
+      );
+    }
+
+    // 6. Validar que la cita esté dentro del horario efectivo del día
+    this.validateWorkingHours(createDto.dateTime, totalDuration, effectiveSchedule);
+
+    // 7. Obtener schedule regular para el scheduleId de la cita
     const schedule = await this.getAppropriateSchedule(createDto.dateTime);
 
-    // 5. Validar que la cita esté dentro del horario laboral
-    this.validateWorkingHours(createDto.dateTime, totalDuration, schedule);
-
-    // 6. Validar disponibilidad y conflictos
+    // 8. Validar disponibilidad y conflictos
     await this.validateAvailability(createDto, totalDuration);
 
-    // 7. Validar límite diario de citas por cliente
+    // 9. Validar límite diario de citas por cliente
     await this.validateDailyAppointmentLimit(clientId, createDto.dateTime);
 
-    // 8. Obtener estado inicial (pendiente)
+    // 10. Obtener estado inicial (pendiente)
     const pendingStatus = await this.getPendingStatus();
 
-    // 9. Crear la entidad de cita con el Client.id correcto
+    // 11. Crear la entidad de cita con el Client.id correcto
     const appointment = Appointment.create(
       new Date(createDto.dateTime),
       totalDuration,
@@ -111,10 +125,10 @@ export class CreateAppointment {
       createDto.serviceIds,
     );
 
-    // 10. Guardar en repositorio
+    // 12. Guardar en repositorio
     const savedAppointment = await this.appointmentRepository.save(appointment);
 
-    // 11. Mapear a DTO de respuesta
+    // 13. Mapear a DTO de respuesta
     return this.mapToAppointmentDto(savedAppointment);
   }
 
@@ -260,6 +274,22 @@ export class CreateAppointment {
     }
 
     // TODO: Validar días festivos (ISSUE-12: diferido)
+  }
+
+  /**
+   * Valida que el día de la cita no esté cerrado por feriado o falta de horario
+   * Usa el servicio de disponibilidad que aplica la prioridad:
+   * ScheduleException > Holiday (cerrado) > Schedule regular
+   * @param dateTimeStr - Fecha y hora de la cita en formato ISO string
+   * @throws BusinessRuleError si el día está cerrado
+   */
+  private async validateDayAvailability(dateTimeStr: string): Promise<void> {
+    const appointmentDate = new Date(dateTimeStr);
+    const isClosed = await this.scheduleAvailabilityService.isDayClosed(appointmentDate);
+
+    if (isClosed) {
+      throw new BusinessRuleError('The salon is closed on the selected date (holiday or no schedule available)');
+    }
   }
 
   /**

--- a/src/modules/appointments/application/use-cases/GetAvailableSlots.ts
+++ b/src/modules/appointments/application/use-cases/GetAvailableSlots.ts
@@ -1,5 +1,6 @@
 import { IAppointmentRepository } from '../../domain/repositories/IAppointmentRepository';
 import { IScheduleRepository } from '../../domain/repositories/IScheduleRepository';
+import { ScheduleAvailabilityService } from '../../domain/services/ScheduleAvailabilityService';
 import { GetAvailableSlotsDto } from '../dto/request/GetAvailableSlotsDto';
 import { DayAvailabilityDto, AvailableSlotDto } from '../dto/response/AvailableSlotDto';
 import { ValidationError } from '../../../../shared/exceptions/ValidationError';
@@ -14,6 +15,7 @@ export class GetAvailableSlots {
   constructor(
     private appointmentRepository: IAppointmentRepository,
     private scheduleRepository: IScheduleRepository,
+    private scheduleAvailabilityService: ScheduleAvailabilityService,
   ) {}
 
   /**
@@ -36,16 +38,21 @@ export class GetAvailableSlots {
     // 4. Obtener día de la semana
     const dayOfWeek = this.getDayOfWeek(targetDate);
 
-    // 5. Obtener horario laboral para el día
-    const schedule = await this.getWorkingSchedule(dayOfWeek);
+    // 5. Obtener horario efectivo (prioridad: Exception > Holiday > Schedule regular)
+    const effectiveSchedule =
+      await this.scheduleAvailabilityService.getEffectiveSchedule(targetDate);
 
-    // 6. Si no hay horario laboral, retornar día no laboral
-    if (!schedule) {
+    // 6. Si el día está cerrado (feriado sin excepción o sin horario), retornar no laboral
+    if (!effectiveSchedule) {
       return this.createNonWorkingDayResponse(request.date, dayOfWeek);
     }
 
-    // 7. Generar slots base según horario laboral
-    const baseSlots = this.generateBaseSlots(schedule, duration);
+    // 7. Generar slots base usando el horario efectivo
+    const baseSlots = this.generateBaseSlotsFromTimes(
+      effectiveSchedule.startTime,
+      effectiveSchedule.endTime,
+      duration,
+    );
 
     // 8. Obtener citas existentes para el día
     const existingAppointments = await this.getExistingAppointments(targetDate, request.stylistId);
@@ -59,8 +66,13 @@ export class GetAvailableSlots {
       request.stylistId,
     );
 
-    // 10. Construir y retornar respuesta
-    return this.buildDayAvailabilityResponse(request.date, dayOfWeek, schedule, availableSlots);
+    // 10. Construir y retornar respuesta con horario efectivo
+    return this.buildDayAvailabilityResponse(
+      request.date,
+      dayOfWeek,
+      { startTime: effectiveSchedule.startTime, endTime: effectiveSchedule.endTime },
+      availableSlots,
+    );
   }
 
   /**
@@ -198,6 +210,34 @@ export class GetAvailableSlots {
   }
 
   /**
+   * Genera slots base a partir de horarios explícitos (startTime/endTime)
+   * @param startTime - Hora de inicio (HH:MM)
+   * @param endTime - Hora de fin (HH:MM)
+   * @param duration - Duración de cada slot en minutos
+   * @returns Array de slots en formato HH:MM
+   */
+  private generateBaseSlotsFromTimes(
+    startTime: string,
+    endTime: string,
+    duration: number,
+  ): string[] {
+    const [startHour, startMin] = startTime.split(':').map(Number);
+    const [endHour, endMin] = endTime.split(':').map(Number);
+
+    const startMinutes = startHour * 60 + startMin;
+    const endMinutes = endHour * 60 + endMin;
+
+    const slots: string[] = [];
+    for (let time = startMinutes; time + duration <= endMinutes; time += 15) {
+      const hours = Math.floor(time / 60);
+      const minutes = time % 60;
+      slots.push(`${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`);
+    }
+
+    return slots;
+  }
+
+  /**
    * Genera slots base según el horario laboral y duración
    * @param schedule - Horario laboral del día
    * @param duration - Duración requerida en minutos
@@ -305,10 +345,13 @@ export class GetAvailableSlots {
       if (slotStart < appointmentEnd && slotEnd > appointmentStart) {
         return {
           hasConflict: true,
-          reason: `Conflict with existing appointment at ${appointmentStart.toLocaleTimeString('en-US', {
-            hour: '2-digit',
-            minute: '2-digit',
-          })}`,
+          reason: `Conflict with existing appointment at ${appointmentStart.toLocaleTimeString(
+            'en-US',
+            {
+              hour: '2-digit',
+              minute: '2-digit',
+            },
+          )}`,
         };
       }
     }

--- a/src/modules/appointments/domain/services/ScheduleAvailabilityService.ts
+++ b/src/modules/appointments/domain/services/ScheduleAvailabilityService.ts
@@ -1,0 +1,105 @@
+import { IScheduleRepository } from '../repositories/IScheduleRepository';
+import { IHolidayRepository } from '../../../holidays/domain/repositories/IHolidayRepository';
+import { IScheduleExceptionRepository } from '../../../holidays/domain/repositories/IScheduleExceptionRepository';
+import { DayOfWeekEnum } from '../entities/Schedule';
+
+/**
+ * Resultado del cálculo de disponibilidad horaria para un día específico
+ * `null` indica que el día está cerrado (no hay disponibilidad)
+ */
+export interface EffectiveSchedule {
+  /** Hora de inicio del horario efectivo (formato HH:MM) */
+  startTime: string;
+  /** Hora de fin del horario efectivo (formato HH:MM) */
+  endTime: string;
+  /** Fuente que determinó el horario: 'exception', 'holiday' o 'regular' */
+  source: 'exception' | 'regular';
+}
+
+/**
+ * Servicio de dominio para determinar el horario efectivo de un día
+ *
+ * Implementa la lógica de prioridad:
+ * 1. ScheduleException > 2. Holiday (cerrado) > 3. Schedule regular
+ *
+ * - Si hay una ScheduleException para la fecha, usa su horario especial
+ * - Si es Holiday sin excepción, el día está cerrado (retorna null)
+ * - Si no hay ni excepción ni feriado, usa el horario regular del día de la semana
+ */
+export class ScheduleAvailabilityService {
+  constructor(
+    private holidayRepository: IHolidayRepository,
+    private scheduleExceptionRepository: IScheduleExceptionRepository,
+    private scheduleRepository: IScheduleRepository,
+  ) {}
+
+  /**
+   * Determina el horario efectivo para una fecha específica
+   * @param date - Fecha a consultar
+   * @returns EffectiveSchedule con el horario efectivo, o null si el día está cerrado
+   */
+  async getEffectiveSchedule(date: Date): Promise<EffectiveSchedule | null> {
+    // 1. Prioridad máxima: ScheduleException
+    const exception = await this.scheduleExceptionRepository.getExceptionForDate(date);
+
+    if (exception) {
+      return {
+        startTime: exception.startTimeException,
+        endTime: exception.endTimeException,
+        source: 'exception',
+      };
+    }
+
+    // 2. Segunda prioridad: Holiday (sin excepción = día cerrado)
+    const isHoliday = await this.holidayRepository.isHoliday(date);
+
+    if (isHoliday) {
+      return null;
+    }
+
+    // 3. Fallback: horario regular del día de la semana
+    const dayOfWeek = this.getDayOfWeek(date);
+    const schedules = await this.scheduleRepository.findByDayOfWeek(dayOfWeek);
+
+    if (schedules.length === 0) {
+      // No hay horario regular para este día (ej: domingo sin horario configurado)
+      return null;
+    }
+
+    const schedule = schedules[0];
+    return {
+      startTime: schedule.startTime,
+      endTime: schedule.endTime,
+      source: 'regular',
+    };
+  }
+
+  /**
+   * Verifica si un día está cerrado (feriado sin excepción o sin horario regular)
+   * @param date - Fecha a consultar
+   * @returns true si el día está cerrado
+   */
+  async isDayClosed(date: Date): Promise<boolean> {
+    const effectiveSchedule = await this.getEffectiveSchedule(date);
+    return effectiveSchedule === null;
+  }
+
+  /**
+   * Convierte una fecha al enum DayOfWeekEnum
+   * @param date - Fecha a convertir
+   * @returns Día de la semana como enum
+   */
+  private getDayOfWeek(date: Date): DayOfWeekEnum {
+    const dayNames = [
+      DayOfWeekEnum.SUNDAY,
+      DayOfWeekEnum.MONDAY,
+      DayOfWeekEnum.TUESDAY,
+      DayOfWeekEnum.WEDNESDAY,
+      DayOfWeekEnum.THURSDAY,
+      DayOfWeekEnum.FRIDAY,
+      DayOfWeekEnum.SATURDAY,
+    ];
+
+    return dayNames[date.getDay()];
+  }
+}

--- a/src/modules/holidays/HolidayContainer.ts
+++ b/src/modules/holidays/HolidayContainer.ts
@@ -6,6 +6,12 @@ import { IScheduleExceptionRepository } from './domain/repositories/IScheduleExc
 import { PrismaHolidayRepository } from './infrastructure/persistence/PrismaHolidayRepository';
 import { PrismaScheduleExceptionRepository } from './infrastructure/persistence/PrismaScheduleExceptionRepository';
 
+// Repositorios cross-module (para auto-cancel de citas al crear feriado)
+import { IAppointmentRepository } from '../appointments/domain/repositories/IAppointmentRepository';
+import { IAppointmentStatusRepository } from '../appointments/domain/repositories/IAppointmentStatusRepository';
+import { PrismaAppointmentRepository } from '../appointments/infrastructure/persistence/PrismaAppointmentRepository';
+import { PrismaAppointmentStatusRepository } from '../appointments/infrastructure/persistence/PrismaAppointmentStatusRepository';
+
 // Holiday Use Cases
 import { CreateHoliday } from './application/use-cases/CreateHoliday';
 import { GetHolidayById } from './application/use-cases/GetHolidayById';
@@ -100,8 +106,16 @@ export class HolidayContainer {
     this._holidayRepository = new PrismaHolidayRepository(this.prisma);
     this._scheduleExceptionRepository = new PrismaScheduleExceptionRepository(this.prisma);
 
-    // 2. Inicializar Holiday use cases
-    this._createHoliday = new CreateHoliday(this._holidayRepository);
+    // 2. Repositorios cross-module
+    const appointmentRepository: IAppointmentRepository = new PrismaAppointmentRepository(this.prisma);
+    const appointmentStatusRepository: IAppointmentStatusRepository = new PrismaAppointmentStatusRepository(this.prisma);
+
+    // 3. Inicializar Holiday use cases
+    this._createHoliday = new CreateHoliday(
+      this._holidayRepository,
+      appointmentRepository,
+      appointmentStatusRepository,
+    );
     this._getHolidayById = new GetHolidayById(this._holidayRepository);
     this._getHolidays = new GetHolidays(this._holidayRepository);
     this._getHolidaysByYear = new GetHolidaysByYear(this._holidayRepository);

--- a/src/modules/holidays/application/use-cases/CreateHoliday.ts
+++ b/src/modules/holidays/application/use-cases/CreateHoliday.ts
@@ -1,16 +1,25 @@
 import { generateUuid } from '../../../../shared/utils/uuid';
 import { Holiday } from '../../domain/entities/Holiday';
 import { IHolidayRepository } from '../../domain/repositories/IHolidayRepository';
+import { IAppointmentRepository } from '../../../appointments/domain/repositories/IAppointmentRepository';
+import { IAppointmentStatusRepository } from '../../../appointments/domain/repositories/IAppointmentStatusRepository';
+import { AppointmentStatusEnum } from '../../../appointments/domain/entities/AppointmentStatus';
 import { CreateHolidayDto } from '../dto/request/CreateHolidayDto';
 import { HolidayResponseDto, HolidayResponseMapper } from '../dto/response/HolidayResponseDto';
 import { ConflictError } from '../../../../shared/exceptions/ConflictError';
+import { NotFoundError } from '../../../../shared/exceptions/NotFoundError';
 
 /**
  * Caso de uso: Crear feriado
- * @description Crea un nuevo feriado en el sistema
+ * @description Crea un nuevo feriado y cancela automáticamente las citas activas
+ * (PENDING/CONFIRMED) que existan para esa fecha
  */
 export class CreateHoliday {
-  constructor(private readonly holidayRepository: IHolidayRepository) {}
+  constructor(
+    private readonly holidayRepository: IHolidayRepository,
+    private readonly appointmentRepository: IAppointmentRepository,
+    private readonly appointmentStatusRepository: IAppointmentStatusRepository,
+  ) {}
 
   /**
    * Ejecuta el caso de uso
@@ -38,6 +47,51 @@ export class CreateHoliday {
     // Guardar en el repositorio
     const savedHoliday = await this.holidayRepository.save(holiday);
 
+    // Cancelar automáticamente citas activas en la fecha del feriado
+    await this.cancelAppointmentsOnHolidayDate(date);
+
     return HolidayResponseMapper.toDto(savedHoliday);
+  }
+
+  /**
+   * Cancela automáticamente las citas activas (PENDING/CONFIRMED) en la fecha del feriado
+   * Usa cancelación directa vía entidad (acción de sistema, no reutiliza CancelAppointment)
+   * @param holidayDate - Fecha del feriado
+   */
+  private async cancelAppointmentsOnHolidayDate(holidayDate: Date): Promise<void> {
+    // Obtener estado CANCELLED
+    const cancelledStatus = await this.appointmentStatusRepository.findByName(
+      AppointmentStatusEnum.CANCELLED,
+    );
+    if (!cancelledStatus) {
+      throw new NotFoundError('AppointmentStatus', AppointmentStatusEnum.CANCELLED);
+    }
+
+    // Obtener estados activos
+    const [pendingStatus, confirmedStatus] = await Promise.all([
+      this.appointmentStatusRepository.findByName(AppointmentStatusEnum.PENDING),
+      this.appointmentStatusRepository.findByName(AppointmentStatusEnum.CONFIRMED),
+    ]);
+
+    const activeStatusIds = [pendingStatus?.id, confirmedStatus?.id].filter(Boolean) as string[];
+
+    if (activeStatusIds.length === 0) return;
+
+    // Buscar citas del día (inicio y fin del día del feriado)
+    const startOfDay = new Date(holidayDate);
+    startOfDay.setHours(0, 0, 0, 0);
+
+    const endOfDay = new Date(holidayDate);
+    endOfDay.setHours(23, 59, 59, 999);
+
+    const appointments = await this.appointmentRepository.findByDateRange(startOfDay, endOfDay);
+
+    // Filtrar solo las activas y cancelarlas
+    const activeAppointments = appointments.filter(a => activeStatusIds.includes(a.statusId));
+
+    for (const appointment of activeAppointments) {
+      appointment.markAsCancelled(cancelledStatus.id, 'Holiday created', 'system');
+      await this.appointmentRepository.update(appointment);
+    }
   }
 }

--- a/tests/unit/appointments/application/use-cases/CreateAppointment.unit.test.ts
+++ b/tests/unit/appointments/application/use-cases/CreateAppointment.unit.test.ts
@@ -17,6 +17,7 @@ import { ValidationError } from '../../../../../src/shared/exceptions/Validation
 import { NotFoundError } from '../../../../../src/shared/exceptions/NotFoundError';
 import { ConflictError } from '../../../../../src/shared/exceptions/ConflictError';
 import { BusinessRuleError } from '../../../../../src/shared/exceptions/BusinessRuleError';
+import { ScheduleAvailabilityService } from '../../../../../src/modules/appointments/domain/services/ScheduleAvailabilityService';
 import { generateUuid } from '../../../../../src/shared/utils/uuid';
 
 describe('CreateAppointment Use Case', () => {
@@ -28,6 +29,7 @@ describe('CreateAppointment Use Case', () => {
   let mockStylistRepository: jest.Mocked<StylistRepository>;
   let mockStylistServiceRepository: jest.Mocked<IStylistServiceRepository>;
   let mockClientRepository: jest.Mocked<ClientRepository>;
+  let mockScheduleAvailabilityService: jest.Mocked<ScheduleAvailabilityService>;
 
   // Utilidades de fecha dinámicas y mantenibles
   const getNextMonday = (hoursFromNow: number = 48): Date => {
@@ -212,6 +214,13 @@ describe('CreateAppointment Use Case', () => {
     mockAppointmentRepository.findConflictingAppointments.mockResolvedValue([]);
     mockAppointmentRepository.findByClientAndDateRange.mockResolvedValue([]);
     mockAppointmentRepository.save.mockResolvedValue(appointment);
+
+    // Mock del servicio de disponibilidad — retorna horario regular por defecto
+    mockScheduleAvailabilityService.getEffectiveSchedule.mockResolvedValue({
+      startTime: '09:00',
+      endTime: '18:00',
+      source: 'regular',
+    });
   };
 
   beforeEach(() => {
@@ -315,6 +324,15 @@ describe('CreateAppointment Use Case', () => {
       existsByUserId: jest.fn(),
     } as unknown as jest.Mocked<ClientRepository>;
 
+    mockScheduleAvailabilityService = {
+      getEffectiveSchedule: jest.fn().mockResolvedValue({
+        startTime: '09:00',
+        endTime: '18:00',
+        source: 'regular',
+      }),
+      isDayClosed: jest.fn().mockResolvedValue(false),
+    } as unknown as jest.Mocked<ScheduleAvailabilityService>;
+
     useCase = new CreateAppointment(
       mockAppointmentRepository,
       mockAppointmentStatusRepository,
@@ -323,6 +341,7 @@ describe('CreateAppointment Use Case', () => {
       mockStylistRepository,
       mockStylistServiceRepository,
       mockClientRepository,
+      mockScheduleAvailabilityService,
     );
   });
 

--- a/tests/unit/appointments/application/use-cases/GetAvailableSlots.unit.test.ts
+++ b/tests/unit/appointments/application/use-cases/GetAvailableSlots.unit.test.ts
@@ -1,17 +1,22 @@
 import { GetAvailableSlots } from '../../../../../src/modules/appointments/application/use-cases/GetAvailableSlots';
-import { AppointmentRepository } from '../../../../../src/modules/appointments/domain/repositories/AppointmentRepository';
-import { ScheduleRepository } from '../../../../../src/modules/appointments/domain/repositories/ScheduleRepository';
-import { Schedule, DayOfWeekEnum } from '../../../../../src/modules/appointments/domain/entities/Schedule';
+import { IAppointmentRepository } from '../../../../../src/modules/appointments/domain/repositories/IAppointmentRepository';
+import { IScheduleRepository } from '../../../../../src/modules/appointments/domain/repositories/IScheduleRepository';
+import {
+  Schedule,
+  DayOfWeekEnum,
+} from '../../../../../src/modules/appointments/domain/entities/Schedule';
 import { Appointment } from '../../../../../src/modules/appointments/domain/entities/Appointment';
 import { GetAvailableSlotsDto } from '../../../../../src/modules/appointments/application/dto/request/GetAvailableSlotsDto';
 import { ValidationError } from '../../../../../src/shared/exceptions/ValidationError';
 import { BusinessRuleError } from '../../../../../src/shared/exceptions/BusinessRuleError';
+import { ScheduleAvailabilityService } from '../../../../../src/modules/appointments/domain/services/ScheduleAvailabilityService';
 import { generateUuid } from '../../../../../src/shared/utils/uuid';
 
 describe('GetAvailableSlots Use Case', () => {
   let useCase: GetAvailableSlots;
-  let mockAppointmentRepository: jest.Mocked<AppointmentRepository>;
-  let mockScheduleRepository: jest.Mocked<ScheduleRepository>;
+  let mockAppointmentRepository: jest.Mocked<IAppointmentRepository>;
+  let mockScheduleRepository: jest.Mocked<IScheduleRepository>;
+  let mockScheduleAvailabilityService: jest.Mocked<ScheduleAvailabilityService>;
 
   // Utilidades de fecha dinámicas
   const getFutureDateString = (daysFromNow: number = 7): string => {
@@ -60,11 +65,28 @@ describe('GetAvailableSlots Use Case', () => {
       endTime,
       createdAt: new Date(),
       updatedAt: new Date(),
-      getAvailableSlots: jest.fn().mockReturnValue([
-        '09:00', '09:30', '10:00', '10:30', '11:00', '11:30',
-        '12:00', '12:30', '13:00', '13:30', '14:00', '14:30',
-        '15:00', '15:30', '16:00', '16:30', '17:00', '17:30',
-      ]),
+      getAvailableSlots: jest
+        .fn()
+        .mockReturnValue([
+          '09:00',
+          '09:30',
+          '10:00',
+          '10:30',
+          '11:00',
+          '11:30',
+          '12:00',
+          '12:30',
+          '13:00',
+          '13:30',
+          '14:00',
+          '14:30',
+          '15:00',
+          '15:30',
+          '16:00',
+          '16:30',
+          '17:00',
+          '17:30',
+        ]),
       isWithinWorkingHours: jest.fn().mockReturnValue(true),
       validate: jest.fn(),
     } as unknown as Schedule;
@@ -116,6 +138,11 @@ describe('GetAvailableSlots Use Case', () => {
 
     mockScheduleRepository.findByDayOfWeek.mockResolvedValue([schedule]);
     mockAppointmentRepository.findByDate.mockResolvedValue([]);
+    mockScheduleAvailabilityService.getEffectiveSchedule.mockResolvedValue({
+      startTime: '09:00',
+      endTime: '18:00',
+      source: 'regular',
+    });
   };
 
   beforeEach(() => {
@@ -141,7 +168,7 @@ describe('GetAvailableSlots Use Case', () => {
       countByDateRange: jest.fn(),
       findUpcomingAppointments: jest.fn(),
       findPendingConfirmation: jest.fn(),
-    } as unknown as jest.Mocked<AppointmentRepository>;
+    } as unknown as jest.Mocked<IAppointmentRepository>;
 
     // Mock de ScheduleRepository
     mockScheduleRepository = {
@@ -158,9 +185,22 @@ describe('GetAvailableSlots Use Case', () => {
       findAvailableSchedulesForDay: jest.fn(),
       findScheduleByTimeSlot: jest.fn(),
       findConflictingSchedules: jest.fn(),
-    } as unknown as jest.Mocked<ScheduleRepository>;
+    } as unknown as jest.Mocked<IScheduleRepository>;
 
-    useCase = new GetAvailableSlots(mockAppointmentRepository, mockScheduleRepository);
+    mockScheduleAvailabilityService = {
+      getEffectiveSchedule: jest.fn().mockResolvedValue({
+        startTime: '09:00',
+        endTime: '18:00',
+        source: 'regular',
+      }),
+      isDayClosed: jest.fn().mockResolvedValue(false),
+    } as unknown as jest.Mocked<ScheduleAvailabilityService>;
+
+    useCase = new GetAvailableSlots(
+      mockAppointmentRepository,
+      mockScheduleRepository,
+      mockScheduleAvailabilityService,
+    );
   });
 
   afterEach(() => {
@@ -225,7 +265,7 @@ describe('GetAvailableSlots Use Case', () => {
 
       const result = await useCase.execute(dto);
 
-      result.slots.forEach(slot => {
+      result.slots.forEach((slot) => {
         expect(slot.duration).toBe(30);
       });
     });
@@ -238,7 +278,7 @@ describe('GetAvailableSlots Use Case', () => {
 
       const result = await useCase.execute(dto);
 
-      result.slots.forEach(slot => {
+      result.slots.forEach((slot) => {
         expect(slot.duration).toBe(60);
       });
     });
@@ -251,7 +291,7 @@ describe('GetAvailableSlots Use Case', () => {
 
       const result = await useCase.execute(dto);
 
-      result.slots.forEach(slot => {
+      result.slots.forEach((slot) => {
         expect(slot.stylist).toBeDefined();
         expect(slot.stylist!.id).toBe(validStylistId);
       });
@@ -265,7 +305,7 @@ describe('GetAvailableSlots Use Case', () => {
 
       const result = await useCase.execute(dto);
 
-      const availableCount = result.slots.filter(slot => slot.available).length;
+      const availableCount = result.slots.filter((slot) => slot.available).length;
       expect(result.availableSlots).toBe(availableCount);
     });
   });
@@ -276,7 +316,8 @@ describe('GetAvailableSlots Use Case', () => {
       const dateString = getFutureDateString(7);
       const dto = createValidDto({ date: dateString });
 
-      mockScheduleRepository.findByDayOfWeek.mockResolvedValue([]);
+      // Día cerrado: el servicio retorna null
+      mockScheduleAvailabilityService.getEffectiveSchedule.mockResolvedValue(null);
 
       const result = await useCase.execute(dto);
 
@@ -292,7 +333,8 @@ describe('GetAvailableSlots Use Case', () => {
       const dateString = getFutureDateString(7);
       const dto = createValidDto({ date: dateString });
 
-      mockScheduleRepository.findByDayOfWeek.mockResolvedValue([]);
+      // Día cerrado: el servicio retorna null
+      mockScheduleAvailabilityService.getEffectiveSchedule.mockResolvedValue(null);
 
       const result = await useCase.execute(dto);
 
@@ -319,7 +361,7 @@ describe('GetAvailableSlots Use Case', () => {
       const result = await useCase.execute(dto);
 
       // Buscar slot de las 10:00 y verificar que no esté disponible
-      const conflictingSlot = result.slots.find(slot => slot.time === '10:00');
+      const conflictingSlot = result.slots.find((slot) => slot.time === '10:00');
       if (conflictingSlot) {
         expect(conflictingSlot.available).toBe(false);
         expect(conflictingSlot.conflictReason).toBeDefined();
@@ -338,13 +380,17 @@ describe('GetAvailableSlots Use Case', () => {
       // Crear cita de otro estilista - no debería afectar disponibilidad
       const otherStylistId = generateUuid();
       const appointmentDate = new Date(dateString + 'T10:00:00.000Z');
-      const otherStylistAppointment = createMockExistingAppointment(appointmentDate, 60, otherStylistId);
+      const otherStylistAppointment = createMockExistingAppointment(
+        appointmentDate,
+        60,
+        otherStylistId,
+      );
       mockAppointmentRepository.findByDate.mockResolvedValue([otherStylistAppointment]);
 
       const result = await useCase.execute(dto);
 
       // El slot de las 10:00 debería estar disponible porque la cita es de otro estilista
-      const slot = result.slots.find(s => s.time === '10:00');
+      const slot = result.slots.find((s) => s.time === '10:00');
       if (slot) {
         expect(slot.available).toBe(true);
       }
@@ -369,7 +415,7 @@ describe('GetAvailableSlots Use Case', () => {
       const result = await useCase.execute(dto);
 
       // Verificar que hay algunos slots no disponibles
-      const unavailableSlots = result.slots.filter(slot => !slot.available);
+      const unavailableSlots = result.slots.filter((slot) => !slot.available);
       expect(unavailableSlots.length).toBeGreaterThan(0);
     });
   });
@@ -379,18 +425,14 @@ describe('GetAvailableSlots Use Case', () => {
     it('should throw error for empty date', async () => {
       const dto = createValidDto({ date: '' });
 
-      await expect(useCase.execute(dto)).rejects.toThrow(
-        new ValidationError('Date is required'),
-      );
+      await expect(useCase.execute(dto)).rejects.toThrow(new ValidationError('Date is required'));
     });
 
     // Debería lanzar error para fecha solo con espacios
     it('should throw error for whitespace-only date', async () => {
       const dto = createValidDto({ date: '   ' });
 
-      await expect(useCase.execute(dto)).rejects.toThrow(
-        new ValidationError('Date is required'),
-      );
+      await expect(useCase.execute(dto)).rejects.toThrow(new ValidationError('Date is required'));
     });
 
     // Debería lanzar error para formato de fecha inválido
@@ -603,12 +645,12 @@ describe('GetAvailableSlots Use Case', () => {
     it('should call scheduleRepository.findByDayOfWeek with correct day', async () => {
       const dateString = getFutureDateString(7);
       const dto = createValidDto({ date: dateString });
-      const expectedDayOfWeek = getDayOfWeekFromDateString(dateString);
       setupSuccessfulMocks(dateString);
 
       await useCase.execute(dto);
 
-      expect(mockScheduleRepository.findByDayOfWeek).toHaveBeenCalledWith(expectedDayOfWeek);
+      // El servicio de disponibilidad maneja la consulta al scheduleRepository
+      expect(mockScheduleAvailabilityService.getEffectiveSchedule).toHaveBeenCalled();
     });
 
     // Debería llamar a appointmentRepository.findByDate con fecha correcta
@@ -627,7 +669,8 @@ describe('GetAvailableSlots Use Case', () => {
       const dateString = getFutureDateString(7);
       const dto = createValidDto({ date: dateString });
 
-      mockScheduleRepository.findByDayOfWeek.mockResolvedValue([]);
+      // Día cerrado: el servicio retorna null
+      mockScheduleAvailabilityService.getEffectiveSchedule.mockResolvedValue(null);
 
       await useCase.execute(dto);
 
@@ -642,7 +685,7 @@ describe('GetAvailableSlots Use Case', () => {
       const dto = createValidDto({ date: dateString });
       const repositoryError = new Error('Database connection failed');
 
-      mockScheduleRepository.findByDayOfWeek.mockRejectedValue(repositoryError);
+      mockScheduleAvailabilityService.getEffectiveSchedule.mockRejectedValue(repositoryError);
 
       await expect(useCase.execute(dto)).rejects.toThrow(repositoryError);
     });
@@ -653,9 +696,10 @@ describe('GetAvailableSlots Use Case', () => {
       const dto = createValidDto({ date: dateString });
       const repositoryError = new Error('Query timeout');
 
-      const dayOfWeek = getDayOfWeekFromDateString(dateString);
-      const schedule = createMockSchedule(dayOfWeek);
-      mockScheduleRepository.findByDayOfWeek.mockResolvedValue([schedule]);
+      // Configurar servicio para que pase, pero findByDate falle
+      mockScheduleAvailabilityService.getEffectiveSchedule.mockResolvedValue({
+        startTime: '09:00', endTime: '18:00', source: 'regular',
+      });
       mockAppointmentRepository.findByDate.mockRejectedValue(repositoryError);
 
       await expect(useCase.execute(dto)).rejects.toThrow(repositoryError);

--- a/tests/unit/holidays/application/use-cases/CreateHoliday.unit.test.ts
+++ b/tests/unit/holidays/application/use-cases/CreateHoliday.unit.test.ts
@@ -1,10 +1,14 @@
 import { CreateHoliday } from '../../../../../src/modules/holidays/application/use-cases/CreateHoliday';
 import { IHolidayRepository } from '../../../../../src/modules/holidays/domain/repositories/IHolidayRepository';
+import { IAppointmentRepository } from '../../../../../src/modules/appointments/domain/repositories/IAppointmentRepository';
+import { IAppointmentStatusRepository } from '../../../../../src/modules/appointments/domain/repositories/IAppointmentStatusRepository';
 import { Holiday } from '../../../../../src/modules/holidays/domain/entities/Holiday';
 
 describe('CreateHoliday Use Case', () => {
   let createHoliday: CreateHoliday;
   let mockHolidayRepository: jest.Mocked<IHolidayRepository>;
+  let mockAppointmentRepository: jest.Mocked<IAppointmentRepository>;
+  let mockAppointmentStatusRepository: jest.Mocked<IAppointmentStatusRepository>;
 
   beforeEach(() => {
     mockHolidayRepository = {
@@ -19,9 +23,32 @@ describe('CreateHoliday Use Case', () => {
       delete: jest.fn(),
       existsByDate: jest.fn(),
       isHoliday: jest.fn(),
-    };
+    } as jest.Mocked<IHolidayRepository>;
 
-    createHoliday = new CreateHoliday(mockHolidayRepository);
+    mockAppointmentRepository = {
+      findByDateRange: jest.fn().mockResolvedValue([]),
+      findById: jest.fn(), findAll: jest.fn(), save: jest.fn(), update: jest.fn(),
+      delete: jest.fn(), existsById: jest.fn(), findByClientId: jest.fn(),
+      findByStylistId: jest.fn(), findByUserId: jest.fn(), findByStatusId: jest.fn(),
+      findByClientAndDateRange: jest.fn(), findByStylistAndDateRange: jest.fn(),
+      findConflictingAppointments: jest.fn(), findByScheduleId: jest.fn(),
+      findByDate: jest.fn(), countByStatus: jest.fn(), countByDateRange: jest.fn(),
+      findUpcomingAppointments: jest.fn(), findPendingConfirmation: jest.fn(),
+      existsActiveByServiceId: jest.fn(),
+    } as jest.Mocked<IAppointmentRepository>;
+
+    mockAppointmentStatusRepository = {
+      findByName: jest.fn().mockResolvedValue({ id: 'cancelled-id', name: 'CANCELLED', description: 'Cancelled' }),
+      findById: jest.fn(), findAll: jest.fn(), save: jest.fn(), update: jest.fn(),
+      delete: jest.fn(), existsById: jest.fn(), existsByName: jest.fn(),
+      findTerminalStatuses: jest.fn(), findActiveStatuses: jest.fn(),
+    } as jest.Mocked<IAppointmentStatusRepository>;
+
+    createHoliday = new CreateHoliday(
+      mockHolidayRepository,
+      mockAppointmentRepository,
+      mockAppointmentStatusRepository,
+    );
   });
 
   // Debería crear un feriado exitosamente


### PR DESCRIPTION
## Resumen

Resuelve ISSUE-12 e ISSUE-21: `GetAvailableSlots` y `CreateAppointment` ahora consultan feriados y excepciones, y `CreateHoliday` cancela automáticamente citas activas en la fecha del feriado.

## Problema

- **ISSUE-12:** `GetAvailableSlots` y `CreateAppointment` solo consultaban el horario regular del día, ignorando feriados y excepciones. Un cliente podía agendar citas en días feriados.
- **ISSUE-21:** Al crear un feriado, las citas existentes para esa fecha quedaban vigentes, causando inconsistencias.

## Solución

### F1 — Servicio de dominio `ScheduleAvailabilityService`

Nuevo servicio en `domain/services/` que encapsula la lógica de prioridad:

1. **ScheduleException** (prioridad máxima) → usa horario especial (`startTimeException`/`endTimeException`)
2. **Holiday sin excepción** → día cerrado (retorna `null`)
3. **Schedule regular** → horario normal del día de la semana

Métodos: `getEffectiveSchedule(date)` y `isDayClosed(date)`.

**Justificación de ubicación en `domain/services/`:** La regla de prioridad involucra tres entidades (`Schedule`, `Holiday`, `ScheduleException`) y no pertenece naturalmente a ninguna de ellas. Es el patrón Domain Service de DDD (Evans), canónico en arquitectura hexagonal.

### F1 — Integración en use cases

- **`GetAvailableSlots`:** Usa el servicio para obtener el horario efectivo del día. Si el día está cerrado, retorna `isWorkingDay: false`. Los slots se generan desde los horarios efectivos, no los regulares.
- **`CreateAppointment`:** Valida que el día no esté cerrado antes de crear la cita. Valida horarios laborales contra el schedule efectivo (no el regular), permitiendo correctamente citas en días con horarios reducidos por excepción.

### F2 — Auto-cancel al crear feriado

`CreateHoliday` ahora busca citas activas (PENDING/CONFIRMED) en la fecha del feriado y las cancela automáticamente con razón `"Holiday created"` y cancelledBy `"system"`. Usa cancelación directa vía entidad, consistente con el patrón establecido en Fase 3.

## Testing

- Todos los tests pasan
- 3 archivos de tests actualizados con mocks de `ScheduleAvailabilityService`
- Mocks de repos cross-module agregados a `CreateHoliday` test