### PR TITLE
fix: migrar Appointment.clientId/stylistId de Client.id/Stylist.id a User.id

### DIFF
--- a/prisma/migrations/20260628185928_appointment_fk_to_user_id/migration.sql
+++ b/prisma/migrations/20260628185928_appointment_fk_to_user_id/migration.sql
@@ -1,0 +1,23 @@
+-- DropForeignKey
+ALTER TABLE "Appointment" DROP CONSTRAINT "Appointment_clientId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Appointment" DROP CONSTRAINT "Appointment_stylistId_fkey";
+
+-- Data migration: Convert clientId from Client.id to User.id
+UPDATE "Appointment"
+SET "clientId" = "Client"."userId"
+FROM "Client"
+WHERE "Appointment"."clientId" = "Client"."id";
+
+-- Data migration: Convert stylistId from Stylist.id to User.id
+UPDATE "Appointment"
+SET "stylistId" = "Stylist"."userId"
+FROM "Stylist"
+WHERE "Appointment"."stylistId" = "Stylist"."id";
+
+-- AddForeignKey
+ALTER TABLE "Appointment" ADD CONSTRAINT "Appointment_clientId_fkey" FOREIGN KEY ("clientId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Appointment" ADD CONSTRAINT "Appointment_stylistId_fkey" FOREIGN KEY ("stylistId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,7 +26,9 @@ model User {
   createdAt      DateTime       @default(now())
   updatedAt      DateTime       @updatedAt
   roleId         String
-  appointments   Appointment[]
+  createdAppointments  Appointment[] @relation("AppointmentCreator")
+  clientAppointments   Appointment[] @relation("AppointmentClient")
+  stylistAppointments  Appointment[] @relation("AppointmentStylist")
   client         Client?
   notifications  Notification[]
   stylist        Stylist?
@@ -39,7 +41,6 @@ model Client {
   createdAt    DateTime      @default(now())
   updatedAt    DateTime      @updatedAt
   userId       String        @unique
-  appointments Appointment[]
   user         User          @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
@@ -48,7 +49,6 @@ model Stylist {
   createdAt    DateTime      @default(now())
   updatedAt    DateTime      @updatedAt
   userId       String        @unique
-  appointments Appointment[]
   user         User          @relation(fields: [userId], references: [id], onDelete: Cascade)
   stylistServices StylistService[]
  
@@ -120,11 +120,11 @@ model Appointment {
   stylistId   String?
   scheduleId  String
   statusId    String
-  client      Client            @relation(fields: [clientId], references: [id])
+  user        User              @relation("AppointmentCreator", fields: [userId], references: [id])
+  client      User              @relation("AppointmentClient", fields: [clientId], references: [id])
+  stylist     User?             @relation("AppointmentStylist", fields: [stylistId], references: [id])
   schedule    Schedule          @relation(fields: [scheduleId], references: [id])
   status      AppointmentStatus @relation(fields: [statusId], references: [id])
-  stylist     Stylist?          @relation(fields: [stylistId], references: [id])
-  user        User              @relation(fields: [userId], references: [id])
   payments    Payment[]
   services    Service[]         @relation("AppointmentToService")
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -382,8 +382,8 @@ async function main() {
   const appointment1 = await prisma.appointment.create({
     data: {
       userId: client1.id,
-      clientId: client1.client!.id,
-      stylistId: stylist1.stylist!.id,
+      clientId: client1.id,
+      stylistId: stylist1.id,
       statusId: confirmedStatus.id,
       scheduleId: schedules[0].id,
       dateTime: futureDateAt10,
@@ -401,8 +401,8 @@ async function main() {
   const appointment2 = await prisma.appointment.create({
     data: {
       userId: client2.id,
-      clientId: client2.client!.id,
-      stylistId: stylist2.stylist!.id,
+      clientId: client2.id,
+      stylistId: stylist2.id,
       statusId: completedStatus.id,
       scheduleId: schedules[2].id,
       dateTime: pastDateAt15,

--- a/src/docs/business-rules/06-appointments.md
+++ b/src/docs/business-rules/06-appointments.md
@@ -1,6 +1,6 @@
 # Citas (Appointments) - Reglas de Negocio
 
-> Última actualización: 2026-06-27 | Versión: 3.0
+> Última actualización: 2026-06-29 | Versión: 4.0
 
 ---
 
@@ -19,11 +19,11 @@ El módulo de citas es el núcleo del sistema. Gestiona las reservas de servicio
 | id | UUID | Identificador único |
 | dateTime | DateTime | Fecha y hora de la cita |
 | duration | number | Duración total en minutos (15-480, múltiplos de 15) |
-| userId | UUID | Usuario que creó la cita |
-| clientId | UUID | Cliente asociado a la cita |
+| userId | UUID | ID del usuario (User.id) que creó la cita (auditoría) |
+| clientId | UUID | ID del usuario (User.id) que es el cliente de la cita |
 | scheduleId | UUID | Horario del día asociado |
 | statusId | UUID | Referencia al estado actual (AppointmentStatus) |
-| stylistId | UUID? | Estilista asignado (opcional) |
+| stylistId | UUID? | ID del usuario (User.id) que es el estilista asignado (opcional) |
 | confirmedAt | DateTime? | Fecha de confirmación (null si no confirmada) |
 | serviceIds | string[] | Lista de IDs de servicios incluidos |
 | cancellationReason | string? | Razón de cancelación (máx 500 caracteres) |
@@ -88,6 +88,8 @@ Todas las rutas de consulta requieren solo `authenticate` (sin `authorize`). Cua
 | Cancelar cita | El creador (`userId`), cliente (`clientId`), o estilista (`stylistId`) | `CancelAppointment` valida participación |
 | Actualizar cita | Cualquier autenticado | Solo `authenticate` |
 
+> **Nota sobre ownership:** Los campos `userId`, `clientId` y `stylistId` en Appointment almacenan `User.id`. Esto permite que las comparaciones de ownership (`appointment.clientId === requesterId`) funcionen correctamente, ya que `requesterId` del JWT también es `User.id`.
+
 > **Nota:** ADMIN tiene override de autorización: puede confirmar/cancelar cualquier cita sin necesidad de ser participante. Los demás roles requieren ser participantes de la cita (userId, clientId o stylistId).
 
 ---
@@ -103,8 +105,8 @@ Todas las rutas de consulta requieren solo `authenticate` (sin `authorize`). Cua
 | Servicio requerido | Al menos un `serviceId` debe proporcionarse |
 | Servicios activos | Todos los servicios deben tener `isActive = true`. Se lanza `BusinessRuleError` si algún servicio está inactivo |
 | Estilista ofrece servicios | Si se especifica `stylistId`, el estilista debe tener asignado cada servicio (`IStylistServiceRepository.findByStylistAndService`) y estar ofreciéndolo (`isOffering = true`) |
-| Cliente válido | El `clientId` del DTO es siempre el `User.id` (el ID que el frontend conoce tras login). El use case busca el Client vía `findByUserId()` y lanza `NotFoundError` si no existe |
-| Estilista válido | Si se especifica, el `stylistId` debe existir |
+| Cliente válido | El `clientId` del DTO es el `User.id` del cliente. Se almacena directamente en `Appointment.clientId` sin resolución intermedia |
+| Estilista válido | Si se especifica, el `stylistId` (User.id) se resuelve a `Stylist` via `findByUserId()`. El `Stylist.id` resultante se usa para validar asignaciones de servicio (`StylistService`), pero `Appointment.stylistId` almacena `User.id` |
 | Día laboral | El día debe tener horario efectivo (determinado por `ScheduleAvailabilityService`) |
 | Horario laboral | La hora de la cita debe caer dentro del rango `startTime`-`endTime` del horario efectivo. La cita completa (inicio + duración) debe terminar antes de `endTime` |
 | Sin conflictos | No debe haber citas superpuestas en el mismo horario (validado por `findConflictingAppointments`) |
@@ -233,9 +235,9 @@ NO_SHOW (No Se Presentó)
 
 ## 9. Relaciones con Otros Módulos
 
-- **Auth**: El `userId` identifica quién creó la cita. El `clientId` del DTO es siempre el `User.id`
-- **Clients**: Cada cita está asociada a un cliente (`clientId`). El use case resuelve el Client vía `findByUserId()`
-- **Stylists**: Las citas pueden asignarse a estilistas (`stylistId`). Se valida que el estilista ofrezca los servicios seleccionados (`isOffering = true`)
+- **Auth**: El `userId` identifica quién creó la cita. Los campos `clientId` y `stylistId` también almacenan `User.id`, lo que permite comparaciones directas de ownership contra el `requesterId` del JWT
+- **Clients**: Cada cita está asociada a un cliente via `clientId` (User.id). Las tablas `Client` y `Stylist` siguen existiendo como registros de perfil, pero `Appointment` referencia directamente a `User`
+- **Stylists**: Las citas pueden asignarse a estilistas via `stylistId` (User.id). Para validar asignaciones de servicio, el use case resuelve `User.id → Stylist.id` via `findByUserId()` y usa el `Stylist.id` para consultar `StylistService`
 - **Services**: Las citas incluyen uno o más servicios (`serviceIds`). Se valida que estén activos (`isActive = true`)
 - **Schedules**: Determina disponibilidad de horarios y vincula la cita a un horario (`scheduleId`). Se valida que la cita caiga dentro del horario laboral
 - **Holidays**: Los feriados afectan la disponibilidad de citas. El sistema consulta `ScheduleAvailabilityService` que implementa la prioridad `ScheduleException > Holiday (día cerrado) > Schedule regular`. Al crear un feriado, se cancelan automáticamente las citas activas en esa fecha
@@ -263,4 +265,4 @@ Integrado en: `CreateAppointment` (pasos 4-6), `GetAvailableSlots` (pasos 5-6), 
 
 ## 11. Limitaciones Conocidas
 
-_No hay limitaciones conocidas pendientes. Los issues ISSUE-12, ISSUE-16 e ISSUE-20 fueron resueltos en el plan de intervención v3._
+- **Asimetría de IDs (D9):** `Appointment.stylistId` almacena `User.id`, pero `StylistService.stylistId` sigue almacenando `Stylist.id`. El application layer resuelve esta diferencia via `stylistRepository.findByUserId()`. La migración completa de `StylistService.stylistId` a `User.id` es una mejora futura.

--- a/src/docs/postman/appointments_postman_collection.json
+++ b/src/docs/postman/appointments_postman_collection.json
@@ -104,10 +104,9 @@
                   "if (pm.response.code === 200) {",
                   "    const response = pm.response.json();",
                   "    pm.collectionVariables.set('jwt_token', response.data.token);",
-                  "    if (response.data.user.client) {",
-                  "        pm.collectionVariables.set('client_id', response.data.user.client.id);",
-                  "        console.log('✅ Client ID guardado:', response.data.user.client.id);",
-                  "    }",
+                  "    // Appointment.clientId almacena User.id, no Client.id",
+                  "    pm.collectionVariables.set('client_id', response.data.user.id);",
+                  "    console.log('✅ Client User.id guardado:', response.data.user.id);",
                   "    console.log('✅ Cliente María login exitoso');",
                   "}"
                 ]
@@ -144,10 +143,9 @@
                   "if (pm.response.code === 200) {",
                   "    const response = pm.response.json();",
                   "    pm.collectionVariables.set('jwt_token', response.data.token);",
-                  "    if (response.data.user.stylist) {",
-                  "        pm.collectionVariables.set('stylist_id', response.data.user.stylist.id);",
-                  "        console.log('✅ Stylist ID guardado:', response.data.user.stylist.id);",
-                  "    }",
+                  "    // Appointment.stylistId almacena User.id, no Stylist.id",
+                  "    pm.collectionVariables.set('stylist_id', response.data.user.id);",
+                  "    console.log('✅ Stylist User.id guardado:', response.data.user.id);",
                   "    console.log('✅ Estilista Lucía login exitoso');",
                   "}"
                 ]

--- a/src/docs/session-handoff-v4.md
+++ b/src/docs/session-handoff-v4.md
@@ -1,0 +1,334 @@
+# Session Handoff v4 — Plan de Refinamiento: Calidad, Documentación y Presentación
+
+> Fecha: 2026-06-26 | Autor: Claude + Fernando
+> Contexto: Continuación después del plan de intervención v3 (5 fases completadas)
+> Estado del proyecto: 1127+ tests pasando, 7 módulos, Clean Architecture + DDD + Hexagonal
+
+---
+
+## 1. Contexto — Trabajo completado (plan v3)
+
+### 1.1 Resumen del plan de intervención v3
+
+El plan v3 resolvió 14 items técnicos en 5 fases entre el 2026-06-21 y el 2026-06-26:
+
+| Fase   | Scope                                                                                    | Items                        | Fecha      |
+| :----- | :--------------------------------------------------------------------------------------- | :--------------------------- | :--------- |
+| Fase 1 | Control de acceso híbrido ownership + role-based                                         | P1-P8 (8 items de seguridad) | 2026-06-21 |
+| Fase 2 | Persistencia de `cancellationReason`, `cancelledBy`, `confirmationNotes`, `refundReason` | L2, L3 (ISSUE-16)            | 2026-06-23 |
+| Fase 3 | Desactivación de usuario con cascada para estilistas                                     | L1 (ISSUE-17)                | 2026-06-24 |
+| Fase 4 | Límite de 3 citas activas por cliente por día                                            | L4 (ISSUE-20)                | 2026-06-25 |
+| Fase 5 | Integración holidays↔appointments + auto-cancel al crear feriado                        | F1, F2 (ISSUE-12, ISSUE-21)  | 2026-06-26 |
+
+### 1.2 Arquitectura actual del proyecto
+
+**Stack:** Node.js, TypeScript, Express 5.x, Prisma ORM, PostgreSQL, Docker, Jest
+
+**Módulos (7):**
+
+- `auth` — Registro, login, JWT, roles, perfil, desactivación con cascada
+- `services` — Servicios del salón, categorías, estilistas, asignaciones StylistService
+- `appointments` — Citas, estados, schedules, slots disponibles, conflictos
+- `holidays` — Feriados, excepciones de horario, auto-cancel de citas
+- `payments` — Pagos, estados, reembolsos
+- `notifications` — Sistema de notificaciones
+- `shared` — Excepciones, utilidades, middleware
+
+**Patrones implementados:**
+
+- Clean Architecture (domain → application → infrastructure → presentation)
+- DDD táctico (entities, value objects, repositories, domain services)
+- Hexagonal / Ports & Adapters
+- Autorización híbrida ownership + role-based (RBAC)
+- Domain Service para lógica cross-entity (`ScheduleAvailabilityService`)
+- Acciones de sistema vía entidad directa (no reutilizan use cases de usuario)
+
+### 1.3 Convenciones del proyecto
+
+- Commits en español, convencional commits (`fix(appointments):`, `feat(appointments):`)
+- JSDoc y descripciones de tests (`it()`) en español, nombres de métodos en inglés
+- `unknown` + type narrowing en catch blocks, nunca `catch (error: any)`
+- `_` prefix en propiedades privadas de controllers y entidades Pattern B
+- Layer-by-layer: schema Prisma → domain → infrastructure → application → presentation → tests
+- Tests son fuente de verdad
+- `domain/services/` para lógica de negocio que cruza múltiples entidades
+- Reutilizar métodos existentes del repositorio antes de crear nuevos
+- MCP filesystem: `read_text_file`, `read_multiple_files`, `edit_file`, `write_file`
+- Paths con backslashes de Windows: `C:\Users\Fernando\Desktop\PORTFOLIO2\Turnity-backend\...`
+- Docker: `npm run docker:jest:test` para tests, `npm run docker:prisma:migrate:dev` para migraciones
+
+### 1.4 Decisiones de diseño vigentes (D1-D8, no requieren código)
+
+| ID  | Decisión                                                    | Referencia                                |
+| :-- | :---------------------------------------------------------- | :---------------------------------------- |
+| D1  | Desactivación de categoría sin cascada a servicios          | `02-categories.md` §4.4                   |
+| D2  | Monto de pago independiente de precios de servicios         | `08-payments.md` §11                      |
+| D3  | Unidad monetaria diferente entre módulos (centavos vs base) | `08-payments.md` §11, `03-services.md` §7 |
+| D4  | Múltiples pagos por cita permitidos                         | `08-payments.md` §11                      |
+| D5  | Pagos solo para citas CONFIRMED/COMPLETED                   | `08-payments.md` §11                      |
+| D6  | Feriados con fechas pasadas permitidos (registro histórico) | `09-holidays.md` §10                      |
+| D7  | Feriado sin excepción = día cerrado                         | `09-holidays.md` §10                      |
+| D8  | Defaults de paginación por módulo                           | ISSUE-26                                  |
+| D9  | `StylistService.stylistId` sigue almacenando `Stylist.id` (no migrado a `User.id`) | Hotfix v2 — mejora futura documentada     |
+
+---
+
+## 2. Inventario de items pendientes
+
+### 2.1 Deuda técnica (dead code)
+
+| ID  | Módulo       | Descripción                                                                                                                              | Severidad | Archivos afectados     |
+| :-- | :----------- | :--------------------------------------------------------------------------------------------------------------------------------------- | :-------- | :--------------------- |
+| T1  | Appointments | Método `validateDayAvailability` en `CreateAppointment.ts` ya no se llama (reemplazado por validación inline con `getEffectiveSchedule`) | BAJA      | `CreateAppointment.ts` |
+| T2  | Appointments | Método `generateBaseSlots` en `GetAvailableSlots.ts` reemplazado por `generateBaseSlotsFromTimes`                                        | BAJA      | `GetAvailableSlots.ts` |
+| T3  | Appointments | Método `getWorkingSchedule` en `GetAvailableSlots.ts` reemplazado por `scheduleAvailabilityService.getEffectiveSchedule`                 | BAJA      | `GetAvailableSlots.ts` |
+
+### 2.2 Tests faltantes
+
+| ID  | Módulo       | Descripción                                                                                                                | Severidad | Archivos a crear                                                                   |
+| :-- | :----------- | :------------------------------------------------------------------------------------------------------------------------- | :-------- | :--------------------------------------------------------------------------------- |
+| TS1 | Appointments | `ScheduleAvailabilityService` no tiene tests unitarios propios. Cubre la lógica de prioridad Exception > Holiday > Regular | MEDIA     | `tests/unit/appointments/domain/services/ScheduleAvailabilityService.unit.test.ts` |
+| TS2 | Auth         | `DeactivateUser` no tiene tests unitarios propios. Cubre cascada para STYLIST y no-cascada para otros roles                | MEDIA     | `tests/unit/auth/application/use-cases/DeactivateUser.unit.test.ts`                |
+
+### 2.3 Documentación desactualizada
+
+| ID  | Módulo       | Descripción                                                                                                                                       | Severidad | Archivos afectados                           |
+| :-- | :----------- | :------------------------------------------------------------------------------------------------------------------------------------------------ | :-------- | :------------------------------------------- |
+| DC1 | Appointments | `06-appointments.md` no documenta: límite diario de 3 citas, integración con holidays, prioridad de disponibilidad, `ScheduleAvailabilityService` | MEDIA     | `src/docs/business-rules/06-appointments.md` |
+| DC2 | Holidays     | `09-holidays.md` no documenta: auto-cancel de citas al crear feriado, integración con appointments                                                | MEDIA     | `src/docs/business-rules/09-holidays.md`     |
+| DC3 | Auth         | `01-auth.md` no documenta: endpoint de desactivación, cascada para STYLIST, response con `cascadeSummary`                                         | MEDIA     | `src/docs/business-rules/01-auth.md`         |
+| DC4 | Payments     | `08-payments.md` no documenta: campo `refundReason` en responses                                                                                  | BAJA      | `src/docs/business-rules/08-payments.md`     |
+
+### 2.4 Colecciones Postman
+
+| ID  | Módulo       | Descripción                                                                    | Severidad | Archivos afectados                |
+| :-- | :----------- | :----------------------------------------------------------------------------- | :-------- | :-------------------------------- |
+| PM1 | Auth         | Falta request para `PATCH /auth/users/:id/deactivate`                          | MEDIA     | Colección Postman de Auth         |
+| PM2 | Appointments | Responses no incluyen `cancellationReason`, `cancelledBy`, `confirmationNotes` | BAJA      | Colección Postman de Appointments |
+| PM3 | Payments     | Responses no incluyen `refundReason`                                           | BAJA      | Colección Postman de Payments     |
+
+### 2.5 README y presentación del proyecto
+
+| ID  | Descripción                                                                                   | Severidad |
+| :-- | :-------------------------------------------------------------------------------------------- | :-------- |
+| RD1 | README actual no refleja la arquitectura completa, los módulos, ni las features implementadas | ALTA      |
+| RD2 | Sin diagrama de arquitectura visual (módulos, capas, dependencias)                            | MEDIA     |
+| RD3 | Sin instrucciones claras de setup local (Docker, migraciones, seed, tests)                    | MEDIA     |
+| RD4 | Sin sección de features/endpoints destacados para un portfolio                                | MEDIA     |
+
+### 2.6 Features avanzadas (opcionales)
+
+| ID  | Descripción                                                                         | Severidad | Notas                                                                    |
+| :-- | :---------------------------------------------------------------------------------- | :-------- | :----------------------------------------------------------------------- |
+| FA1 | Swagger/OpenAPI para documentación interactiva de la API                            | MEDIA     | Mejora la presentación como portfolio, alternativa profesional a Postman |
+| FA2 | Tests de integración/E2E para flujos nuevos (desactivación, holidays↔appointments) | MEDIA     | Los flujos nuevos solo tienen tests unitarios                            |
+| FA3 | Rate limiting en endpoints públicos                                                 | BAJA      | Protección contra abuso, buena práctica                                  |
+| FA4 | Logging estructurado (Winston/Pino)                                                 | BAJA      | Observabilidad, buena práctica                                           |
+| FA5 | Health check endpoint (`GET /health`)                                               | BAJA      | Estándar para deployments                                                |
+
+---
+
+## 3. Plan de intervención — Fases propuestas
+
+### Fase 1 — Limpieza de dead code (T1-T3)
+
+**Severidad:** BAJA | **Estimación:** Puntual | **Dependencias:** Ninguna
+
+Eliminar 3 métodos que quedaron sin uso después de la integración con `ScheduleAvailabilityService`.
+
+| Orden | ID  | Acción                                                       |
+| :---- | :-- | :----------------------------------------------------------- |
+| 1     | T1  | Eliminar `validateDayAvailability` de `CreateAppointment.ts` |
+| 2     | T2  | Eliminar `generateBaseSlots` de `GetAvailableSlots.ts`       |
+| 3     | T3  | Eliminar `getWorkingSchedule` de `GetAvailableSlots.ts`      |
+
+### Fase 2 — Tests unitarios faltantes (TS1-TS2)
+
+**Severidad:** MEDIA | **Estimación:** Moderada | **Dependencias:** Ninguna
+
+| Orden | ID  | Acción                                                                                                                                                                                                                                  |
+| :---- | :-- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 4     | TS1 | Crear tests para `ScheduleAvailabilityService`: prioridad exception > holiday > regular, `isDayClosed`, día sin horario, día con excepción, día feriado sin excepción                                                                   |
+| 5     | TS2 | Crear tests para `DeactivateUser`: desactivación exitosa, cascada STYLIST (cancela citas + stopOffering), no-cascada para CLIENT/ADMIN, usuario ya inactivo, usuario no encontrado, graceful degradation (STYLIST sin registro Stylist) |
+
+### Fase 3 — Actualización de business rules (DC1-DC4)
+
+**Severidad:** MEDIA | **Estimación:** Moderada | **Dependencias:** Ninguna
+
+| Orden | ID  | Acción                                                                                                                                             |
+| :---- | :-- | :------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 6     | DC1 | Actualizar `06-appointments.md` con: límite diario, `ScheduleAvailabilityService`, prioridad de disponibilidad, campos de cancelación/confirmación |
+| 7     | DC2 | Actualizar `09-holidays.md` con: auto-cancel al crear feriado, integración cross-module                                                            |
+| 8     | DC3 | Actualizar `01-auth.md` con: endpoint de desactivación, cascada STYLIST, response DTO                                                              |
+| 9     | DC4 | Actualizar `08-payments.md` con: campo `refundReason` en responses                                                                                 |
+
+### Fase 4 — Colecciones Postman (PM1-PM3)
+
+**Severidad:** MEDIA | **Estimación:** Puntual | **Dependencias:** Fase 3 (para tener la doc actualizada como referencia)
+
+| Orden | ID  | Acción                                                                                            |
+| :---- | :-- | :------------------------------------------------------------------------------------------------ |
+| 10    | PM1 | Agregar request `PATCH /auth/users/:id/deactivate` con ejemplo de response con `cascadeSummary`   |
+| 11    | PM2 | Actualizar responses de Appointments con `cancellationReason`, `cancelledBy`, `confirmationNotes` |
+| 12    | PM3 | Actualizar responses de Payments con `refundReason`                                               |
+
+### Fase 5 — README y presentación (RD1-RD4)
+
+**Severidad:** ALTA | **Estimación:** Extensa | **Dependencias:** Fases 1-4 (para documentar el estado final)
+
+| Orden | ID  | Acción                                                                                                      |
+| :---- | :-- | :---------------------------------------------------------------------------------------------------------- |
+| 13    | RD1 | Reescribir README con: descripción del proyecto, stack, arquitectura, módulos, features clave               |
+| 14    | RD2 | Crear diagrama de arquitectura (módulos, capas, dependencias cross-module) — puede ser Mermaid en el README |
+| 15    | RD3 | Agregar sección de setup local: requisitos, Docker, migraciones, seed, tests, variables de entorno          |
+| 16    | RD4 | Agregar sección de endpoints/features destacados con ejemplos de request/response                           |
+
+### Fase 6 — Features avanzadas (FA1-FA5) — OPCIONAL
+
+**Severidad:** Variable | **Estimación:** Extensa | **Dependencias:** Fases 1-5
+
+| Orden | ID  | Acción                                                                                 |
+| :---- | :-- | :------------------------------------------------------------------------------------- |
+| 17    | FA1 | Swagger/OpenAPI: configurar `swagger-jsdoc` o `tsoa`, documentar endpoints con schemas |
+| 18    | FA2 | Tests de integración/E2E para flujos de desactivación y holidays↔appointments         |
+| 19    | FA5 | Health check endpoint `GET /health` con estado de DB y uptime                          |
+| 20    | FA3 | Rate limiting con `express-rate-limit` en endpoints públicos                           |
+| 21    | FA4 | Logging estructurado con Winston o Pino                                                |
+
+---
+
+## 4. Archivos clave por fase
+
+### Fase 1 (dead code)
+
+```
+src/modules/appointments/application/use-cases/CreateAppointment.ts
+src/modules/appointments/application/use-cases/GetAvailableSlots.ts
+```
+
+### Fase 2 (tests)
+
+```
+src/modules/appointments/domain/services/ScheduleAvailabilityService.ts
+src/modules/auth/application/use-cases/DeactivateUser.ts
+tests/unit/appointments/domain/services/ (crear directorio)
+tests/unit/auth/application/use-cases/DeactivateUser.unit.test.ts (crear)
+```
+
+### Fase 3 (business rules)
+
+```
+src/docs/business-rules/01-auth.md
+src/docs/business-rules/06-appointments.md
+src/docs/business-rules/08-payments.md
+src/docs/business-rules/09-holidays.md
+```
+
+### Fase 4 (Postman)
+
+```
+Buscar colecciones en el proyecto: *.postman_collection.json
+```
+
+### Fase 5 (README)
+
+```
+README.md
+```
+
+---
+
+## 5. Flujo de trabajo entre sesiones
+
+### 5.1 Inicio de sesión
+
+1. **Leer el handoff vigente** (`session-handoff-vN.md`) para restaurar contexto completo
+2. No se necesita prompt adicional — el handoff tiene todo el contexto necesario
+
+### 5.2 Planificación antes de implementar
+
+1. **Explorar el código** relevante antes de proponer cambios (leer use cases, entidades, repos, tests)
+2. **Presentar plan técnico** con archivos afectados, orden layer-by-layer, y preguntas de diseño
+3. **Esperar validación** de Fernando antes de escribir código
+4. Si hay decisiones de diseño (ej: ¿servicio de dominio o inline?), presentar opciones con tradeoffs
+
+### 5.3 Implementación
+
+1. **Layer-by-layer:** Schema Prisma → Domain (entidades, servicios) → Infrastructure (repos, mappers) → Application (use cases, DTOs) → Presentation (controller, routes) → Tests
+2. **Single-pass editing:** cada archivo se toca una vez por fase cuando es posible
+3. **Checkpoints incrementales:** correr tests después de cada grupo de cambios, no esperar al final
+4. Si un test falla, corregir antes de seguir con el siguiente archivo
+
+### 5.4 Tests
+
+1. Correr tests unitarios del módulo afectado primero: `npm run docker:jest:test -- tests/unit/modulo/`
+2. Correr suite completo antes de commitear: `npm run docker:jest:test -- tests`
+3. Si un test existente falla por el cambio, evaluar si el test debe actualizarse o el cambio revertirse
+4. Los tests son fuente de verdad para el comportamiento esperado
+
+### 5.5 Commits y PRs
+
+1. **Commits granulares** por capa arquitectónica (no un commit gigante por fase)
+2. **Convencional commits** en español: `feat(módulo):`, `fix(módulo):`, `test(módulo):`, `docs:`, `style:`
+3. **Título de PR** descriptivo con referencia a ISSUE si aplica
+4. **Descripción de PR** con: Resumen, Problema, Solución (detalle técnico), Testing
+5. Fernando hace merge y push
+
+### 5.6 Cierre de sesión
+
+1. **Actualizar handoff** marcando fases completadas con fecha y resumen
+2. **Marcar siguiente fase** como `← SIGUIENTE`
+3. **Agregar preguntas** a resolver antes de implementar la próxima fase
+4. **Documentar nuevas convenciones** que se hayan establecido durante la sesión
+5. Commitear y pushear el handoff actualizado
+
+---
+
+## 6. Instrucciones para el nuevo chat
+
+1. **Leer este documento** para obtener contexto completo del proyecto y el plan
+2. **Leer `session-handoff-v3.md`** si se necesita detalle técnico de alguna fase anterior
+3. **Empezar por Fase 1** (limpieza de dead code) — es rápida y reduce ruido
+4. **Seguir el orden propuesto** — cada fase prepara la siguiente
+5. **Convenciones a respetar:** ver sección 1.3
+6. **Correr tests incrementalmente** después de cada grupo de cambios
+7. **Fase 6 es opcional** — evaluar con Fernando si aporta valor al portfolio antes de implementar
+
+---
+
+## 7. Progreso de ejecución — Sesión 2026-06-28
+
+### Fases completadas
+
+| Fase | Items | Estado | Fecha |
+|------|-------|--------|-------|
+| Fase 1 | T1-T3 (dead code) | ✅ Completada | 2026-06-28 |
+| Fase 2 | TS1-TS2 (tests unitarios) | ✅ Completada | 2026-06-28 |
+| Fase 3 | DC1-DC4 (business rules) | ✅ Completada | 2026-06-28 |
+| Fase 4 | PM1-PM3 (Postman) | ✅ Completada | 2026-06-28 |
+| Fase 5 | RD1-RD4 (README) | ✅ Completada | 2026-06-28 |
+| Fase 6 | FA1-FA5 (features avanzadas) | Pendiente (opcional) | — |
+
+### Trabajo adicional realizado
+
+- Fix preexistente en `ScheduleRepository.integration.test.ts`: cascada cleanup SATURDAY (payments → appointments → schedules)
+- Eliminación de TODO stale de ISSUE-12 en `CreateAppointment.validateAvailability()`
+- Verificación cruzada docs↔código: 2 discrepancias corregidas en `09-holidays.md` (cancellationReason y cancelledAppointmentsCount)
+
+### Convención actualizada
+
+- `describe()` e `it()` en **inglés**, con comentario en **español** arriba de cada `it()` para contexto
+- JSDoc sigue en español
+
+### Descubrimiento crítico: Bug de ownership en Appointment
+
+Durante la revisión de Fase 5, se descubrió que `clientId` y `stylistId` en Appointment almacenan `Client.id` y `Stylist.id` respectivamente, pero todas las ownership checks comparan contra `User.id` (del JWT). Esto causa que las comparaciones nunca matcheen, impidiendo a clientes/estilistas gestionar citas creadas por otro usuario (ej: ADMIN crea para un cliente, el cliente no puede cancelar).
+
+**Plan de corrección:** `INTERVENTION_PLAN_v2.md` — hotfix que migra `clientId`/`stylistId` para almacenar `User.id` directamente. Impacta schema Prisma, CreateAppointment, DeactivateUser, 10+ tests, helpers, docs.
+
+**Asimetría conocida post-hotfix:** `Appointment.stylistId` almacena `User.id`, pero `StylistService.stylistId` sigue almacenando `Stylist.id`. No es un bug — `CreateAppointment` y `UpdateAppointment` resuelven `User.id → Stylist.id` via `stylistRepository.findByUserId()` para validar asignaciones. La migración de `StylistService.stylistId` a `User.id` es una mejora futura separada con su propia cadena de cambios (schema, seed, StylistServiceRepository, tests).
+
+### Siguiente paso
+
+1. Hacer push del PR con Fases 1-5 completadas
+2. Implementar `INTERVENTION_PLAN_v2.md` en una nueva rama/sesión

--- a/src/modules/appointments/AppointmentContainer.ts
+++ b/src/modules/appointments/AppointmentContainer.ts
@@ -17,11 +17,9 @@ import { PrismaScheduleRepository } from './infrastructure/persistence/PrismaSch
 import { IServiceRepository } from '../services/domain/repositories/IServiceRepository';
 import { IStylistRepository } from '../services/domain/repositories/IStylistRepository';
 import { IStylistServiceRepository } from '../services/domain/repositories/IStylistServiceRepository';
-import { IClientRepository } from '../auth/domain/repositories/IClientRepository';
 import { PrismaServiceRepository } from '../services/infrastructure/persistence/PrismaServiceRepository';
 import { PrismaStylistRepository } from '../services/infrastructure/persistence/PrismaStylistRepository';
 import { PrismaStylistServiceRepository } from '../services/infrastructure/persistence/PrismaStylistServiceRepository';
-import { PrismaClientRepository } from '../auth/infrastructure/persistence/PrismaClientRepository';
 
 // Repositorios de módulo holidays (para integración holidays↔appointments)
 import { IHolidayRepository } from '../holidays/domain/repositories/IHolidayRepository';
@@ -73,7 +71,6 @@ export class AppointmentContainer {
   private _serviceRepository: IServiceRepository;
   private _stylistRepository: IStylistRepository;
   private _stylistServiceRepository: IStylistServiceRepository;
-  private _clientRepository: IClientRepository;
 
   /**
    * Constructor privado que inicializa todas las dependencias del módulo
@@ -117,7 +114,6 @@ export class AppointmentContainer {
     this._serviceRepository = new PrismaServiceRepository(this.prisma);
     this._stylistRepository = new PrismaStylistRepository(this.prisma);
     this._stylistServiceRepository = new PrismaStylistServiceRepository(this.prisma);
-    this._clientRepository = new PrismaClientRepository(this.prisma);
 
     // Repositorios de módulo holidays
     const holidayRepository: IHolidayRepository = new PrismaHolidayRepository(this.prisma);
@@ -138,7 +134,6 @@ export class AppointmentContainer {
       this._serviceRepository,
       this._stylistRepository,
       this._stylistServiceRepository,
-      this._clientRepository,
       scheduleAvailabilityService,
     );
 
@@ -313,13 +308,5 @@ export class AppointmentContainer {
    */
   get stylistRepository(): IStylistRepository {
     return this._stylistRepository;
-  }
-
-  /**
-   * Obtiene el repositorio de clientes configurado
-   * @returns Instancia de ClientRepository para uso directo o testing
-   */
-  get clientRepository(): IClientRepository {
-    return this._clientRepository;
   }
 }

--- a/src/modules/appointments/application/dto/response/AppointmentDto.ts
+++ b/src/modules/appointments/application/dto/response/AppointmentDto.ts
@@ -17,25 +17,19 @@ export interface AppointmentDto {
   statusId: string;
   serviceIds: string[];
 
-  // Relaciones pobladas (opcionales)
+  // Relaciones pobladas (opcionales — clientId/stylistId apuntan a User.id)
   client?: {
     id: string;
-    user: {
-      id: string;
-      name: string;
-      email: string;
-      phone: string;
-    };
+    name: string;
+    email: string;
+    phone: string;
   };
 
   stylist?: {
     id: string;
-    user: {
-      id: string;
-      name: string;
-      email: string;
-      phone: string;
-    };
+    name: string;
+    email: string;
+    phone: string;
   };
 
   status?: {

--- a/src/modules/appointments/application/use-cases/CreateAppointment.ts
+++ b/src/modules/appointments/application/use-cases/CreateAppointment.ts
@@ -5,7 +5,6 @@ import { IScheduleRepository } from '../../domain/repositories/IScheduleReposito
 import { IServiceRepository } from '../../../services/domain/repositories/IServiceRepository';
 import { IStylistRepository } from '../../../services/domain/repositories/IStylistRepository';
 import { IStylistServiceRepository } from '../../../services/domain/repositories/IStylistServiceRepository';
-import { IClientRepository } from '../../../auth/domain/repositories/IClientRepository';
 import { CreateAppointmentDto } from '../dto/request/CreateAppointmentDto';
 import { AppointmentDto } from '../dto/response/AppointmentDto';
 import { ValidationError } from '../../../../shared/exceptions/ValidationError';
@@ -29,7 +28,6 @@ export class CreateAppointment {
     private serviceRepository: IServiceRepository,
     private stylistRepository: IStylistRepository,
     private stylistServiceRepository: IStylistServiceRepository,
-    private clientRepository: IClientRepository,
     private scheduleAvailabilityService: ScheduleAvailabilityService,
   ) {}
 
@@ -80,8 +78,8 @@ export class CreateAppointment {
     // 1. Validar datos básicos
     await this.validateBasicData(createDto, userId);
 
-    // 2. Validar que todas las entidades relacionadas existen y obtener Client.id real
-    const clientId = await this.validateRelatedEntitiesAndGetClientId(createDto);
+    // 2. Validar que todas las entidades relacionadas existen
+    await this.validateRelatedEntities(createDto);
 
     // 3. Calcular duración total si no se proporciona
     const totalDuration = await this.calculateTotalDuration(createDto);
@@ -108,17 +106,17 @@ export class CreateAppointment {
     await this.validateAvailability(createDto, totalDuration);
 
     // 9. Validar límite diario de citas por cliente
-    await this.validateDailyAppointmentLimit(clientId, createDto.dateTime);
+    await this.validateDailyAppointmentLimit(createDto.clientId, createDto.dateTime);
 
     // 10. Obtener estado inicial (pendiente)
     const pendingStatus = await this.getPendingStatus();
 
-    // 11. Crear la entidad de cita con el Client.id correcto
+    // 11. Crear la entidad de cita
     const appointment = Appointment.create(
       new Date(createDto.dateTime),
       totalDuration,
       userId,
-      clientId, // Usar el Client.id real, no el userId del DTO
+      createDto.clientId,
       schedule.id,
       pendingStatus.id,
       createDto.stylistId,
@@ -175,28 +173,21 @@ export class CreateAppointment {
   }
 
   /**
-   * Valida que todas las entidades relacionadas existen y retorna el Client.id real
-   * El clientId del DTO siempre se interpreta como User.id (que es lo que el frontend
-   * conoce tras el login). El use case busca el registro Client asociado a ese usuario.
+   * Valida que todas las entidades relacionadas existen
    * @param createDto - Datos de la cita
-   * @returns Promise con el Client.id real
    * @throws NotFoundError si alguna entidad no existe
+   * @throws BusinessRuleError si un servicio está inactivo o el estilista no lo ofrece
    */
-  private async validateRelatedEntitiesAndGetClientId(createDto: CreateAppointmentDto): Promise<string> {
-    // El clientId del DTO es siempre el User.id del cliente
-    // Buscar el registro Client asociado a ese usuario
-    const client = await this.clientRepository.findByUserId(createDto.clientId);
-
-    if (!client) {
-      throw new NotFoundError('Client', createDto.clientId);
-    }
-
+  private async validateRelatedEntities(createDto: CreateAppointmentDto): Promise<void> {
     // Validar que el estilista existe (si se proporciona)
+    // stylistId en el DTO es User.id; se resuelve a Stylist para validar asignaciones de servicio
+    let resolvedStylistId: string | undefined;
     if (createDto.stylistId) {
-      const stylist = await this.stylistRepository.findById(createDto.stylistId);
+      const stylist = await this.stylistRepository.findByUserId(createDto.stylistId);
       if (!stylist) {
         throw new NotFoundError('Stylist', createDto.stylistId);
       }
+      resolvedStylistId = stylist.id;
     }
 
     // Validar que todos los servicios existen y están activos
@@ -211,10 +202,10 @@ export class CreateAppointment {
     }
 
     // Validar que el estilista ofrezca los servicios seleccionados (si se especifica estilista)
-    if (createDto.stylistId) {
+    if (resolvedStylistId) {
       for (const serviceId of createDto.serviceIds) {
         const assignment = await this.stylistServiceRepository.findByStylistAndService(
-          createDto.stylistId,
+          resolvedStylistId,
           serviceId,
         );
         if (!assignment) {
@@ -226,7 +217,7 @@ export class CreateAppointment {
       }
     }
 
-    return client.id;
+    return;
   }
 
   /**
@@ -277,7 +268,7 @@ export class CreateAppointment {
   /**
    * Valida que el cliente no exceda el límite diario de citas activas
    * Solo cuenta citas no canceladas (PENDING, CONFIRMED, COMPLETED)
-   * @param clientId - ID del cliente (Client.id)
+   * @param clientId - ID del usuario cliente (User.id)
    * @param dateTimeStr - Fecha y hora de la cita en formato ISO string
    * @throws BusinessRuleError si el cliente alcanzó el límite diario
    */

--- a/src/modules/appointments/application/use-cases/UpdateAppointment.ts
+++ b/src/modules/appointments/application/use-cases/UpdateAppointment.ts
@@ -279,11 +279,13 @@ export class UpdateAppointment {
 
   /**
    * Actualiza el estilista asignado
+   * @param appointment - La cita a actualizar
+   * @param newStylistId - User.id del nuevo estilista (Appointment.stylistId almacena User.id)
    */
   private async updateStylist(appointment: Appointment, newStylistId: string): Promise<void> {
     if (newStylistId) {
-      // Verificar que el estilista existe
-      const stylist = await this.stylistRepository.findById(newStylistId);
+      // newStylistId es User.id; verificar que existe un estilista con ese userId
+      const stylist = await this.stylistRepository.findByUserId(newStylistId);
       if (!stylist) {
         throw new NotFoundError('Stylist', newStylistId);
       }

--- a/src/modules/auth/application/use-cases/DeactivateUser.ts
+++ b/src/modules/auth/application/use-cases/DeactivateUser.ts
@@ -111,8 +111,10 @@ export class DeactivateUser {
     }
 
     // Ejecutar ambas cascadas
+    // cancelActiveAppointments recibe User.id porque Appointment.stylistId ahora almacena User.id
+    // deactivateStylistServices recibe Stylist.id porque StylistService.stylistId sigue apuntando a Stylist.id
     const [appointmentsCancelled, servicesDeactivated] = await Promise.all([
-      this.cancelActiveAppointments(stylist.id),
+      this.cancelActiveAppointments(userId),
       this.deactivateStylistServices(stylist.id),
     ]);
 
@@ -121,10 +123,10 @@ export class DeactivateUser {
 
   /**
    * Cancela todas las citas activas (PENDING/CONFIRMED) del estilista
-   * @param stylistId - ID del estilista
+   * @param stylistUserId - ID del usuario estilista (User.id), ya que Appointment.stylistId almacena User.id
    * @returns Cantidad de citas canceladas
    */
-  private async cancelActiveAppointments(stylistId: string): Promise<number> {
+  private async cancelActiveAppointments(stylistUserId: string): Promise<number> {
     // Obtener el estado CANCELLED
     const cancelledStatus = await this.appointmentStatusRepository.findByName(
       AppointmentStatusEnum.CANCELLED,
@@ -146,7 +148,7 @@ export class DeactivateUser {
     }
 
     // Obtener todas las citas del estilista
-    const allAppointments = await this.appointmentRepository.findByStylistId(stylistId);
+    const allAppointments = await this.appointmentRepository.findByStylistId(stylistUserId);
 
     // Filtrar solo las activas (PENDING/CONFIRMED)
     const activeAppointments = allAppointments.filter(a =>

--- a/tests/integration/appointments/repositories/AppointmentRepository.integration.test.ts
+++ b/tests/integration/appointments/repositories/AppointmentRepository.integration.test.ts
@@ -22,24 +22,26 @@ describe('AppointmentRepository Integration Tests', () => {
     const clientUser = await createTestUser('CLIENT');
     const clientUserId = clientUser.user?.id || clientUser.id;
     
-    // Crear el registro Client asociado al usuario
-    const client = await testPrisma.client.create({
+    // Crear el registro Client asociado al usuario (necesario para integridad de DB)
+    await testPrisma.client.create({
       data: {
         userId: clientUserId,
       },
     });
-    testClientId = client.id;
+    // Appointment.clientId almacena User.id, no Client.id
+    testClientId = clientUserId;
 
     const stylistUser = await createTestUser('STYLIST');
     const stylistUserId = stylistUser.user?.id || stylistUser.id;
     
-    // Crear el registro Stylist asociado al usuario
-    const stylist = await testPrisma.stylist.create({
+    // Crear el registro Stylist asociado al usuario (necesario para integridad de DB)
+    await testPrisma.stylist.create({
       data: {
         userId: stylistUserId,
       },
     });
-    testStylistId = stylist.id;
+    // Appointment.stylistId almacena User.id, no Stylist.id
+    testStylistId = stylistUserId;
 
     // Obtener schedule y status del seed
     const schedule = await testPrisma.schedule.findFirst();

--- a/tests/setup/appointments-helpers.ts
+++ b/tests/setup/appointments-helpers.ts
@@ -117,8 +117,8 @@ async function getOrCreateBaseData() {
 
   return {
     userId,
-    clientId: client.id,  // Ahora usa Client.id correcto
-    stylistId: stylist.id, // Ahora usa Stylist.id correcto
+    clientId: clientUserId,   // User.id del cliente (Appointment.clientId almacena User.id)
+    stylistId: stylistUserId, // User.id del estilista (Appointment.stylistId almacena User.id)
     scheduleId: schedule.id,
     statusId: status.id
   };
@@ -256,22 +256,13 @@ export async function cleanupTestAppointments(): Promise<void> {
   const testUserIds = testUsers.map(user => user.id);
 
   if (testUserIds.length > 0) {
-    // Obtener Client IDs asociados a los usuarios de prueba
-    const testClients = await testPrisma.client.findMany({
-      where: {
-        userId: { in: testUserIds }
-      },
-      select: { id: true }
-    });
-
-    const testClientIds = testClients.map(client => client.id);
-
-    // Obtener IDs de appointments de prueba
+    // Appointment.clientId ahora almacena User.id, no Client.id
+    // Buscar appointments por userId o clientId (ambos son User.id)
     const testAppointments = await testPrisma.appointment.findMany({
       where: {
         OR: [
           { userId: { in: testUserIds } },
-          { clientId: { in: testClientIds } }
+          { clientId: { in: testUserIds } }
         ]
       },
       select: { id: true }
@@ -293,7 +284,7 @@ export async function cleanupTestAppointments(): Promise<void> {
       where: {
         OR: [
           { userId: { in: testUserIds } },
-          { clientId: { in: testClientIds } }
+          { clientId: { in: testUserIds } }
         ]
       }
     });

--- a/tests/unit/appointments/application/use-cases/CreateAppointment.unit.test.ts
+++ b/tests/unit/appointments/application/use-cases/CreateAppointment.unit.test.ts
@@ -1,17 +1,15 @@
 import { CreateAppointment } from '../../../../../src/modules/appointments/application/use-cases/CreateAppointment';
-import { AppointmentRepository } from '../../../../../src/modules/appointments/domain/repositories/AppointmentRepository';
-import { AppointmentStatusRepository } from '../../../../../src/modules/appointments/domain/repositories/AppointmentStatusRepository';
-import { ScheduleRepository } from '../../../../../src/modules/appointments/domain/repositories/ScheduleRepository';
-import { ServiceRepository } from '../../../../../src/modules/services/domain/repositories/ServiceRepository';
-import { StylistRepository } from '../../../../../src/modules/services/domain/repositories/StylistRepository';
+import { IAppointmentRepository } from '../../../../../src/modules/appointments/domain/repositories/IAppointmentRepository';
+import { IAppointmentStatusRepository } from '../../../../../src/modules/appointments/domain/repositories/IAppointmentStatusRepository';
+import { IScheduleRepository } from '../../../../../src/modules/appointments/domain/repositories/IScheduleRepository';
+import { IServiceRepository } from '../../../../../src/modules/services/domain/repositories/IServiceRepository';
+import { IStylistRepository } from '../../../../../src/modules/services/domain/repositories/IStylistRepository';
 import { IStylistServiceRepository } from '../../../../../src/modules/services/domain/repositories/IStylistServiceRepository';
-import { ClientRepository } from '../../../../../src/modules/auth/domain/repositories/Client';
 import { Appointment } from '../../../../../src/modules/appointments/domain/entities/Appointment';
 import { AppointmentStatus } from '../../../../../src/modules/appointments/domain/entities/AppointmentStatus';
 import { Schedule } from '../../../../../src/modules/appointments/domain/entities/Schedule';
 import { Service } from '../../../../../src/modules/services/domain/entities/Service';
 import { Stylist } from '../../../../../src/modules/services/domain/entities/Stylist';
-import { Client } from '../../../../../src/modules/auth/domain/entities/Client';
 import { CreateAppointmentDto } from '../../../../../src/modules/appointments/application/dto/request/CreateAppointmentDto';
 import { ValidationError } from '../../../../../src/shared/exceptions/ValidationError';
 import { NotFoundError } from '../../../../../src/shared/exceptions/NotFoundError';
@@ -22,28 +20,28 @@ import { generateUuid } from '../../../../../src/shared/utils/uuid';
 
 describe('CreateAppointment Use Case', () => {
   let useCase: CreateAppointment;
-  let mockAppointmentRepository: jest.Mocked<AppointmentRepository>;
-  let mockAppointmentStatusRepository: jest.Mocked<AppointmentStatusRepository>;
-  let mockScheduleRepository: jest.Mocked<ScheduleRepository>;
-  let mockServiceRepository: jest.Mocked<ServiceRepository>;
-  let mockStylistRepository: jest.Mocked<StylistRepository>;
+  let mockAppointmentRepository: jest.Mocked<IAppointmentRepository>;
+  let mockAppointmentStatusRepository: jest.Mocked<IAppointmentStatusRepository>;
+  let mockScheduleRepository: jest.Mocked<IScheduleRepository>;
+  let mockServiceRepository: jest.Mocked<IServiceRepository>;
+  let mockStylistRepository: jest.Mocked<IStylistRepository>;
   let mockStylistServiceRepository: jest.Mocked<IStylistServiceRepository>;
-  let mockClientRepository: jest.Mocked<ClientRepository>;
   let mockScheduleAvailabilityService: jest.Mocked<ScheduleAvailabilityService>;
 
   // Utilidades de fecha dinámicas y mantenibles
   const getNextMonday = (hoursFromNow: number = 48): Date => {
     const future = new Date();
     future.setHours(future.getHours() + hoursFromNow);
-    
+
     // Ajustar al próximo lunes si no es lunes para garantizar día correcto
-    while (future.getDay() !== 1) { // 1 = lunes
+    while (future.getDay() !== 1) {
+      // 1 = lunes
       future.setDate(future.getDate() + 1);
     }
 
     // Fijar hora dentro del horario laboral del mock schedule (09:00-18:00)
     future.setHours(10, 0, 0, 0);
-    
+
     return future;
   };
 
@@ -162,19 +160,6 @@ describe('CreateAppointment Use Case', () => {
     } as unknown as Stylist;
   };
 
-  const createMockClient = (id: string = validClientId, userId: string = generateUuid()): Client => {
-    return {
-      id,
-      userId,
-      preferences: null,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      validate: jest.fn(),
-      updatePreferences: jest.fn(),
-      toPersistence: jest.fn(),
-    } as unknown as Client;
-  };
-
   const createMockSchedule = (
     dayOfWeek: string = 'MONDAY',
     id: string = validScheduleId,
@@ -199,15 +184,20 @@ describe('CreateAppointment Use Case', () => {
   // Helper para configurar mocks exitosos básicos
   const setupBasicSuccessfulMocks = (appointment: Appointment = createMockAppointment()) => {
     const pendingStatus = createMockAppointmentStatus('Pendiente');
-    const client = createMockClient(validClientId);
     const stylist = createMockStylist(validStylistId);
     const service = createMockService(validServiceId1, 60);
     const schedule = createMockSchedule('MONDAY');
-    const stylistService = { stylistId: validStylistId, serviceId: validServiceId1, isOffering: true, customPrice: null, createdAt: new Date(), updatedAt: new Date() };
+    const stylistService = {
+      stylistId: validStylistId,
+      serviceId: validServiceId1,
+      isOffering: true,
+      customPrice: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
 
     mockAppointmentStatusRepository.findByName.mockResolvedValue(pendingStatus);
-    mockClientRepository.findByUserId.mockResolvedValue(client);
-    mockStylistRepository.findById.mockResolvedValue(stylist);
+    mockStylistRepository.findByUserId.mockResolvedValue(stylist);
     mockServiceRepository.findById.mockResolvedValue(service);
     mockStylistServiceRepository.findByStylistAndService.mockResolvedValue(stylistService as any);
     mockScheduleRepository.findAll.mockResolvedValue([schedule]);
@@ -246,7 +236,7 @@ describe('CreateAppointment Use Case', () => {
       countByDateRange: jest.fn(),
       findUpcomingAppointments: jest.fn(),
       findPendingConfirmation: jest.fn(),
-    } as unknown as jest.Mocked<AppointmentRepository>;
+    } as unknown as jest.Mocked<IAppointmentRepository>;
 
     // Mock de AppointmentStatusRepository
     mockAppointmentStatusRepository = {
@@ -260,7 +250,7 @@ describe('CreateAppointment Use Case', () => {
       existsByName: jest.fn(),
       findTerminalStatuses: jest.fn(),
       findActiveStatuses: jest.fn(),
-    } as unknown as jest.Mocked<AppointmentStatusRepository>;
+    } as unknown as jest.Mocked<IAppointmentStatusRepository>;
 
     // Mock de ScheduleRepository
     mockScheduleRepository = {
@@ -272,7 +262,7 @@ describe('CreateAppointment Use Case', () => {
       update: jest.fn(),
       delete: jest.fn(),
       existsById: jest.fn(),
-    } as unknown as jest.Mocked<ScheduleRepository>;
+    } as unknown as jest.Mocked<IScheduleRepository>;
 
     // Mock de ServiceRepository
     mockServiceRepository = {
@@ -287,7 +277,7 @@ describe('CreateAppointment Use Case', () => {
       delete: jest.fn(),
       existsById: jest.fn(),
       existsByName: jest.fn(),
-    } as unknown as jest.Mocked<ServiceRepository>;
+    } as unknown as jest.Mocked<IServiceRepository>;
 
     // Mock de StylistRepository
     mockStylistRepository = {
@@ -298,7 +288,7 @@ describe('CreateAppointment Use Case', () => {
       update: jest.fn(),
       delete: jest.fn(),
       existsById: jest.fn(),
-    } as unknown as jest.Mocked<StylistRepository>;
+    } as unknown as jest.Mocked<IStylistRepository>;
 
     mockStylistServiceRepository = {
       findByStylistAndService: jest.fn(),
@@ -311,18 +301,6 @@ describe('CreateAppointment Use Case', () => {
       delete: jest.fn(),
       existsAssignment: jest.fn(),
     } as unknown as jest.Mocked<IStylistServiceRepository>;
-
-    // Mock de ClientRepository
-    mockClientRepository = {
-      findById: jest.fn(),
-      findByUserId: jest.fn(),
-      findAll: jest.fn(),
-      save: jest.fn(),
-      update: jest.fn(),
-      delete: jest.fn(),
-      existsById: jest.fn(),
-      existsByUserId: jest.fn(),
-    } as unknown as jest.Mocked<ClientRepository>;
 
     mockScheduleAvailabilityService = {
       getEffectiveSchedule: jest.fn().mockResolvedValue({
@@ -340,7 +318,6 @@ describe('CreateAppointment Use Case', () => {
       mockServiceRepository,
       mockStylistRepository,
       mockStylistServiceRepository,
-      mockClientRepository,
       mockScheduleAvailabilityService,
     );
   });
@@ -469,48 +446,9 @@ describe('CreateAppointment Use Case', () => {
   });
 
   describe('Not Found Handling', () => {
-    // Debería lanzar NotFoundError cuando el cliente no existe
-    it('should throw NotFoundError when client does not exist', async () => {
-      mockClientRepository.findByUserId.mockResolvedValue(null);
-
-      await expect(useCase.execute(validCreateDto, validUserId)).rejects.toThrow(
-        new NotFoundError('Client', validClientId),
-      );
-    });
-
-    // Debería encontrar cliente por userId (clientId del DTO siempre es User.id)
-    it('should find client by userId', async () => {
-      const client = createMockClient(validClientId);
-      const stylist = createMockStylist(validStylistId);
-      const service = createMockService(validServiceId1);
-      const pendingStatus = createMockAppointmentStatus('PENDING');
-      const schedule = createMockSchedule('MONDAY');
-      const appointment = createMockAppointment();
-
-      mockClientRepository.findByUserId.mockResolvedValue(client);
-      mockStylistRepository.findById.mockResolvedValue(stylist);
-      mockServiceRepository.findById.mockResolvedValue(service);
-      mockStylistServiceRepository.findByStylistAndService.mockResolvedValue(
-        { stylistId: validStylistId, serviceId: validServiceId1, isOffering: true } as any,
-      );
-      mockAppointmentStatusRepository.findByName.mockResolvedValue(pendingStatus);
-      mockScheduleRepository.findAll.mockResolvedValue([schedule]);
-      mockAppointmentRepository.findConflictingAppointments.mockResolvedValue([]);
-      mockAppointmentRepository.findByClientAndDateRange.mockResolvedValue([]);
-      mockAppointmentRepository.save.mockResolvedValue(appointment);
-
-      const result = await useCase.execute(validCreateDto, validUserId);
-
-      expect(mockClientRepository.findByUserId).toHaveBeenCalledWith(validClientId);
-      expect(mockClientRepository.findById).not.toHaveBeenCalled();
-      expect(result.id).toBe(appointment.id);
-    });
-
     // Debería lanzar NotFoundError cuando el estilista no existe
     it('should throw NotFoundError when stylist does not exist', async () => {
-      const client = createMockClient(validClientId);
-      mockClientRepository.findByUserId.mockResolvedValue(client);
-      mockStylistRepository.findById.mockResolvedValue(null);
+      mockStylistRepository.findByUserId.mockResolvedValue(null);
 
       await expect(useCase.execute(validCreateDto, validUserId)).rejects.toThrow(
         new NotFoundError('Stylist', validStylistId),
@@ -519,11 +457,9 @@ describe('CreateAppointment Use Case', () => {
 
     // Debería lanzar NotFoundError cuando un servicio no existe
     it('should throw NotFoundError when service does not exist', async () => {
-      const client = createMockClient(validClientId);
       const stylist = createMockStylist(validStylistId);
 
-      mockClientRepository.findByUserId.mockResolvedValue(client);
-      mockStylistRepository.findById.mockResolvedValue(stylist);
+      mockStylistRepository.findByUserId.mockResolvedValue(stylist);
       mockServiceRepository.findById.mockResolvedValue(null);
 
       await expect(useCase.execute(validCreateDto, validUserId)).rejects.toThrow(
@@ -533,51 +469,45 @@ describe('CreateAppointment Use Case', () => {
 
     // Debería lanzar BusinessRuleError cuando un servicio no está activo
     it('should throw BusinessRuleError when service is not active', async () => {
-      const client = createMockClient(validClientId);
       const stylist = createMockStylist(validStylistId);
       const inactiveService = createMockService(validServiceId1, 60);
       (inactiveService as any).isActive = false;
 
-      mockClientRepository.findByUserId.mockResolvedValue(client);
-      mockStylistRepository.findById.mockResolvedValue(stylist);
+      mockStylistRepository.findByUserId.mockResolvedValue(stylist);
       mockServiceRepository.findById.mockResolvedValue(inactiveService);
 
-      await expect(useCase.execute(validCreateDto, validUserId)).rejects.toThrow(
-        BusinessRuleError,
-      );
+      await expect(useCase.execute(validCreateDto, validUserId)).rejects.toThrow(BusinessRuleError);
     });
 
     // Debería lanzar BusinessRuleError cuando el estilista no tiene asignado el servicio
     it('should throw BusinessRuleError when stylist does not offer service', async () => {
-      const client = createMockClient(validClientId);
       const stylist = createMockStylist(validStylistId);
       const service = createMockService(validServiceId1, 60);
 
-      mockClientRepository.findByUserId.mockResolvedValue(client);
-      mockStylistRepository.findById.mockResolvedValue(stylist);
+      mockStylistRepository.findByUserId.mockResolvedValue(stylist);
       mockServiceRepository.findById.mockResolvedValue(service);
       mockStylistServiceRepository.findByStylistAndService.mockResolvedValue(null);
 
-      await expect(useCase.execute(validCreateDto, validUserId)).rejects.toThrow(
-        BusinessRuleError,
-      );
+      await expect(useCase.execute(validCreateDto, validUserId)).rejects.toThrow(BusinessRuleError);
     });
 
     // Debería lanzar BusinessRuleError cuando el estilista no está ofreciendo el servicio actualmente
     it('should throw BusinessRuleError when stylist is not currently offering service', async () => {
-      const client = createMockClient(validClientId);
       const stylist = createMockStylist(validStylistId);
       const service = createMockService(validServiceId1, 60);
-      const notOfferingAssignment = { stylistId: validStylistId, serviceId: validServiceId1, isOffering: false };
+      const notOfferingAssignment = {
+        stylistId: validStylistId,
+        serviceId: validServiceId1,
+        isOffering: false,
+      };
 
-      mockClientRepository.findByUserId.mockResolvedValue(client);
-      mockStylistRepository.findById.mockResolvedValue(stylist);
+      mockStylistRepository.findByUserId.mockResolvedValue(stylist);
       mockServiceRepository.findById.mockResolvedValue(service);
-      mockStylistServiceRepository.findByStylistAndService.mockResolvedValue(notOfferingAssignment as any);
-
-      await expect(useCase.execute(validCreateDto, validUserId)).rejects.toThrow(
-        BusinessRuleError,
+      mockStylistServiceRepository.findByStylistAndService.mockResolvedValue(
+        notOfferingAssignment as any,
       );
+
+      await expect(useCase.execute(validCreateDto, validUserId)).rejects.toThrow(BusinessRuleError);
     });
   });
 
@@ -595,9 +525,7 @@ describe('CreateAppointment Use Case', () => {
       const appointment = createMockAppointment();
       setupBasicSuccessfulMocks(appointment);
 
-      await expect(useCase.execute(earlyDto, validUserId)).rejects.toThrow(
-        BusinessRuleError,
-      );
+      await expect(useCase.execute(earlyDto, validUserId)).rejects.toThrow(BusinessRuleError);
     });
 
     // Debería lanzar BusinessRuleError cuando la cita termina después del horario laboral
@@ -614,9 +542,7 @@ describe('CreateAppointment Use Case', () => {
       const appointment = createMockAppointment();
       setupBasicSuccessfulMocks(appointment);
 
-      await expect(useCase.execute(lateDto, validUserId)).rejects.toThrow(
-        BusinessRuleError,
-      );
+      await expect(useCase.execute(lateDto, validUserId)).rejects.toThrow(BusinessRuleError);
     });
   });
 
@@ -624,18 +550,18 @@ describe('CreateAppointment Use Case', () => {
     // Debería lanzar ConflictError cuando hay citas en conflicto
     it('should throw ConflictError when there are conflicting appointments', async () => {
       const conflictingAppointment = createMockAppointment({ id: generateUuid() });
-      const client = createMockClient(validClientId);
       const stylist = createMockStylist(validStylistId);
       const service = createMockService(validServiceId1);
       const pendingStatus = createMockAppointmentStatus('PENDING');
       const schedule = createMockSchedule('MONDAY');
 
-      mockClientRepository.findByUserId.mockResolvedValue(client);
-      mockStylistRepository.findById.mockResolvedValue(stylist);
+      mockStylistRepository.findByUserId.mockResolvedValue(stylist);
       mockServiceRepository.findById.mockResolvedValue(service);
-      mockStylistServiceRepository.findByStylistAndService.mockResolvedValue(
-        { stylistId: validStylistId, serviceId: validServiceId1, isOffering: true } as any,
-      );
+      mockStylistServiceRepository.findByStylistAndService.mockResolvedValue({
+        stylistId: validStylistId,
+        serviceId: validServiceId1,
+        isOffering: true,
+      } as any);
       mockAppointmentStatusRepository.findByName.mockResolvedValue(pendingStatus);
       mockScheduleRepository.findAll.mockResolvedValue([schedule]);
       mockAppointmentRepository.findConflictingAppointments.mockResolvedValue([
@@ -656,8 +582,7 @@ describe('CreateAppointment Use Case', () => {
 
       await useCase.execute(validCreateDto, validUserId);
 
-      expect(mockClientRepository.findByUserId).toHaveBeenCalledWith(validClientId);
-      expect(mockStylistRepository.findById).toHaveBeenCalledWith(validStylistId);
+      expect(mockStylistRepository.findByUserId).toHaveBeenCalledWith(validStylistId);
       expect(mockServiceRepository.findById).toHaveBeenCalledWith(validServiceId1);
       expect(mockAppointmentStatusRepository.findByName).toHaveBeenCalledWith('PENDING');
       expect(mockScheduleRepository.findAll).toHaveBeenCalled();

--- a/tests/unit/appointments/application/use-cases/UpdateAppointment.unit.test.ts
+++ b/tests/unit/appointments/application/use-cases/UpdateAppointment.unit.test.ts
@@ -225,7 +225,7 @@ describe('UpdateAppointment Use Case', () => {
       jest.spyOn(appointment, 'canBeModified').mockReturnValue(true);
       jest.spyOn(appointment, 'isConfirmed').mockReturnValue(true);
       setupBasicSuccessfulMocks(appointment);
-      mockStylistRepository.findById.mockResolvedValue(createMockStylist(validNewStylistId));
+      mockStylistRepository.findByUserId.mockResolvedValue(createMockStylist(validNewStylistId));
       mockServiceRepository.findById.mockResolvedValue(createMockService(validNewServiceId));
 
       const result = await useCase.execute(
@@ -255,7 +255,7 @@ describe('UpdateAppointment Use Case', () => {
       );
 
       expect(result.id).toBe(appointment.id);
-      expect(mockStylistRepository.findById).not.toHaveBeenCalled();
+      expect(mockStylistRepository.findByUserId).not.toHaveBeenCalled();
     });
 
     it('should allow update by assigned stylist', async () => {
@@ -442,7 +442,7 @@ describe('UpdateAppointment Use Case', () => {
       jest.spyOn(appointment, 'canBeModified').mockReturnValue(true);
       setupBasicSuccessfulMocks(appointment);
       const invalidStylistDto: UpdateAppointmentDto = { stylistId: validNewStylistId };
-      mockStylistRepository.findById.mockResolvedValue(null);
+      mockStylistRepository.findByUserId.mockResolvedValue(null);
 
       await expect(
         useCase.execute(validAppointmentId, invalidStylistDto, validRequesterId, adminRole),


### PR DESCRIPTION
## Problema

`Appointment.clientId` almacenaba `Client.id` y `Appointment.stylistId` almacenaba `Stylist.id`, pero todas las ownership checks comparaban contra `User.id` del JWT (`requesterId`). Resultado: cuando un ADMIN creaba una cita para un cliente, ese cliente no podía cancelar/confirmar su propia cita porque `Client.id ≠ User.id`.

## Solución

Migrar ambos campos para almacenar `User.id` directamente, usando relaciones Prisma nombradas (`AppointmentCreator`, `AppointmentClient`, `AppointmentStylist`).

## Cambios por fase

### Fase 1 — Schema y migración
- `prisma/schema.prisma`: FKs de Appointment apuntan a User con relaciones nombradas
- Migración SQL: DROP FKs → UPDATE datos → ADD nuevos FKs
- `prisma/seed.ts`: usa `User.id` para clientId/stylistId

### Fase 2 — Application Layer
- `AppointmentContainer`: eliminar `IClientRepository`/`PrismaClientRepository`
- `CreateAppointment`: `stylistRepository.findByUserId()` + `resolvedStylistId` para validar StylistService
- `UpdateAppointment`: `stylistRepository.findByUserId()` en updateStylist
- `DeactivateUser`: `cancelActiveAppointments(userId)` en vez de `stylist.id`
- `AppointmentDto`: interfaces `client?`/`stylist?` aplanadas

### Fase 3 — Tests unitarios
- `CreateAppointment.unit.test.ts`: eliminado ClientRepository completo, findById → findByUserId
- `UpdateAppointment.unit.test.ts`: findById → findByUserId (3 puntos)
- 6 archivos de test verificados sin cambios necesarios

### Fase 4 — Tests integración/E2E
- `appointments-helpers.ts`: retorna `User.id` para clientId/stylistId, cleanup simplificado
- `AppointmentRepository.integration.test.ts`: testClientId/testStylistId usan `User.id`

### Fase 5 — Documentación
- `06-appointments.md` v4.0: entidad, ownership, relaciones actualizadas
- Postman: login scripts guardan `User.id` en vez de `Client.id`/`Stylist.id`
- `session-handoff-v4.md`: decisión D9 documentada

## Asimetría conocida (D9)

`Appointment.stylistId` → `User.id`, pero `StylistService.stylistId` → `Stylist.id`. El application layer resuelve via `findByUserId()`. Mejora futura: eliminar tablas Client/Stylist y usar User.id en todo el sistema.

## Testing

- 1127+ tests unitarios ✅
- Tests de integración ✅
- Tests E2E ✅