### PR TITLE
docs(session-handoff-v6): actualizar documentación post-refactor Client/Stylist (business rules, Postman, README, Swagger)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,13 +3,13 @@
 ![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6.svg?logo=typescript&logoColor=white)
 ![Express](https://img.shields.io/badge/Express-5.x-000000.svg?logo=express&logoColor=white)
 ![PostgreSQL](https://img.shields.io/badge/PostgreSQL-14%2B-4169E1.svg?logo=postgresql&logoColor=white)
-![Tests](https://img.shields.io/badge/Tests-1127%2B%20passing-brightgreen.svg)
+![Tests](https://img.shields.io/badge/Tests-1118%2B%20passing-brightgreen.svg)
 
 # 💇‍♀️ Turnity Backend
 
 Backend API para sistema de gestión de salones de belleza construido con **Node.js**, **TypeScript**, **Express** y **Prisma ORM**.
 
-Implementa **Clean Architecture**, **DDD táctico** y **Arquitectura Hexagonal** (Ports & Adapters) con 7 módulos de negocio, 1127+ tests automatizados y documentación Swagger interactiva.
+Implementa **Clean Architecture**, **DDD táctico** y **Arquitectura Hexagonal** (Ports & Adapters) con 7 módulos de negocio, 1118+ tests automatizados y documentación Swagger interactiva.
 
 ---
 
@@ -301,7 +301,7 @@ GET    /services/category/:categoryId/active   # Servicios activos por categorí
 POST   /services                               # Crear servicio (ADMIN)
 PUT    /services/:id                           # Actualizar servicio (ADMIN)
 PATCH  /services/:id/activate                  # Activar servicio (ADMIN)
-PATCH  /services/:id/deactivate               # Desactivar servicio (ADMIN)
+PATCH  /services/:id/deactivate                # Desactivar servicio (ADMIN)
 DELETE /services/:id                           # Eliminar servicio (ADMIN)
 ```
 
@@ -322,14 +322,14 @@ DELETE /services/stylists/:stylistId/services/:serviceId   # Remover asignación
 ### Appointments
 
 ```
-POST   /appointments                          # Crear nueva cita (autenticado)
+POST   /appointments                           # Crear nueva cita (autenticado)
 GET    /appointments/available-slots           # Obtener slots disponibles (público)
 GET    /appointments/client/:clientId          # Citas de un cliente (autenticado)
 GET    /appointments/stylist/:stylistId        # Citas de un estilista (autenticado)
 GET    /appointments/:id                       # Obtener cita por ID (autenticado)
 PUT    /appointments/:id                       # Actualizar cita (autenticado)
-POST   /appointments/:id/confirm              # Confirmar cita (autenticado)
-POST   /appointments/:id/cancel               # Cancelar cita (autenticado)
+POST   /appointments/:id/confirm               # Confirmar cita (autenticado)
+POST   /appointments/:id/cancel                # Cancelar cita (autenticado)
 ```
 
 ### Payments
@@ -338,12 +338,12 @@ POST   /appointments/:id/cancel               # Cancelar cita (autenticado)
 GET    /payments                               # Listar pagos paginados (ADMIN)
 POST   /payments                               # Crear pago (ADMIN/STYLIST)
 GET    /payments/statistics                    # Estadísticas de pagos (ADMIN)
-GET    /payments/appointment/:appointmentId    # Pagos de una cita (autenticado)
-GET    /payments/:id                           # Obtener pago por ID (autenticado)
+GET    /payments/appointment/:appointmentId    # Pagos de una cita (ADMIN/STYLIST)
+GET    /payments/:id                           # Obtener pago por ID (ADMIN/STYLIST)
 PUT    /payments/:id                           # Actualizar monto (ADMIN)
-POST   /payments/:id/process                  # Procesar pago (ADMIN/STYLIST)
-POST   /payments/:id/refund                   # Reembolsar pago (ADMIN)
-POST   /payments/:id/cancel                   # Cancelar pago (ADMIN/STYLIST)
+POST   /payments/:id/process                   # Procesar pago (ADMIN/STYLIST)
+POST   /payments/:id/refund                    # Reembolsar pago (ADMIN)
+POST   /payments/:id/cancel                    # Cancelar pago (ADMIN/STYLIST)
 ```
 
 ### Holidays
@@ -377,10 +377,10 @@ GET    /holidays/:holidayId/exceptions         # Excepciones de un feriado (púb
 GET    /notifications                          # Notificaciones del usuario (autenticado)
 POST   /notifications                          # Crear notificación (ADMIN)
 GET    /notifications/unread-count             # Conteo de no leídas (autenticado)
-POST   /notifications/mark-read               # Marcar como leídas (autenticado)
-POST   /notifications/mark-all-read           # Marcar todas como leídas (autenticado)
+POST   /notifications/mark-read                # Marcar como leídas (autenticado)
+POST   /notifications/mark-all-read            # Marcar todas como leídas (autenticado)
 GET    /notifications/:id                      # Obtener por ID (autenticado)
-PATCH  /notifications/:id/read                # Marcar una como leída (autenticado)
+PATCH  /notifications/:id/read                 # Marcar una como leída (autenticado)
 ```
 
 ---
@@ -389,7 +389,7 @@ PATCH  /notifications/:id/read                # Marcar una como leída (autentic
 
 [Índice](#índice)
 
-El proyecto cuenta con **1127+ tests** organizados en tres niveles:
+El proyecto cuenta con **1118+ tests** organizados en tres niveles:
 
 ### Estructura de tests
 
@@ -397,7 +397,7 @@ El proyecto cuenta con **1127+ tests** organizados en tres niveles:
 tests/
 ├── unit/                  # Tests unitarios (entidades y use cases)
 │   ├── auth/              # 6 tests: User, Role, AuthService, BcryptHash, JwtToken, DeactivateUser
-│   ├── services/          # 7 tests: Category, Service, Stylist, StylistService + UseCases
+│   ├── services/          # 6 tests: Category, Service, StylistService + UseCases
 │   ├── appointments/      # 12 tests: 3 entidades + 8 use cases + ScheduleAvailabilityService
 │   ├── holidays/          # 12 tests: 2 entidades + 10 use cases
 │   ├── notifications/     # 7 tests: 2 entidades + 5 use cases
@@ -450,23 +450,21 @@ Los tests utilizan la misma base de datos de desarrollo con limpieza selectiva p
 
 ### Entidades
 
-| Entidad                | Módulo        | Descripción                                                     |
-| ---------------------- | ------------- | --------------------------------------------------------------- |
-| **User**               | auth          | Usuarios del sistema con roles diferenciados                    |
-| **Role**               | auth          | Roles del sistema (ADMIN, CLIENT, STYLIST)                      |
-| **Category**           | services      | Categorías de servicios (ej: Corte, Coloración)                 |
-| **Service**            | services      | Servicios ofrecidos con precios y duración                      |
-| **StylistService**     | services      | Relación estilista-servicio con precios personalizados          |
-| **Client**             | services      | Perfil extendido para clientes                                  |
-| **Stylist**            | services      | Perfil extendido para estilistas                                |
-| **Appointment**        | appointments  | Citas entre clientes y estilistas                               |
-| **AppointmentStatus**  | appointments  | Estados de citas (Pendiente, Confirmada, Completada, Cancelada) |
-| **Schedule**           | appointments  | Horarios de disponibilidad por día de semana                    |
-| **Holiday**            | holidays      | Días festivos y fechas especiales                               |
-| **ScheduleException**  | holidays      | Excepciones de horario para fechas específicas                  |
-| **Payment**            | payments      | Pagos de citas con múltiples métodos y estados                  |
-| **Notification**       | notifications | Notificaciones del sistema (citas, promociones, sistema)        |
-| **NotificationStatus** | notifications | Estados de notificaciones (Enviada, Leída)                      |
+| Entidad                | Módulo        | Descripción                                                                             |
+| ---------------------- | ------------- | --------------------------------------------------------------------------------------- |
+| **User**               | auth          | Usuarios del sistema con roles diferenciados (incluye `preferences` opcional)           |
+| **Role**               | auth          | Roles del sistema (ADMIN, CLIENT, STYLIST)                                              |
+| **Category**           | services      | Categorías de servicios (ej: Corte, Coloración)                                         |
+| **Service**            | services      | Servicios ofrecidos con precios y duración                                              |
+| **StylistService**     | services      | Relación estilista-servicio con precios personalizados (`stylistId` apunta a `User.id`) |
+| **Appointment**        | appointments  | Citas entre clientes y estilistas                                                       |
+| **AppointmentStatus**  | appointments  | Estados de citas (Pendiente, Confirmada, Completada, Cancelada)                         |
+| **Schedule**           | appointments  | Horarios de disponibilidad por día de semana                                            |
+| **Holiday**            | holidays      | Días festivos y fechas especiales                                                       |
+| **ScheduleException**  | holidays      | Excepciones de horario para fechas específicas                                          |
+| **Payment**            | payments      | Pagos de citas con múltiples métodos y estados                                          |
+| **Notification**       | notifications | Notificaciones del sistema (citas, promociones, sistema)                                |
+| **NotificationStatus** | notifications | Estados de notificaciones (Enviada, Leída)                                              |
 
 ### Comandos útiles
 

--- a/src/docs/business-rules/01-auth.md
+++ b/src/docs/business-rules/01-auth.md
@@ -24,6 +24,7 @@ El módulo de autenticación gestiona el registro, login y sesiones de usuarios 
 | isActive | boolean | Estado del usuario |
 | profilePicture | string? | URL de foto de perfil |
 | roleId | UUID | Rol asignado |
+| preferences | string? | Preferencias del usuario (opcional, relevante para clientes) |
 | createdAt | DateTime | Fecha de creación |
 | updatedAt | DateTime | Última actualización |
 
@@ -35,18 +36,6 @@ El módulo de autenticación gestiona el registro, login y sesiones de usuarios 
 | name | RoleName | ADMIN, STYLIST, CLIENT |
 | description | string? | Descripción del rol (opcional) |
 | createdAt | DateTime | Fecha de creación |
-
-### Client (extensión de User)
-
-| Campo | Tipo | Descripción |
-|-------|------|-------------|
-| id | UUID | Identificador único |
-| userId | UUID | Referencia al User |
-| preferences | string? | Preferencias del cliente (texto serializado) |
-| createdAt | DateTime | Fecha de creación |
-| updatedAt | DateTime | Última actualización |
-
-> **Nota:** La entidad Stylist pertenece al módulo `services`. Ver `04-stylists.md`.
 
 ---
 
@@ -120,7 +109,6 @@ El módulo de autenticación gestiona el registro, login y sesiones de usuarios 
 | UUID válido | El `userId` debe ser un UUID válido |
 | Cascada STYLIST | Si el usuario tiene rol STYLIST, se ejecutan acciones en cascada: (1) Cancelar todas las citas activas (PENDING/CONFIRMED) con `cancellationReason: 'Stylist deactivated'` y `cancelledBy: 'system'`, (2) Desactivar todas las asignaciones StylistService activas (`isOffering = false`) |
 | Sin cascada otros roles | Para CLIENT y ADMIN no se ejecuta cascada |
-| Graceful degradation | Si el usuario tiene rol STYLIST pero no tiene registro en la tabla Stylist, la cascada retorna conteos en 0 sin lanzar error |
 | Response | Retorna `DeactivateUserResponseDto` con `userId`, `email`, `name`, `cascadeApplied` (boolean) y `cascadeSummary` (conteo de citas canceladas y servicios desactivados) |
 
 ---
@@ -166,7 +154,7 @@ El `AuthMiddleware` protege las rutas que requieren autenticación. Expone dos m
 - **Appointments**: El `userId` se usa para identificar quién crea las citas. Al desactivar un estilista, sus citas activas se cancelan automáticamente
 - **Notifications**: Las notificaciones se envían a usuarios específicos
 - **Payments**: Los pagos están asociados a citas de usuarios
-- **Stylists**: Los usuarios con rol STYLIST tienen un perfil Stylist asociado. Al desactivar un estilista, sus asignaciones StylistService se desactivan (`isOffering = false`)
+- **Stylists**: Los usuarios con rol STYLIST no tienen un perfil separado; el propio `User.id` se usa como `stylistId`. Al desactivar un estilista, la cascada opera directamente sobre `StylistService` y `Appointment` usando `User.id`, desactivando sus asignaciones (`isOffering = false`)
 
 ---
 

--- a/src/docs/business-rules/04-stylists.md
+++ b/src/docs/business-rules/04-stylists.md
@@ -6,35 +6,25 @@
 
 ## 1. Descripción General
 
-El módulo gestiona la relación entre estilistas y los servicios que ofrecen. Los estilistas se crean automáticamente al registrar un usuario con rol STYLIST. La funcionalidad principal es la asignación de servicios específicos que cada estilista ofrece, con posibilidad de precios personalizados en centavos.
+El módulo gestiona la relación entre estilistas y los servicios que ofrecen. Los estilistas son simplemente usuarios (`User`) con rol STYLIST; no existe un registro ni una creación automática de un perfil separado. La funcionalidad principal es la asignación de servicios específicos que cada estilista ofrece, con posibilidad de precios personalizados en centavos.
 
 ---
 
 ## 2. Entidades
 
-### Stylist
-
-| Campo | Tipo | Descripción |
-|-------|------|-------------|
-| id | UUID | Identificador único |
-| userId | UUID | Referencia al User |
-| createdAt | DateTime | Fecha de creación |
-| updatedAt | DateTime | Última actualización |
-
-> **Nota**: La entidad Stylist es un perfil mínimo vinculado al User. No tiene campos adicionales como bio o specialties.
-
 ### StylistService (Asignación de servicios)
 
 | Campo | Tipo | Descripción |
 |-------|------|-------------|
-| stylistId | UUID | Referencia al Stylist (clave compuesta) |
-| serviceId | UUID | Referencia al Service (clave compuesta) |
+| id | UUID | Identificador único |
+| stylistId | UUID | Referencia al User (User.id de un usuario con rol STYLIST) |
+| serviceId | UUID | Referencia al Service |
 | customPrice | number? | Precio personalizado en centavos (opcional) |
 | isOffering | boolean | Si actualmente ofrece el servicio (default: true) |
 | createdAt | DateTime | Fecha de creación |
 | updatedAt | DateTime | Última actualización |
 
-> **Nota**: StylistService no tiene campo `id` propio. Usa clave compuesta (`stylistId` + `serviceId`).
+> **Nota**: StylistService SÍ tiene campo `id` propio (UUID). `stylistId` y `serviceId` no son clave compuesta.
 
 ---
 
@@ -59,7 +49,7 @@ El módulo gestiona la relación entre estilistas y los servicios que ofrecen. L
 | Regla | Descripción |
 |-------|-------------|
 | Usuario STYLIST | El User asociado al estilista debe tener rol STYLIST (validado en use case) |
-| Estilista válido | El `stylistId` debe existir en la base de datos |
+| Estilista válido | El `stylistId` (User.id) se valida via `IUserRepository.findByIdWithRole()`, verificando que el usuario exista y tenga rol STYLIST |
 | Servicio válido | El `serviceId` debe existir en la base de datos |
 | Relación única | Un estilista solo puede tener una asignación por servicio (ConflictError si duplica) |
 | Estado inicial | Se crea con `isOffering = true` por defecto |
@@ -141,7 +131,7 @@ Todos los endpoints están bajo el prefijo `/api/v1/services`.
 
 ## 7. Relaciones con Otros Módulos
 
-- **Auth**: Cada estilista tiene un User con rol STYLIST
+- **Auth**: Un estilista no es una entidad separada, es un `User` con rol STYLIST. No existe un "perfil Stylist"; toda validación de rol se hace via `IUserRepository.findByIdWithRole()`
 - **Services**: Los estilistas asignan servicios que ofrecen. Solo se pueden asignar servicios activos (`isActive = true`)
 - **Appointments**: Las citas se asignan a estilistas específicos. `CreateAppointment` valida que el estilista ofrezca los servicios seleccionados (`isOffering = true`)
 - **Schedules**: Cada estilista puede tener su propio horario
@@ -150,6 +140,4 @@ Todos los endpoints están bajo el prefijo `/api/v1/services`.
 
 ## 8. Limitaciones Conocidas
 
-| ID | Descripción |
-|----|-------------|
-| ISSUE-17 | La desactivación de un usuario con rol STYLIST (`isActive = false`) no tiene efecto cascada sobre las entidades del estilista. Sus asignaciones StylistService permanecen activas, sus citas pendientes/confirmadas siguen vigentes, y sigue apareciendo en consultas de estilistas por servicio. Se recomienda cancelar manualmente las citas pendientes y desactivar las asignaciones antes de desactivar un estilista |
+_No hay limitaciones conocidas pendientes. El issue ISSUE-17 fue resuelto: la desactivación de un usuario con rol STYLIST ahora ejecuta la cascada completa (cancelación de citas activas y desactivación de asignaciones StylistService)._

--- a/src/docs/business-rules/06-appointments.md
+++ b/src/docs/business-rules/06-appointments.md
@@ -106,7 +106,7 @@ Todas las rutas de consulta requieren solo `authenticate` (sin `authorize`). Cua
 | Servicios activos | Todos los servicios deben tener `isActive = true`. Se lanza `BusinessRuleError` si algún servicio está inactivo |
 | Estilista ofrece servicios | Si se especifica `stylistId`, el estilista debe tener asignado cada servicio (`IStylistServiceRepository.findByStylistAndService`) y estar ofreciéndolo (`isOffering = true`) |
 | Cliente válido | El `clientId` del DTO es el `User.id` del cliente. Se almacena directamente en `Appointment.clientId` sin resolución intermedia |
-| Estilista válido | Si se especifica, el `stylistId` (User.id) se resuelve a `Stylist` via `findByUserId()`. El `Stylist.id` resultante se usa para validar asignaciones de servicio (`StylistService`), pero `Appointment.stylistId` almacena `User.id` |
+| Estilista válido | Si se especifica, el `stylistId` (User.id) se valida via `IUserRepository.findByIdWithRole()`, verificando rol STYLIST. El mismo `stylistId` (User.id) se usa directamente para consultar `StylistService`, que también almacena `User.id` |
 | Día laboral | El día debe tener horario efectivo (determinado por `ScheduleAvailabilityService`) |
 | Horario laboral | La hora de la cita debe caer dentro del rango `startTime`-`endTime` del horario efectivo. La cita completa (inicio + duración) debe terminar antes de `endTime` |
 | Sin conflictos | No debe haber citas superpuestas en el mismo horario (validado por `findConflictingAppointments`) |
@@ -236,8 +236,8 @@ NO_SHOW (No Se Presentó)
 ## 9. Relaciones con Otros Módulos
 
 - **Auth**: El `userId` identifica quién creó la cita. Los campos `clientId` y `stylistId` también almacenan `User.id`, lo que permite comparaciones directas de ownership contra el `requesterId` del JWT
-- **Clients**: Cada cita está asociada a un cliente via `clientId` (User.id). Las tablas `Client` y `Stylist` siguen existiendo como registros de perfil, pero `Appointment` referencia directamente a `User`
-- **Stylists**: Las citas pueden asignarse a estilistas via `stylistId` (User.id). Para validar asignaciones de servicio, el use case resuelve `User.id → Stylist.id` via `findByUserId()` y usa el `Stylist.id` para consultar `StylistService`
+- **Clients**: Cada cita está asociada a un cliente via `clientId` (User.id). No existe una tabla `Client` separada; `Appointment` referencia directamente a `User`
+- **Stylists**: Las citas pueden asignarse a estilistas via `stylistId` (User.id). No existe una tabla `Stylist` separada: el use case valida el rol via `IUserRepository.findByIdWithRole()` y usa el mismo `User.id` directamente para consultar `StylistService`
 - **Services**: Las citas incluyen uno o más servicios (`serviceIds`). Se valida que estén activos (`isActive = true`)
 - **Schedules**: Determina disponibilidad de horarios y vincula la cita a un horario (`scheduleId`). Se valida que la cita caiga dentro del horario laboral
 - **Holidays**: Los feriados afectan la disponibilidad de citas. El sistema consulta `ScheduleAvailabilityService` que implementa la prioridad `ScheduleException > Holiday (día cerrado) > Schedule regular`. Al crear un feriado, se cancelan automáticamente las citas activas en esa fecha
@@ -265,4 +265,4 @@ Integrado en: `CreateAppointment` (pasos 4-6), `GetAvailableSlots` (pasos 5-6), 
 
 ## 11. Limitaciones Conocidas
 
-- **Asimetría de IDs (D9):** `Appointment.stylistId` almacena `User.id`, pero `StylistService.stylistId` sigue almacenando `Stylist.id`. El application layer resuelve esta diferencia via `stylistRepository.findByUserId()`. La migración completa de `StylistService.stylistId` a `User.id` es una mejora futura.
+_No hay limitaciones conocidas pendientes. La antigua asimetría de IDs (D9) entre `Appointment.stylistId` y `StylistService.stylistId` fue resuelta: ambos campos almacenan `User.id` directamente, sin necesidad de resolución intermedia._

--- a/src/docs/postman/appointments_postman_collection.json
+++ b/src/docs/postman/appointments_postman_collection.json
@@ -416,10 +416,15 @@
               "listen": "prerequest",
               "script": {
                 "exec": [
-                  "// Generar fecha/hora 7 días en el futuro a las 10:00",
+                  "// Generar fecha/hora en UTC (coincide con como el servidor valida horario laboral), evitando fines de semana",
                   "const futureDate = new Date();",
-                  "futureDate.setDate(futureDate.getDate() + 7);",
-                  "futureDate.setHours(10, 0, 0, 0);",
+                  "const randomDayOffset = Math.floor(Math.random() * 10) + 7; // 7-16 dias en el futuro",
+                  "futureDate.setUTCDate(futureDate.getUTCDate() + randomDayOffset);",
+                  "const utcDay = futureDate.getUTCDay();",
+                  "if (utcDay === 6) futureDate.setUTCDate(futureDate.getUTCDate() + 2); // sabado -> lunes",
+                  "if (utcDay === 0) futureDate.setUTCDate(futureDate.getUTCDate() + 1); // domingo -> lunes",
+                  "const randomHourUTC = Math.floor(Math.random() * 6) + 10; // 10:00-15:00 UTC, margen seguro dentro de 09:00-18:00",
+                  "futureDate.setUTCHours(randomHourUTC, 0, 0, 0);",
                   "pm.collectionVariables.set('appointment_datetime', futureDate.toISOString());",
                   "console.log('📅 DateTime para cita:', futureDate.toISOString());"
                 ]
@@ -478,10 +483,15 @@
               "listen": "prerequest",
               "script": {
                 "exec": [
-                  "// Generar fecha/hora 8 días en el futuro a las 14:00",
+                  "// Generar fecha/hora en UTC (rango distinto al de Create Appointment), evitando fines de semana",
                   "const futureDate = new Date();",
-                  "futureDate.setDate(futureDate.getDate() + 8);",
-                  "futureDate.setHours(14, 0, 0, 0);",
+                  "const randomDayOffset = Math.floor(Math.random() * 10) + 18; // 18-27 dias en el futuro",
+                  "futureDate.setUTCDate(futureDate.getUTCDate() + randomDayOffset);",
+                  "const utcDay = futureDate.getUTCDay();",
+                  "if (utcDay === 6) futureDate.setUTCDate(futureDate.getUTCDate() + 2); // sabado -> lunes",
+                  "if (utcDay === 0) futureDate.setUTCDate(futureDate.getUTCDate() + 1); // domingo -> lunes",
+                  "const randomHourUTC = Math.floor(Math.random() * 6) + 10; // 10:00-15:00 UTC",
+                  "futureDate.setUTCHours(randomHourUTC, 0, 0, 0);",
                   "pm.collectionVariables.set('appointment_datetime_2', futureDate.toISOString());"
                 ]
               }
@@ -567,10 +577,15 @@
               "listen": "prerequest",
               "script": {
                 "exec": [
-                  "// Nueva fecha/hora 9 días en el futuro a las 11:00",
+                  "// Nueva fecha/hora en UTC (rango distinto a las Create), evitando fines de semana",
                   "const newDate = new Date();",
-                  "newDate.setDate(newDate.getDate() + 9);",
-                  "newDate.setHours(11, 0, 0, 0);",
+                  "const randomDayOffset = Math.floor(Math.random() * 10) + 28; // 28-37 dias en el futuro",
+                  "newDate.setUTCDate(newDate.getUTCDate() + randomDayOffset);",
+                  "const utcDay = newDate.getUTCDay();",
+                  "if (utcDay === 6) newDate.setUTCDate(newDate.getUTCDate() + 2); // sabado -> lunes",
+                  "if (utcDay === 0) newDate.setUTCDate(newDate.getUTCDate() + 1); // domingo -> lunes",
+                  "const randomHourUTC = Math.floor(Math.random() * 6) + 10; // 10:00-15:00 UTC",
+                  "newDate.setUTCHours(randomHourUTC, 0, 0, 0);",
                   "pm.collectionVariables.set('new_appointment_datetime', newDate.toISOString());"
                 ]
               }
@@ -993,6 +1008,9 @@
           "request": {
             "method": "GET",
             "header": [],
+            "auth": {
+              "type": "noauth"
+            },
             "url": {
               "raw": "{{base_url}}/appointments/{{appointment_id}}",
               "host": ["{{base_url}}"],
@@ -1025,6 +1043,9 @@
                 "type": "text"
               }
             ],
+            "auth": {
+              "type": "noauth"
+            },
             "url": {
               "raw": "{{base_url}}/appointments/{{appointment_id}}",
               "host": ["{{base_url}}"],

--- a/src/docs/postman/auth_postman_collection.json
+++ b/src/docs/postman/auth_postman_collection.json
@@ -56,6 +56,7 @@
                   "    pm.test('Usuario registrado correctamente', function () {",
                   "        pm.expect(response.success).to.be.true;",
                   "        pm.expect(response.data.role.name).to.eql('CLIENT');",
+                  "        pm.expect(response.data).to.have.property('preferences');",
                   "    });",
                   "}"
                 ]
@@ -262,6 +263,7 @@
                   "        pm.expect(response.success).to.be.true;",
                   "        pm.expect(response.data).to.have.property('id');",
                   "        pm.expect(response.data).to.have.property('role');",
+                  "        pm.expect(response.data).to.have.property('preferences');",
                   "    });",
                   "}"
                 ]
@@ -748,6 +750,9 @@
           "request": {
             "method": "GET",
             "header": [],
+            "auth": {
+              "type": "noauth"
+            },
             "url": {
               "raw": "{{base_url}}/auth/profile",
               "host": ["{{base_url}}"],
@@ -780,6 +785,9 @@
                 "type": "text"
               }
             ],
+            "auth": {
+              "type": "noauth"
+            },
             "url": {
               "raw": "{{base_url}}/auth/profile",
               "host": ["{{base_url}}"],

--- a/src/docs/postman/holidays_postman_collection.json
+++ b/src/docs/postman/holidays_postman_collection.json
@@ -1,0 +1,647 @@
+{
+  "info": {
+    "_postman_id": "holidays-collection-v1",
+    "name": "Turnity - Holidays & Schedule Exceptions",
+    "description": "Colección de endpoints para el módulo de feriados y excepciones de horario de Turnity Backend.\n\n## Permisos\n- **Consultas (GET)**: Públicas\n- **Creación, actualización, eliminación**: Solo ADMIN\n\n## Entidades\n- **Holiday**: Días feriados donde el salón no opera\n- **ScheduleException**: Excepciones puntuales de horario (horarios reducidos, especiales, etc.)",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "http://localhost:3000/api/v1"
+    },
+    {
+      "key": "jwt_token",
+      "value": ""
+    },
+    {
+      "key": "holiday_id",
+      "value": ""
+    },
+    {
+      "key": "exception_id",
+      "value": ""
+    }
+  ],
+  "item": [
+    {
+      "name": "1. Authentication Setup",
+      "description": "Autenticación requerida para operaciones de escritura",
+      "item": [
+        {
+          "name": "Login as Admin",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.collectionVariables.set('jwt_token', jsonData.data.token);",
+                  "    console.log('Token saved successfully');",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"email\": \"admin@turnity.com\",\n    \"password\": \"admin123\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/auth/login",
+              "host": ["{{base_url}}"],
+              "path": ["auth", "login"]
+            },
+            "description": "Autentica como admin para obtener el JWT token necesario para crear, actualizar y eliminar feriados."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "2. Holiday CRUD",
+      "description": "Operaciones CRUD para feriados",
+      "item": [
+        {
+          "name": "Create Holiday",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 201) {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.collectionVariables.set('holiday_id', jsonData.data.id);",
+                  "    console.log('Holiday ID saved:', jsonData.data.id);",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"name\": \"Navidad\",\n    \"date\": \"2025-12-25\",\n    \"description\": \"Día de Navidad - Salón cerrado\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/holidays",
+              "host": ["{{base_url}}"],
+              "path": ["holidays"]
+            },
+            "description": "Crea un nuevo feriado (solo Admin)."
+          },
+          "response": []
+        },
+        {
+          "name": "Get All Holidays",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/holidays?page=1&limit=10",
+              "host": ["{{base_url}}"],
+              "path": ["holidays"],
+              "query": [
+                {"key": "page", "value": "1"},
+                {"key": "limit", "value": "10"},
+                {"key": "year", "value": "", "disabled": true},
+                {"key": "month", "value": "", "disabled": true},
+                {"key": "name", "value": "", "disabled": true}
+              ]
+            },
+            "description": "Lista todos los feriados con paginación y filtros opcionales. Endpoint público."
+          },
+          "response": []
+        },
+        {
+          "name": "Get Holiday by ID",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/holidays/{{holiday_id}}",
+              "host": ["{{base_url}}"],
+              "path": ["holidays", "{{holiday_id}}"]
+            },
+            "description": "Obtiene un feriado específico por su ID. Endpoint público."
+          },
+          "response": []
+        },
+        {
+          "name": "Get Upcoming Holidays",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/holidays/upcoming?limit=5",
+              "host": ["{{base_url}}"],
+              "path": ["holidays", "upcoming"],
+              "query": [
+                {"key": "limit", "value": "5"}
+              ]
+            },
+            "description": "Obtiene los próximos feriados (futuros). Endpoint público."
+          },
+          "response": []
+        },
+        {
+          "name": "Get Holidays by Year",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/holidays/year/2025",
+              "host": ["{{base_url}}"],
+              "path": ["holidays", "year", "2025"]
+            },
+            "description": "Obtiene todos los feriados de un año específico. Endpoint público."
+          },
+          "response": []
+        },
+        {
+          "name": "Check Is Holiday",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/holidays/check/2025-12-25",
+              "host": ["{{base_url}}"],
+              "path": ["holidays", "check", "2025-12-25"]
+            },
+            "description": "Verifica si una fecha específica es feriado. Retorna isHoliday true/false y los datos del feriado si existe."
+          },
+          "response": []
+        },
+        {
+          "name": "Update Holiday",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"name\": \"Navidad Actualizada\",\n    \"description\": \"Nueva descripción de Navidad\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/holidays/{{holiday_id}}",
+              "host": ["{{base_url}}"],
+              "path": ["holidays", "{{holiday_id}}"]
+            },
+            "description": "Actualiza un feriado existente (solo Admin)."
+          },
+          "response": []
+        },
+        {
+          "name": "Delete Holiday",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/holidays/{{holiday_id}}",
+              "host": ["{{base_url}}"],
+              "path": ["holidays", "{{holiday_id}}"]
+            },
+            "description": "Elimina un feriado y todas sus excepciones asociadas (solo Admin)."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "3. Schedule Exceptions",
+      "description": "Operaciones para excepciones de horario",
+      "item": [
+        {
+          "name": "Create Schedule Exception",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 201) {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.collectionVariables.set('exception_id', jsonData.data.id);",
+                  "    console.log('Exception ID saved:', jsonData.data.id);",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"exceptionDate\": \"2025-12-24\",\n    \"startTimeException\": \"09:00\",\n    \"endTimeException\": \"14:00\",\n    \"reason\": \"Horario reducido de Nochebuena\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/holidays/exceptions",
+              "host": ["{{base_url}}"],
+              "path": ["holidays", "exceptions"]
+            },
+            "description": "Crea una nueva excepción de horario (solo Admin)."
+          },
+          "response": []
+        },
+        {
+          "name": "Create Exception with Holiday",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"exceptionDate\": \"2025-12-25\",\n    \"startTimeException\": \"00:00\",\n    \"endTimeException\": \"23:59\",\n    \"reason\": \"Salón cerrado por Navidad\",\n    \"holidayId\": \"{{holiday_id}}\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/holidays/exceptions",
+              "host": ["{{base_url}}"],
+              "path": ["holidays", "exceptions"]
+            },
+            "description": "Crea una excepción asociada a un feriado específico."
+          },
+          "response": []
+        },
+        {
+          "name": "Get All Exceptions",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/holidays/exceptions?page=1&limit=10",
+              "host": ["{{base_url}}"],
+              "path": ["holidays", "exceptions"],
+              "query": [
+                {"key": "page", "value": "1"},
+                {"key": "limit", "value": "10"},
+                {"key": "startDate", "value": "", "disabled": true},
+                {"key": "endDate", "value": "", "disabled": true},
+                {"key": "holidayId", "value": "", "disabled": true}
+              ]
+            },
+            "description": "Lista todas las excepciones de horario con paginación y filtros. Endpoint público."
+          },
+          "response": []
+        },
+        {
+          "name": "Get Exception by ID",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/holidays/exceptions/{{exception_id}}",
+              "host": ["{{base_url}}"],
+              "path": ["holidays", "exceptions", "{{exception_id}}"]
+            },
+            "description": "Obtiene una excepción específica por su ID. Endpoint público."
+          },
+          "response": []
+        },
+        {
+          "name": "Get Upcoming Exceptions",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/holidays/exceptions/upcoming?limit=5",
+              "host": ["{{base_url}}"],
+              "path": ["holidays", "exceptions", "upcoming"],
+              "query": [
+                {"key": "limit", "value": "5"}
+              ]
+            },
+            "description": "Obtiene las próximas excepciones de horario. Endpoint público."
+          },
+          "response": []
+        },
+        {
+          "name": "Get Exceptions by Holiday",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/holidays/{{holiday_id}}/exceptions",
+              "host": ["{{base_url}}"],
+              "path": ["holidays", "{{holiday_id}}", "exceptions"]
+            },
+            "description": "Obtiene todas las excepciones asociadas a un feriado específico. Endpoint público."
+          },
+          "response": []
+        },
+        {
+          "name": "Update Exception",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"startTimeException\": \"10:00\",\n    \"endTimeException\": \"15:00\",\n    \"reason\": \"Horario actualizado\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/holidays/exceptions/{{exception_id}}",
+              "host": ["{{base_url}}"],
+              "path": ["holidays", "exceptions", "{{exception_id}}"]
+            },
+            "description": "Actualiza una excepción de horario (solo Admin)."
+          },
+          "response": []
+        },
+        {
+          "name": "Delete Exception",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/holidays/exceptions/{{exception_id}}",
+              "host": ["{{base_url}}"],
+              "path": ["holidays", "exceptions", "{{exception_id}}"]
+            },
+            "description": "Elimina una excepción de horario (solo Admin)."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "4. Complete Flow",
+      "description": "Flujo completo de prueba",
+      "item": [
+        {
+          "name": "Step 1 - Create Holiday",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Holiday created successfully', function() {",
+                  "    pm.response.to.have.status(201);",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.collectionVariables.set('holiday_id', jsonData.data.id);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {"key": "Content-Type", "value": "application/json"},
+              {"key": "Authorization", "value": "Bearer {{jwt_token}}"}
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"name\": \"Test Holiday Flow\",\n    \"date\": \"2099-06-15\",\n    \"description\": \"Holiday for testing complete flow\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/holidays",
+              "host": ["{{base_url}}"],
+              "path": ["holidays"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Step 2 - Create Exception",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Exception created successfully', function() {",
+                  "    pm.response.to.have.status(201);",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.collectionVariables.set('exception_id', jsonData.data.id);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {"key": "Content-Type", "value": "application/json"},
+              {"key": "Authorization", "value": "Bearer {{jwt_token}}"}
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"exceptionDate\": \"2099-06-15\",\n    \"startTimeException\": \"09:00\",\n    \"endTimeException\": \"18:00\",\n    \"reason\": \"Exception for test holiday\",\n    \"holidayId\": \"{{holiday_id}}\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/holidays/exceptions",
+              "host": ["{{base_url}}"],
+              "path": ["holidays", "exceptions"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Step 3 - Verify Holiday",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Holiday verification successful', function() {",
+                  "    pm.response.to.have.status(200);",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.expect(jsonData.data.isHoliday).to.be.true;",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/holidays/check/2099-06-15",
+              "host": ["{{base_url}}"],
+              "path": ["holidays", "check", "2099-06-15"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Step 4 - Cleanup Holiday (cascades exceptions)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Holiday deleted successfully', function() {",
+                  "    pm.response.to.have.status(200);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {"key": "Authorization", "value": "Bearer {{jwt_token}}"}
+            ],
+            "url": {
+              "raw": "{{base_url}}/holidays/{{holiday_id}}",
+              "host": ["{{base_url}}"],
+              "path": ["holidays", "{{holiday_id}}"]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "5. Error Testing",
+      "description": "Pruebas de errores y validaciones",
+      "item": [
+        {
+          "name": "Create Holiday without Auth (should fail 401)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {"key": "Content-Type", "value": "application/json"}
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"name\": \"Unauthorized Holiday\",\n    \"date\": \"2025-07-04\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/holidays",
+              "host": ["{{base_url}}"],
+              "path": ["holidays"]
+            },
+            "description": "Intenta crear un feriado sin autenticación. Debería fallar con 401."
+          },
+          "response": []
+        },
+        {
+          "name": "Create Holiday without Name (should fail 400)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {"key": "Content-Type", "value": "application/json"},
+              {"key": "Authorization", "value": "Bearer {{jwt_token}}"}
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"date\": \"2025-08-15\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/holidays",
+              "host": ["{{base_url}}"],
+              "path": ["holidays"]
+            },
+            "description": "Intenta crear un feriado sin nombre. Debería fallar con 400."
+          },
+          "response": []
+        },
+        {
+          "name": "Create Exception with Invalid Time (should fail 400)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {"key": "Content-Type", "value": "application/json"},
+              {"key": "Authorization", "value": "Bearer {{jwt_token}}"}
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"exceptionDate\": \"2025-09-01\",\n    \"startTimeException\": \"25:00\",\n    \"endTimeException\": \"14:00\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/holidays/exceptions",
+              "host": ["{{base_url}}"],
+              "path": ["holidays", "exceptions"]
+            },
+            "description": "Intenta crear una excepción con hora inválida. Debería fallar con 400."
+          },
+          "response": []
+        },
+        {
+          "name": "Get Non-existent Holiday (should fail 404/500)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/holidays/00000000-0000-4000-8000-000000000000",
+              "host": ["{{base_url}}"],
+              "path": ["holidays", "00000000-0000-4000-8000-000000000000"]
+            },
+            "description": "Intenta obtener un feriado que no existe."
+          },
+          "response": []
+        }
+      ]
+    }
+  ]
+}

--- a/src/docs/postman/notifications_postman_collection.json
+++ b/src/docs/postman/notifications_postman_collection.json
@@ -1,0 +1,995 @@
+{
+  "info": {
+    "name": "Notifications API v1.0",
+    "description": "Colección para el módulo Notifications - Gestión de notificaciones de usuario",
+    "version": "1.0.0",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "http://localhost:3000/api/v1",
+      "type": "string"
+    },
+    {
+      "key": "jwt_token",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "notification_id",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "user_id",
+      "value": "",
+      "type": "string"
+    }
+  ],
+  "auth": {
+    "type": "bearer",
+    "bearer": [
+      {
+        "key": "token",
+        "value": "{{jwt_token}}",
+        "type": "string"
+      }
+    ]
+  },
+  "item": [
+    {
+      "name": "Authentication Setup",
+      "description": "Setup de autenticación para testing",
+      "item": [
+        {
+          "name": "Login Client María (Setup)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    const response = pm.response.json();",
+                  "    pm.collectionVariables.set('jwt_token', response.data.token);",
+                  "    pm.collectionVariables.set('user_id', response.data.user.id);",
+                  "    console.log('✅ Cliente María login exitoso');",
+                  "    console.log('User ID:', response.data.user.id);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"maria@example.com\",\n  \"password\": \"client123\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/auth/login",
+              "host": ["{{base_url}}"],
+              "path": ["auth", "login"]
+            },
+            "description": "Login con cliente María. Guarda token y user_id automáticamente."
+          }
+        },
+        {
+          "name": "Login Stylist Lucía (Setup)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    const response = pm.response.json();",
+                  "    pm.collectionVariables.set('jwt_token', response.data.token);",
+                  "    pm.collectionVariables.set('user_id', response.data.user.id);",
+                  "    console.log('✅ Estilista Lucía login exitosa');",
+                  "    console.log('User ID:', response.data.user.id);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"lucia@turnity.com\",\n  \"password\": \"stylist123\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/auth/login",
+              "host": ["{{base_url}}"],
+              "path": ["auth", "login"]
+            },
+            "description": "Login con estilista Lucía. Guarda token y user_id automáticamente."
+          }
+        },
+        {
+          "name": "Login Admin (Setup)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    const response = pm.response.json();",
+                  "    pm.collectionVariables.set('jwt_token', response.data.token);",
+                  "    pm.collectionVariables.set('user_id', response.data.user.id);",
+                  "    console.log('✅ Admin login exitoso');",
+                  "    console.log('User ID:', response.data.user.id);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"admin@turnity.com\",\n  \"password\": \"admin123\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/auth/login",
+              "host": ["{{base_url}}"],
+              "path": ["auth", "login"]
+            },
+            "description": "Login con admin. Guarda token y user_id automáticamente. Se ejecuta al final a proposito, para dejar el token de Admin activo antes de Admin Operations y Error Testing (requieren rol ADMIN)."
+          }
+        },
+        {
+          "name": "Create Notification (Setup)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 201) {",
+                  "    const response = pm.response.json();",
+                  "    pm.collectionVariables.set('notification_id', response.data.id);",
+                  "    console.log('✅ Notification ID (setup) guardado:', response.data.id);",
+                  "} else {",
+                  "    console.log('⚠️ No se pudo crear notificacion de setup:', pm.response.code);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"type\": \"SYSTEM\",\n  \"message\": \"Notificacion de setup para tests\",\n  \"userId\": \"{{user_id}}\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/notifications",
+              "host": ["{{base_url}}"],
+              "path": ["notifications"]
+            },
+            "description": "Crea una notificacion de setup (requiere Admin) para que Notification Queries tenga un notification_id valido para probar, sin depender de que ya existan notificaciones previas en la base."
+          }
+        }
+      ]
+    },
+    {
+      "name": "Notification Queries",
+      "description": "Consultas de notificaciones - Requiere autenticación",
+      "item": [
+        {
+          "name": "Get My Notifications",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    const response = pm.response.json();",
+                  "    pm.test('Success response', function () {",
+                  "        pm.expect(response.success).to.be.true;",
+                  "        pm.expect(response.data).to.have.property('notifications');",
+                  "        pm.expect(response.data).to.have.property('total');",
+                  "    });",
+                  "    if (response.data.notifications.length > 0) {",
+                  "        pm.collectionVariables.set('notification_id', response.data.notifications[0].id);",
+                  "        console.log('✅ Notification ID guardado:', response.data.notifications[0].id);",
+                  "    }",
+                  "    console.log('📬 Total notificaciones:', response.data.total);",
+                  "    console.log('📄 En esta página:', response.data.notifications.length);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/notifications",
+              "host": ["{{base_url}}"],
+              "path": ["notifications"]
+            },
+            "description": "Obtiene las notificaciones del usuario autenticado"
+          }
+        },
+        {
+          "name": "Get My Notifications (Paginated)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    const response = pm.response.json();",
+                  "    pm.test('Pagination info present', function () {",
+                  "        pm.expect(response.data.page).to.eql(1);",
+                  "        pm.expect(response.data.limit).to.eql(5);",
+                  "        pm.expect(response.data).to.have.property('totalPages');",
+                  "        pm.expect(response.data).to.have.property('hasNextPage');",
+                  "    });",
+                  "    console.log('📄 Página:', response.data.page, 'de', response.data.totalPages);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/notifications?page=1&limit=5",
+              "host": ["{{base_url}}"],
+              "path": ["notifications"],
+              "query": [
+                {
+                  "key": "page",
+                  "value": "1"
+                },
+                {
+                  "key": "limit",
+                  "value": "5"
+                }
+              ]
+            },
+            "description": "Obtiene notificaciones con paginación"
+          }
+        },
+        {
+          "name": "Get Unread Notifications Only",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    const response = pm.response.json();",
+                  "    pm.test('Success response', function () {",
+                  "        pm.expect(response.success).to.be.true;",
+                  "    });",
+                  "    console.log('📬 Notificaciones no leídas:', response.data.notifications.length);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/notifications?unreadOnly=true",
+              "host": ["{{base_url}}"],
+              "path": ["notifications"],
+              "query": [
+                {
+                  "key": "unreadOnly",
+                  "value": "true"
+                }
+              ]
+            },
+            "description": "Obtiene solo las notificaciones no leídas"
+          }
+        },
+        {
+          "name": "Get Notifications by Type",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    const response = pm.response.json();",
+                  "    pm.test('All notifications are of correct type', function () {",
+                  "        response.data.notifications.forEach(n => {",
+                  "            pm.expect(n.type).to.eql('APPOINTMENT_CONFIRMATION');",
+                  "        });",
+                  "    });",
+                  "    console.log('📬 Confirmaciones de cita:', response.data.notifications.length);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/notifications?type=APPOINTMENT_CONFIRMATION",
+              "host": ["{{base_url}}"],
+              "path": ["notifications"],
+              "query": [
+                {
+                  "key": "type",
+                  "value": "APPOINTMENT_CONFIRMATION"
+                }
+              ]
+            },
+            "description": "Filtra notificaciones por tipo"
+          }
+        },
+        {
+          "name": "Get Notification by ID",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    const response = pm.response.json();",
+                  "    pm.test('Notification retrieved', function () {",
+                  "        pm.expect(response.success).to.be.true;",
+                  "        pm.expect(response.data.id).to.eql(pm.collectionVariables.get('notification_id'));",
+                  "    });",
+                  "    console.log('📋 Tipo:', response.data.type);",
+                  "    console.log('📝 Mensaje:', response.data.message);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/notifications/{{notification_id}}",
+              "host": ["{{base_url}}"],
+              "path": ["notifications", "{{notification_id}}"]
+            },
+            "description": "Obtiene una notificación específica por ID"
+          }
+        },
+        {
+          "name": "Get Unread Count",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    const response = pm.response.json();",
+                  "    pm.test('Unread count returned', function () {",
+                  "        pm.expect(response.success).to.be.true;",
+                  "        pm.expect(response.data).to.have.property('unreadCount');",
+                  "        pm.expect(response.data.unreadCount).to.be.a('number');",
+                  "    });",
+                  "    console.log('🔔 Notificaciones sin leer:', response.data.unreadCount);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/notifications/unread-count",
+              "host": ["{{base_url}}"],
+              "path": ["notifications", "unread-count"]
+            },
+            "description": "Obtiene el conteo de notificaciones no leídas"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Notification Actions",
+      "description": "Acciones sobre notificaciones",
+      "item": [
+        {
+          "name": "Mark Single Notification as Read",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    const response = pm.response.json();",
+                  "    pm.test('Notification marked as read', function () {",
+                  "        pm.expect(response.success).to.be.true;",
+                  "        pm.expect(response.data.isRead).to.be.true;",
+                  "    });",
+                  "    console.log('✅ Notificación marcada como leída');",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/notifications/{{notification_id}}/read",
+              "host": ["{{base_url}}"],
+              "path": ["notifications", "{{notification_id}}", "read"]
+            },
+            "description": "Marca una notificación específica como leída"
+          }
+        },
+        {
+          "name": "Mark Multiple Notifications as Read",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    const response = pm.response.json();",
+                  "    pm.test('Notifications marked as read', function () {",
+                  "        pm.expect(response.success).to.be.true;",
+                  "        pm.expect(response.data).to.have.property('updatedCount');",
+                  "    });",
+                  "    console.log('✅ Notificaciones actualizadas:', response.data.updatedCount);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"notificationId\": \"{{notification_id}}\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/notifications/mark-read",
+              "host": ["{{base_url}}"],
+              "path": ["notifications", "mark-read"]
+            },
+            "description": "Marca una o múltiples notificaciones como leídas"
+          }
+        },
+        {
+          "name": "Mark All Notifications as Read",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    const response = pm.response.json();",
+                  "    pm.test('All notifications marked as read', function () {",
+                  "        pm.expect(response.success).to.be.true;",
+                  "        pm.expect(response.data).to.have.property('updatedCount');",
+                  "    });",
+                  "    console.log('✅ Todas las notificaciones marcadas como leídas:', response.data.updatedCount);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/notifications/mark-all-read",
+              "host": ["{{base_url}}"],
+              "path": ["notifications", "mark-all-read"]
+            },
+            "description": "Marca todas las notificaciones del usuario como leídas"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Admin Operations",
+      "description": "Operaciones de administrador - Solo ADMIN",
+      "item": [
+        {
+          "name": "Create Notification (Admin)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 201) {",
+                  "    const response = pm.response.json();",
+                  "    pm.collectionVariables.set('notification_id', response.data.id);",
+                  "    pm.test('Notification created', function () {",
+                  "        pm.expect(response.success).to.be.true;",
+                  "        pm.expect(response.data).to.have.property('id');",
+                  "    });",
+                  "    console.log('✅ Notificación creada:', response.data.id);",
+                  "} else {",
+                  "    console.log('❌ Error:', pm.response.json().message);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"type\": \"SYSTEM\",\n  \"message\": \"Este es un mensaje de prueba del sistema\",\n  \"userId\": \"{{user_id}}\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/notifications",
+              "host": ["{{base_url}}"],
+              "path": ["notifications"]
+            },
+            "description": "Crea una nueva notificación. Solo ADMIN puede crear notificaciones."
+          }
+        },
+        {
+          "name": "Create Appointment Confirmation (Admin)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 201) {",
+                  "    const response = pm.response.json();",
+                  "    pm.test('Appointment confirmation created', function () {",
+                  "        pm.expect(response.data.type).to.eql('APPOINTMENT_CONFIRMATION');",
+                  "    });",
+                  "    console.log('✅ Confirmación de cita creada');",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"type\": \"APPOINTMENT_CONFIRMATION\",\n  \"message\": \"Tu cita ha sido confirmada para mañana a las 10:00 AM\",\n  \"userId\": \"{{user_id}}\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/notifications",
+              "host": ["{{base_url}}"],
+              "path": ["notifications"]
+            },
+            "description": "Crea una notificación de confirmación de cita"
+          }
+        },
+        {
+          "name": "Create Promotional Notification (Admin)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 201) {",
+                  "    const response = pm.response.json();",
+                  "    pm.test('Promotional notification created', function () {",
+                  "        pm.expect(response.data.type).to.eql('PROMOTIONAL');",
+                  "    });",
+                  "    console.log('✅ Notificación promocional creada');",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"type\": \"PROMOTIONAL\",\n  \"message\": \"¡Aprovecha nuestra promoción de verano! 20% de descuento en todos los servicios\",\n  \"userId\": \"{{user_id}}\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/notifications",
+              "host": ["{{base_url}}"],
+              "path": ["notifications"]
+            },
+            "description": "Crea una notificación promocional"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Error Testing",
+      "description": "Tests de validación de errores",
+      "item": [
+        {
+          "name": "Get Notification - Invalid UUID",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Error 400 - Invalid UUID', function () {",
+                  "    pm.expect(pm.response.code).to.eql(400);",
+                  "});",
+                  "console.log('✅ Error esperado - UUID inválido');"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/notifications/invalid-uuid",
+              "host": ["{{base_url}}"],
+              "path": ["notifications", "invalid-uuid"]
+            },
+            "description": "Test de UUID inválido"
+          }
+        },
+        {
+          "name": "Get Notification - Not Found",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Error 404 - Not found', function () {",
+                  "    pm.expect(pm.response.code).to.eql(404);",
+                  "});",
+                  "console.log('✅ Error esperado - No encontrada');"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/notifications/123e4567-e89b-12d3-a456-426614174000",
+              "host": ["{{base_url}}"],
+              "path": ["notifications", "123e4567-e89b-12d3-a456-426614174000"]
+            },
+            "description": "Test de notificación no existente"
+          }
+        },
+        {
+          "name": "Unauthorized Access",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Error 401 - Unauthorized', function () {",
+                  "    pm.expect(pm.response.code).to.eql(401);",
+                  "});",
+                  "console.log('✅ Error esperado - Sin autenticación');"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "auth": {
+              "type": "noauth"
+            },
+            "url": {
+              "raw": "{{base_url}}/notifications",
+              "host": ["{{base_url}}"],
+              "path": ["notifications"]
+            },
+            "description": "Test de acceso sin token"
+          }
+        },
+        {
+          "name": "Invalid Token",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Error 401 - Invalid token', function () {",
+                  "    pm.expect(pm.response.code).to.eql(401);",
+                  "});",
+                  "console.log('✅ Error esperado - Token inválido');"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer invalid.token.here",
+                "type": "text"
+              }
+            ],
+            "auth": {
+              "type": "noauth"
+            },
+            "url": {
+              "raw": "{{base_url}}/notifications",
+              "host": ["{{base_url}}"],
+              "path": ["notifications"]
+            },
+            "description": "Test de token inválido"
+          }
+        },
+        {
+          "name": "Create - Invalid Type",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Error 400 - Invalid type', function () {",
+                  "    pm.expect(pm.response.code).to.eql(400);",
+                  "});",
+                  "console.log('✅ Error esperado - Tipo inválido');"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"type\": \"INVALID_TYPE\",\n  \"message\": \"Test message\",\n  \"userId\": \"{{user_id}}\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/notifications",
+              "host": ["{{base_url}}"],
+              "path": ["notifications"]
+            },
+            "description": "Test de tipo de notificación inválido"
+          }
+        },
+        {
+          "name": "Create - Empty Message",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Error 400 - Empty message', function () {",
+                  "    pm.expect(pm.response.code).to.eql(400);",
+                  "});",
+                  "console.log('✅ Error esperado - Mensaje vacío');"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"type\": \"SYSTEM\",\n  \"message\": \"\",\n  \"userId\": \"{{user_id}}\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/notifications",
+              "host": ["{{base_url}}"],
+              "path": ["notifications"]
+            },
+            "description": "Test de mensaje vacío"
+          }
+        },
+        {
+          "name": "Mark Read - Empty IDs",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Error 400 - No IDs provided', function () {",
+                  "    pm.expect(pm.response.code).to.eql(400);",
+                  "});",
+                  "console.log('✅ Error esperado - Sin IDs');"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            },
+            "url": {
+              "raw": "{{base_url}}/notifications/mark-read",
+              "host": ["{{base_url}}"],
+              "path": ["notifications", "mark-read"]
+            },
+            "description": "Test de marcar como leído sin IDs"
+          }
+        }
+      ]
+    }
+  ],
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          "// Script global que se ejecuta antes de cada request",
+          "console.log('🚀 Request:', pm.request.method, pm.request.url.toString());",
+          "",
+          "// Verificar token para requests autenticados",
+          "const authHeader = pm.request.headers.get('Authorization');",
+          "if (authHeader && authHeader.includes('{{jwt_token}}')) {",
+          "    const token = pm.collectionVariables.get('jwt_token');",
+          "    if (!token) {",
+          "        console.log('⚠️ Token no encontrado - ejecuta primero un request de Login');",
+          "    }",
+          "}"
+        ]
+      }
+    }
+  ]
+}

--- a/src/docs/postman/payments_postman_collection.json
+++ b/src/docs/postman/payments_postman_collection.json
@@ -48,42 +48,6 @@
       "description": "Setup de autenticación para testing",
       "item": [
         {
-          "name": "Login Admin (Setup)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "if (pm.response.code === 200) {",
-                  "    const response = pm.response.json();",
-                  "    pm.collectionVariables.set('jwt_token', response.data.token);",
-                  "    console.log('✅ Admin login exitoso');",
-                  "}"
-                ]
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"email\": \"admin@turnity.com\",\n  \"password\": \"admin123\"\n}"
-            },
-            "url": {
-              "raw": "{{base_url}}/auth/login",
-              "host": ["{{base_url}}"],
-              "path": ["auth", "login"]
-            },
-            "description": "Login con admin. Guarda token automáticamente."
-          }
-        },
-        {
           "name": "Login Stylist Lucía (Setup)",
           "event": [
             {
@@ -93,9 +57,8 @@
                   "if (pm.response.code === 200) {",
                   "    const response = pm.response.json();",
                   "    pm.collectionVariables.set('jwt_token', response.data.token);",
-                  "    if (response.data.user.stylist) {",
-                  "        pm.collectionVariables.set('stylist_id', response.data.user.stylist.id);",
-                  "    }",
+                  "    // stylist_id es el User.id del estilista (no un Stylist.id separado)",
+                  "    pm.collectionVariables.set('stylist_id', response.data.user.id);",
                   "    console.log('✅ Estilista Lucía login exitosa');",
                   "}"
                 ]
@@ -168,8 +131,11 @@
                   "if (pm.response.code === 200) {",
                   "    const response = pm.response.json();",
                   "    if (response.data && response.data.length > 0) {",
-                  "        pm.collectionVariables.set('appointment_id', response.data[0].id);",
-                  "        console.log('✅ Appointment ID guardado:', response.data[0].id);",
+                  "        // Preferir una cita CONFIRMED/COMPLETED (confirmedAt seteado, no cancelada), ya que CreatePayment lo exige",
+                  "        const validAppointment = response.data.find(apt => apt.confirmedAt && !apt.cancelledBy);",
+                  "        const chosen = validAppointment || response.data[0];",
+                  "        pm.collectionVariables.set('appointment_id', chosen.id);",
+                  "        console.log('✅ Appointment ID guardado:', chosen.id, validAppointment ? '(confirmada)' : '(sin confirmar, puede fallar en Create Payment)');",
                   "    } else {",
                   "        console.log('⚠️ No hay citas disponibles');",
                   "    }",
@@ -193,6 +159,42 @@
               "path": ["appointments", "stylist", "{{stylist_id}}"]
             },
             "description": "Obtiene citas del estilista logueado para usar su appointment_id en los tests de pagos. Alternativa: setear appointment_id manualmente."
+          }
+        },
+        {
+          "name": "Login Admin (Setup)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    const response = pm.response.json();",
+                  "    pm.collectionVariables.set('jwt_token', response.data.token);",
+                  "    console.log('✅ Admin login exitoso');",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"admin@turnity.com\",\n  \"password\": \"admin123\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/auth/login",
+              "host": ["{{base_url}}"],
+              "path": ["auth", "login"]
+            },
+            "description": "Login con admin. Guarda token automáticamente. Se ejecuta al final a proposito, para dejar el token de Admin activo antes de las carpetas Payment CRUD y Payment Queries (requieren rol ADMIN o ADMIN/STYLIST)."
           }
         }
       ]
@@ -1353,6 +1355,9 @@
           "request": {
             "method": "GET",
             "header": [],
+            "auth": {
+              "type": "noauth"
+            },
             "url": {
               "raw": "{{base_url}}/payments",
               "host": ["{{base_url}}"],
@@ -1385,6 +1390,9 @@
                 "type": "text"
               }
             ],
+            "auth": {
+              "type": "noauth"
+            },
             "url": {
               "raw": "{{base_url}}/payments",
               "host": ["{{base_url}}"],

--- a/src/docs/postman/services_postman_collection.json
+++ b/src/docs/postman/services_postman_collection.json
@@ -1,0 +1,741 @@
+{
+  "info": {
+    "name": "Services API v1.0",
+    "description": "Colección para el módulo Services - Gestión de categorías, servicios y relaciones estilista-servicio",
+    "version": "1.0.0",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "http://localhost:3000/api/v1",
+      "type": "string"
+    },
+    {
+      "key": "jwt_token",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "category_id",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "service_id",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "stylist_id",
+      "value": "",
+      "type": "string"
+    }
+  ],
+  "auth": {
+    "type": "bearer",
+    "bearer": [
+      {
+        "key": "token",
+        "value": "{{jwt_token}}",
+        "type": "string"
+      }
+    ]
+  },
+  "item": [
+    {
+      "name": "Categories Management",
+      "description": "Gestión de categorías de servicios",
+      "item": [
+        {
+          "name": "Get All Categories",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    const response = pm.response.json();",
+                  "    pm.test('Success response', function () {",
+                  "        pm.expect(response.success).to.be.true;",
+                  "        pm.expect(Array.isArray(response.data)).to.be.true;",
+                  "    });",
+                  "    if (response.data.length > 0) {",
+                  "        pm.collectionVariables.set('category_id', response.data[0].id);",
+                  "    }",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/categories",
+              "host": ["{{base_url}}"],
+              "path": ["categories"]
+            }
+          }
+        },
+        {
+          "name": "Get Active Categories",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/categories/active",
+              "host": ["{{base_url}}"],
+              "path": ["categories", "active"]
+            }
+          }
+        },
+        {
+          "name": "Get Category by ID",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/categories/{{category_id}}",
+              "host": ["{{base_url}}"],
+              "path": ["categories", "{{category_id}}"]
+            }
+          }
+        },
+        {
+          "name": "Create Category (Admin)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 201) {",
+                  "    const response = pm.response.json();",
+                  "    pm.collectionVariables.set('category_id', response.data.id);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Cabello & Estilismo\",\n  \"description\": \"Servicios profesionales de corte, peinado y tratamientos capilares\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/categories",
+              "host": ["{{base_url}}"],
+              "path": ["categories"]
+            }
+          }
+        },
+        {
+          "name": "Update Category (Admin)",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Cabello & Estilismo Actualizada\",\n  \"description\": \"Servicios profesionales de corte, peinado y tratamientos capilares - Descripción actualizada\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/categories/{{category_id}}",
+              "host": ["{{base_url}}"],
+              "path": ["categories", "{{category_id}}"]
+            }
+          }
+        },
+        {
+          "name": "Deactivate Category (Admin)",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/categories/{{category_id}}/deactivate",
+              "host": ["{{base_url}}"],
+              "path": ["categories", "{{category_id}}", "deactivate"]
+            }
+          }
+        },
+        {
+          "name": "Activate Category (Admin)",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/categories/{{category_id}}/activate",
+              "host": ["{{base_url}}"],
+              "path": ["categories", "{{category_id}}", "activate"]
+            }
+          }
+        },
+        {
+          "name": "Delete Category (Admin)",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/categories/{{category_id}}",
+              "host": ["{{base_url}}"],
+              "path": ["categories", "{{category_id}}"]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Services Management",
+      "description": "Gestión de servicios",
+      "item": [
+        {
+          "name": "Get All Services",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    const response = pm.response.json();",
+                  "    pm.test('Success response', function () {",
+                  "        pm.expect(response.success).to.be.true;",
+                  "    });",
+                  "    if (response.data.length > 0) {",
+                  "        pm.collectionVariables.set('service_id', response.data[0].id);",
+                  "    }",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/services",
+              "host": ["{{base_url}}"],
+              "path": ["services"]
+            }
+          }
+        },
+        {
+          "name": "Get Active Services",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/services/active",
+              "host": ["{{base_url}}"],
+              "path": ["services", "active"]
+            }
+          }
+        },
+        {
+          "name": "Get Services by Category",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/services/category/{{category_id}}",
+              "host": ["{{base_url}}"],
+              "path": ["services", "category", "{{category_id}}"]
+            }
+          }
+        },
+        {
+          "name": "Get Active Services by Category",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/services/category/{{category_id}}/active",
+              "host": ["{{base_url}}"],
+              "path": ["services", "category", "{{category_id}}", "active"]
+            }
+          }
+        },
+        {
+          "name": "Get Service by ID",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/services/{{service_id}}",
+              "host": ["{{base_url}}"],
+              "path": ["services", "{{service_id}}"]
+            }
+          }
+        },
+        {
+          "name": "Create Service (Admin)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 201) {",
+                  "    const response = pm.response.json();",
+                  "    pm.collectionVariables.set('service_id', response.data.id);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"categoryId\": \"{{category_id}}\",\n  \"name\": \"Corte Premium\",\n  \"description\": \"Corte de cabello profesional con consulta de estilo personalizada\",\n  \"duration\": 45,\n  \"durationVariation\": 15,\n  \"price\": 35.00\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/services",
+              "host": ["{{base_url}}"],
+              "path": ["services"]
+            }
+          }
+        },
+        {
+          "name": "Update Service (Admin)",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Corte Premium Deluxe\",\n  \"description\": \"Corte de cabello profesional con consulta de estilo, lavado y peinado incluidos\",\n  \"duration\": 60,\n  \"durationVariation\": 20,\n  \"price\": 40.00\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/services/{{service_id}}",
+              "host": ["{{base_url}}"],
+              "path": ["services", "{{service_id}}"]
+            }
+          }
+        },
+        {
+          "name": "Deactivate Service (Admin)",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/services/{{service_id}}/deactivate",
+              "host": ["{{base_url}}"],
+              "path": ["services", "{{service_id}}", "deactivate"]
+            }
+          }
+        },
+        {
+          "name": "Activate Service (Admin)",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/services/{{service_id}}/activate",
+              "host": ["{{base_url}}"],
+              "path": ["services", "{{service_id}}", "activate"]
+            }
+          }
+        },
+        {
+          "name": "Delete Service (Admin)",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/services/{{service_id}}",
+              "host": ["{{base_url}}"],
+              "path": ["services", "{{service_id}}"]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Stylist-Service Management",
+      "description": "Gestión de relaciones entre estilistas y servicios",
+      "item": [
+        {
+          "name": "Get Stylist Services",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/services/stylists/{{stylist_id}}/services",
+              "host": ["{{base_url}}"],
+              "path": ["services", "stylists", "{{stylist_id}}", "services"]
+            }
+          }
+        },
+        {
+          "name": "Get Active Stylist Offerings",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/services/stylists/{{stylist_id}}/services/active",
+              "host": ["{{base_url}}"],
+              "path": ["services", "stylists", "{{stylist_id}}", "services", "active"]
+            }
+          }
+        },
+        {
+          "name": "Get Service Stylists",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/services/{{service_id}}/stylists",
+              "host": ["{{base_url}}"],
+              "path": ["services", "{{service_id}}", "stylists"]
+            }
+          }
+        },
+        {
+          "name": "Get Stylists Offering Service",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/services/{{service_id}}/stylists/offering",
+              "host": ["{{base_url}}"],
+              "path": ["services", "{{service_id}}", "stylists", "offering"]
+            }
+          }
+        },
+        {
+          "name": "Assign Service to Stylist",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"serviceId\": \"{{service_id}}\",\n  \"customPrice\": 45.00\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/services/stylists/{{stylist_id}}/services",
+              "host": ["{{base_url}}"],
+              "path": ["services", "stylists", "{{stylist_id}}", "services"]
+            }
+          }
+        },
+        {
+          "name": "Update Stylist Service",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"customPrice\": 50.00,\n  \"isOffering\": true\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/services/stylists/{{stylist_id}}/services/{{service_id}}",
+              "host": ["{{base_url}}"],
+              "path": ["services", "stylists", "{{stylist_id}}", "services", "{{service_id}}"]
+            }
+          }
+        },
+        {
+          "name": "Remove Service from Stylist",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/services/stylists/{{stylist_id}}/services/{{service_id}}",
+              "host": ["{{base_url}}"],
+              "path": ["services", "stylists", "{{stylist_id}}", "services", "{{service_id}}"]
+            }
+          }
+        },
+        {
+          "name": "Get Stylist with Services (Detailed)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/services/stylists/{{stylist_id}}/services/detailed",
+              "host": ["{{base_url}}"],
+              "path": ["services", "stylists", "{{stylist_id}}", "services", "detailed"]
+            }
+          }
+        },
+        {
+          "name": "Get Service with Stylists (Detailed)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/services/{{service_id}}/stylists/detailed",
+              "host": ["{{base_url}}"],
+              "path": ["services", "{{service_id}}", "stylists", "detailed"]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Authentication Setup",
+      "description": "Setup de autenticación para testing",
+      "item": [
+        {
+          "name": "Quick Login Admin",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    const response = pm.response.json();",
+                  "    pm.collectionVariables.set('jwt_token', response.data.token);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"admin@turnity.com\",\n  \"password\": \"admin123\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/auth/login",
+              "host": ["{{base_url}}"],
+              "path": ["auth", "login"]
+            }
+          }
+        },
+        {
+          "name": "Quick Login Stylist",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    const response = pm.response.json();",
+                  "    pm.collectionVariables.set('jwt_token', response.data.token);",
+                  "    // stylist_id es el User.id del estilista (no un Stylist.id separado)",
+                  "    pm.collectionVariables.set('stylist_id', response.data.user.id);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"lucia@turnity.com\",\n  \"password\": \"stylist123\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/auth/login",
+              "host": ["{{base_url}}"],
+              "path": ["auth", "login"]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Error Testing",
+      "description": "Tests de validación de errores",
+      "item": [
+        {
+          "name": "Invalid UUID in Category",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Error de UUID inválido', function () {",
+                  "    pm.expect(pm.response.code).to.eql(400);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/categories/invalid-uuid",
+              "host": ["{{base_url}}"],
+              "path": ["categories", "invalid-uuid"]
+            }
+          }
+        },
+        {
+          "name": "Non-existent Category",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Error de categoría no encontrada', function () {",
+                  "    pm.expect(pm.response.code).to.eql(404);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/categories/123e4567-e89b-12d3-a456-426614174000",
+              "host": ["{{base_url}}"],
+              "path": ["categories", "123e4567-e89b-12d3-a456-426614174000"]
+            }
+          }
+        },
+        {
+          "name": "Unauthorized Category Creation",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Error de no autorizado', function () {",
+                  "    pm.expect(pm.response.code).to.eql(401);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Test Category\",\n  \"description\": \"This should fail\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/categories",
+              "host": ["{{base_url}}"],
+              "path": ["categories"]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -115,6 +115,21 @@ paths:
                           email:
                             type: string
                             example: "ana.lopez@example.com"
+                          role:
+                            type: object
+                            properties:
+                              id:
+                                type: string
+                                example: "123e4567-e89b-12d3-a456-426614174000"
+                              name:
+                                type: string
+                                enum: [ADMIN, CLIENT, STYLIST]
+                                example: "CLIENT"
+                          preferences:
+                            type: string
+                            nullable: true
+                            example: null
+                            description: "Preferencias del usuario (opcional, relevante para clientes)"
         '401':
           $ref: '#/components/responses/Error401'
 
@@ -754,12 +769,7 @@ paths:
       summary: Servicios de un estilista
       security: []
       parameters:
-        - name: stylistId
-          in: path
-          required: true
-          schema:
-            type: string
-            example: "123e4567-e89b-12d3-a456-426614174000"
+        - $ref: '#/components/parameters/StylistIdParam'
       responses:
         '200':
           description: Servicios del estilista obtenidos exitosamente
@@ -785,12 +795,7 @@ paths:
       tags: [Stylist Services]
       summary: Asignar servicio a estilista
       parameters:
-        - name: stylistId
-          in: path
-          required: true
-          schema:
-            type: string
-            example: "123e4567-e89b-12d3-a456-426614174000"
+        - $ref: '#/components/parameters/StylistIdParam'
       requestBody:
         required: true
         content:
@@ -827,12 +832,7 @@ paths:
       summary: Servicios que ofrece activamente
       security: []
       parameters:
-        - name: stylistId
-          in: path
-          required: true
-          schema:
-            type: string
-            example: "123e4567-e89b-12d3-a456-426614174000"
+        - $ref: '#/components/parameters/StylistIdParam'
       responses:
         '200':
           description: Servicios activos del estilista obtenidos exitosamente
@@ -860,12 +860,7 @@ paths:
       summary: Estilista con servicios detallados
       security: []
       parameters:
-        - name: stylistId
-          in: path
-          required: true
-          schema:
-            type: string
-            example: "123e4567-e89b-12d3-a456-426614174000"
+        - $ref: '#/components/parameters/StylistIdParam'
       responses:
         '200':
           description: Estilista con servicios obtenido exitosamente
@@ -881,12 +876,7 @@ paths:
       tags: [Stylist Services]
       summary: Actualizar relación estilista-servicio
       parameters:
-        - name: stylistId
-          in: path
-          required: true
-          schema:
-            type: string
-            example: "123e4567-e89b-12d3-a456-426614174000"
+        - $ref: '#/components/parameters/StylistIdParam'
         - name: serviceId
           in: path
           required: true
@@ -926,12 +916,7 @@ paths:
       tags: [Stylist Services]
       summary: Remover servicio de estilista
       parameters:
-        - name: stylistId
-          in: path
-          required: true
-          schema:
-            type: string
-            example: "123e4567-e89b-12d3-a456-426614174000"
+        - $ref: '#/components/parameters/StylistIdParam'
         - name: serviceId
           in: path
           required: true
@@ -1065,6 +1050,7 @@ paths:
                 stylistId:
                   type: string
                   example: "123e4567-e89b-12d3-a456-426614174000"
+                  description: "ID del estilista asignado (User.id de un usuario con rol STYLIST, opcional)"
                 serviceIds:
                   type: array
                   items:
@@ -1109,6 +1095,7 @@ paths:
         - name: stylistId
           in: query
           required: false
+          description: "ID del estilista para filtrar (User.id de un usuario con rol STYLIST)"
           schema:
             type: string
             example: "123e4567-e89b-12d3-a456-426614174000"
@@ -1148,12 +1135,7 @@ paths:
       tags: [Appointments]
       summary: Obtener citas de un estilista
       parameters:
-        - name: stylistId
-          in: path
-          required: true
-          schema:
-            type: string
-            example: "123e4567-e89b-12d3-a456-426614174000"
+        - $ref: '#/components/parameters/StylistIdParam'
       responses:
         '200':
           description: Citas del estilista obtenidas exitosamente
@@ -1213,6 +1195,7 @@ paths:
                 stylistId:
                   type: string
                   example: "123e4567-e89b-12d3-a456-426614174000"
+                  description: "ID del estilista asignado (User.id de un usuario con rol STYLIST, opcional)"
                 serviceIds:
                   type: array
                   items:
@@ -2516,6 +2499,16 @@ components:
       scheme: bearer
       bearerFormat: JWT
 
+  parameters:
+    StylistIdParam:
+      name: stylistId
+      in: path
+      required: true
+      description: "ID del estilista (User.id de un usuario con rol STYLIST, no una entidad Stylist separada)"
+      schema:
+        type: string
+        example: "123e4567-e89b-12d3-a456-426614174000"
+
   schemas:
     SuccessResponse:
       type: object
@@ -2613,6 +2606,7 @@ components:
         stylistId:
           type: string
           example: "123e4567-e89b-12d3-a456-426614174000"
+          description: "ID del estilista (User.id de un usuario con rol STYLIST, no una entidad Stylist separada)"
         serviceId:
           type: string
           example: "123e4567-e89b-12d3-a456-426614174000"
@@ -2675,7 +2669,7 @@ components:
         stylistId:
           type: string
           example: "123e4567-e89b-12d3-a456-426614174000"
-          description: "ID del estilista asignado (opcional)"
+          description: "ID del estilista asignado (User.id de un usuario con rol STYLIST, opcional). No es una entidad Stylist separada."
         scheduleId:
           type: string
           example: "123e4567-e89b-12d3-a456-426614174000"
@@ -2773,7 +2767,7 @@ components:
         stylistId:
           type: string
           example: "123e4567-e89b-12d3-a456-426614174000"
-          description: "ID del estilista para este slot (opcional)"
+          description: "ID del estilista para este slot (User.id de un usuario con rol STYLIST, opcional)"
 
     Payment:
       type: object

--- a/src/modules/notifications/application/use-cases/GetNotificationById.ts
+++ b/src/modules/notifications/application/use-cases/GetNotificationById.ts
@@ -2,7 +2,7 @@ import { INotificationRepository } from '../../domain/repositories/INotification
 import { NotificationDto } from '../dto/response/NotificationDto';
 import { ValidationError } from '../../../../shared/exceptions/ValidationError';
 import { NotFoundError } from '../../../../shared/exceptions/NotFoundError';
-import { BusinessRuleError } from '../../../../shared/exceptions/BusinessRuleError';
+import { ForbiddenError } from '../../../../shared/exceptions/ForbiddenError';
 
 /**
  * Caso de uso para obtener una notificación por su ID
@@ -18,7 +18,7 @@ export class GetNotificationById {
    * @returns Promise con el DTO de la notificación
    * @throws ValidationError si los IDs no son válidos
    * @throws NotFoundError si la notificación no existe
-   * @throws BusinessRuleError si el usuario no tiene permiso
+   * @throws ForbiddenError si el usuario no tiene permiso
    */
   async execute(notificationId: string, requesterId: string): Promise<NotificationDto> {
     // 1. Validar IDs
@@ -34,7 +34,7 @@ export class GetNotificationById {
 
     // 3. Validar permisos (solo el propietario puede ver su notificación)
     if (notification.userId !== requesterId) {
-      throw new BusinessRuleError('You do not have permission to access this notification');
+      throw new ForbiddenError('You do not have permission to access this notification');
     }
 
     // 4. Mapear a DTO

--- a/src/modules/notifications/application/use-cases/MarkNotificationAsRead.ts
+++ b/src/modules/notifications/application/use-cases/MarkNotificationAsRead.ts
@@ -5,7 +5,7 @@ import { MarkAsReadDto } from '../dto/request/MarkAsReadDto';
 import { NotificationDto } from '../dto/response/NotificationDto';
 import { ValidationError } from '../../../../shared/exceptions/ValidationError';
 import { NotFoundError } from '../../../../shared/exceptions/NotFoundError';
-import { BusinessRuleError } from '../../../../shared/exceptions/BusinessRuleError';
+import { ForbiddenError } from '../../../../shared/exceptions/ForbiddenError';
 
 /**
  * Caso de uso para marcar notificaciones como leídas
@@ -24,7 +24,7 @@ export class MarkNotificationAsRead {
    * @returns Promise con el número de notificaciones actualizadas
    * @throws ValidationError si los datos no son válidos
    * @throws NotFoundError si la notificación o estado no existe
-   * @throws BusinessRuleError si el usuario no tiene permiso
+   * @throws ForbiddenError si el usuario no tiene permiso
    */
   async execute(dto: MarkAsReadDto, requesterId: string): Promise<{ updatedCount: number }> {
     // 1. Validar datos de entrada
@@ -67,7 +67,7 @@ export class MarkNotificationAsRead {
 
     // 3. Validar que la notificación pertenece al usuario
     if (notification.userId !== requesterId) {
-      throw new BusinessRuleError('You do not have permission to access this notification');
+      throw new ForbiddenError('You do not have permission to access this notification');
     }
 
     // 4. Obtener el estado READ
@@ -169,7 +169,7 @@ export class MarkNotificationAsRead {
    * @param notificationIds - IDs de notificaciones a validar
    * @param userId - ID del usuario propietario esperado
    * @throws NotFoundError si alguna notificación no existe
-   * @throws BusinessRuleError si alguna notificación no pertenece al usuario
+   * @throws ForbiddenError si alguna notificación no pertenece al usuario
    */
   private async validateNotificationsOwnership(
     notificationIds: string[],
@@ -183,7 +183,7 @@ export class MarkNotificationAsRead {
       }
       
       if (notification.userId !== userId) {
-        throw new BusinessRuleError(
+        throw new ForbiddenError(
           `You do not have permission to access notification ${id}`,
         );
       }

--- a/tests/unit/notifications/application/use-cases/GetNotificationById.unit.test.ts
+++ b/tests/unit/notifications/application/use-cases/GetNotificationById.unit.test.ts
@@ -3,7 +3,7 @@ import { NotificationRepository } from '../../../../../src/modules/notifications
 import { Notification, NotificationTypeEnum } from '../../../../../src/modules/notifications/domain/entities/Notification';
 import { ValidationError } from '../../../../../src/shared/exceptions/ValidationError';
 import { NotFoundError } from '../../../../../src/shared/exceptions/NotFoundError';
-import { BusinessRuleError } from '../../../../../src/shared/exceptions/BusinessRuleError';
+import { ForbiddenError } from '../../../../../src/shared/exceptions/ForbiddenError';
 import { generateUuid } from '../../../../../src/shared/utils/uuid';
 
 describe('GetNotificationById Use Case', () => {
@@ -156,15 +156,15 @@ describe('GetNotificationById Use Case', () => {
   });
 
   describe('Permission Validation', () => {
-    // Debería lanzar BusinessRuleError si el usuario no es propietario
-    it('should throw BusinessRuleError if user is not owner', async () => {
+    // Debería lanzar ForbiddenError si el usuario no es propietario
+    it('should throw ForbiddenError if user is not owner', async () => {
       // Arrange
       const otherUserId = generateUuid();
       const notification = createMockNotification({ userId: otherUserId });
       mockNotificationRepository.findById.mockResolvedValue(notification);
 
       // Act & Assert
-      await expect(useCase.execute(validNotificationId, validUserId)).rejects.toThrow(BusinessRuleError);
+      await expect(useCase.execute(validNotificationId, validUserId)).rejects.toThrow(ForbiddenError);
       await expect(useCase.execute(validNotificationId, validUserId)).rejects.toThrow('You do not have permission to access this notification');
     });
 

--- a/tests/unit/notifications/application/use-cases/MarkNotificationAsRead.unit.test.ts
+++ b/tests/unit/notifications/application/use-cases/MarkNotificationAsRead.unit.test.ts
@@ -5,7 +5,7 @@ import { Notification, NotificationTypeEnum } from '../../../../../src/modules/n
 import { NotificationStatus, NotificationStatusEnum } from '../../../../../src/modules/notifications/domain/entities/NotificationStatus';
 import { ValidationError } from '../../../../../src/shared/exceptions/ValidationError';
 import { NotFoundError } from '../../../../../src/shared/exceptions/NotFoundError';
-import { BusinessRuleError } from '../../../../../src/shared/exceptions/BusinessRuleError';
+import { ForbiddenError } from '../../../../../src/shared/exceptions/ForbiddenError';
 import { generateUuid } from '../../../../../src/shared/utils/uuid';
 
 describe('MarkNotificationAsRead Use Case', () => {
@@ -201,8 +201,8 @@ describe('MarkNotificationAsRead Use Case', () => {
   });
 
   describe('Permission Validation', () => {
-    // Debería lanzar BusinessRuleError si usuario no es propietario
-    it('should throw BusinessRuleError if user is not owner', async () => {
+    // Debería lanzar ForbiddenError si usuario no es propietario
+    it('should throw ForbiddenError if user is not owner', async () => {
       // Arrange
       const otherUserId = generateUuid();
       const notification = createMockNotification({ userId: otherUserId });
@@ -211,11 +211,11 @@ describe('MarkNotificationAsRead Use Case', () => {
 
       // Act & Assert
       await expect(useCase.execute({ notificationId: validNotificationId }, validUserId))
-        .rejects.toThrow(BusinessRuleError);
+        .rejects.toThrow(ForbiddenError);
     });
 
-    // Debería lanzar BusinessRuleError en executeSingle si usuario no es propietario
-    it('should throw BusinessRuleError in executeSingle if user is not owner', async () => {
+    // Debería lanzar ForbiddenError en executeSingle si usuario no es propietario
+    it('should throw ForbiddenError in executeSingle if user is not owner', async () => {
       // Arrange
       const otherUserId = generateUuid();
       const notification = createMockNotification({ userId: otherUserId });
@@ -224,7 +224,7 @@ describe('MarkNotificationAsRead Use Case', () => {
 
       // Act & Assert
       await expect(useCase.executeSingle(validNotificationId, validUserId))
-        .rejects.toThrow(BusinessRuleError);
+        .rejects.toThrow(ForbiddenError);
     });
   });
 


### PR DESCRIPTION
## Contexto

Continuación de la campaña de actualización de documentación posterior al refactor que eliminó las tablas intermedias `Client` y `Stylist` (ahora `Appointment.clientId`, `Appointment.stylistId` y `StylistService.stylistId` referencian `User.id` directamente). Este PR ejecuta las 4 fases planificadas en `src/docs/session-handoff-v6.md`.

## Fase 1 — Business Rules
- `01-auth.md`: agregado campo `preferences` a `User`, eliminada entidad `Client`, actualizada sección de desactivación en cascada y relaciones con Stylists.
- `04-stylists.md`: eliminada entidad `Stylist`, corregido `StylistService.stylistId` → `User.id`, actualizadas reglas de asignación y relación con Auth, cerrado ISSUE-17.
- `06-appointments.md`: actualizada validación de estilista, relaciones con Clients/Stylists, cerrada limitación de asimetría de IDs (D9).

## Fase 2 — Postman Collections
Alcance original: `auth`, `services`, `appointments`. Se extendió a `payments` y `notifications` al encontrar el mismo bug raíz por fuera del alcance planeado; `holidays` se verificó sin cambios necesarios.

Bugs reales encontrados y corregidos (no solo texto desactualizado):
- **Referencia rota `response.data.user.stylist.id`**: el login response ya no incluye objetos `client`/`stylist` anidados (breaking change). Corregido en `services` y `payments`.
- **Bug de herencia de auth**: requests de "sin token" / "token inválido" heredaban el `jwt_token` válido de la colección en vez de probar el caso real. Corregido con `auth: noauth` en 4 colecciones.
- **Fechas hardcodeadas no repetibles** en `appointments`: generación aleatoria en UTC (evita timezone del servidor vs. cliente) respetando horario laboral y evitando fines de semana.
- **Orden de login incorrecto** en `payments` y `notifications`: el token de Admin quedaba pisado por logins posteriores, causando `401` en operaciones que requieren rol ADMIN.
- **Selección ciega de cita en `payments`**: tomaba la primera cita de la lista sin validar su estado, pudiendo ser una cancelada.
- **Query antes de creación en `notifications`**: se consultaban notificaciones antes de que existiera ninguna.

Validado ejecutando las 6 colecciones con Newman contra un servidor local — todas en verde.

## Fase 3 — README.md
- Badge y conteo de tests actualizado (1118+).
- Tabla de entidades: eliminadas `Client`/`Stylist`, actualizadas `User` y `StylistService`.
- Estructura de tests actualizada.
- Verificación adicional contra el código real (no solo contra el plan): confirmado que endpoints, roles y estructura de módulos coinciden con el código, excepto 2 endpoints de Payments documentados como `(autenticado)` que en realidad requieren `(ADMIN/STYLIST)` — corregido.

## Fase 4 — Swagger/OpenAPI
- Confirmado que no existen schemas `Client`/`Stylist`.
- Agregado componente reutilizable `StylistIdParam` y documentado `stylistId` como `User.id` en 3 schemas y ~10 endpoints.
- Enriquecido el objeto `user` de `/auth/login` con `role` y `preferences`.
- Validado con `openapi-spec-validator` (spec OpenAPI 3.0.3 válido, sin referencias rotas).

## Bug adicional (fuera de alcance, detectado por la suite de tests)
`GetNotificationById` y `MarkNotificationAsRead` lanzaban `BusinessRuleError` (422) en vez de `ForbiddenError` (403) al validar ownership de notificaciones — inconsistente con los tests de integración existentes y con el propio uso documentado de `ForbiddenError`. Corregido en las 3 ocurrencias, junto con los unit tests que afirmaban el comportamiento anterior.

## Testing
- 6 colecciones de Postman ejecutadas manualmente vía Newman: todas en verde.
- Suite completa de Jest: **1118 tests, 73 suites, 0 fallos**.

## Pendiente (documentado en Trabajo Futuro, no incluido en este PR)
- Extracción de `UserRoleValidationService` como Domain Service (duplicación en 3 use cases).
- Gap de validación en `clientId` (no valida existencia ni rol, a diferencia de `stylistId`).
- Validación de `preferences` en Postman sin confirmar en la práctica (requiere reset completo de base).