### PR TITLE
fix: remediación de auditoría de reglas de negocio (9 divergencias, 6 gaps) + endurecimiento de dominio

### DIFF
--- a/src/docs/business-rules/01-auth.md
+++ b/src/docs/business-rules/01-auth.md
@@ -62,7 +62,7 @@ El módulo de autenticación gestiona el registro, login y sesiones de usuarios 
 | Nombre requerido | No puede estar vacío, máximo 100 caracteres, se trimea al guardar |
 | Email único | No pueden existir dos usuarios con el mismo email |
 | Email válido | Debe tener formato de email válido. Se normaliza a minúsculas al registrar |
-| Teléfono válido | Formato E.164 simplificado: `+` opcional al inicio, primer dígito 1–9, entre 2 y 15 dígitos en total; sin letras ni separadores |
+| Teléfono válido | Formato E.164 simplificado: `+` opcional al inicio, primer dígito 1–9, entre 7 y 15 dígitos en total; sin letras ni separadores. Se rechazan teléfonos compuestos solo por ceros (ej. `0000000`) |
 | Password seguro | Mínimo 8 caracteres, al menos una mayúscula, una minúscula y un número |
 | Rol por defecto | Si no se especifica, se asigna rol CLIENT |
 | Foto de perfil | Opcional. Si se proporciona, debe ser una URL válida |
@@ -90,7 +90,7 @@ El módulo de autenticación gestiona el registro, login y sesiones de usuarios 
 | Email inmutable | El email no puede cambiarse después del registro |
 | Password separado | La contraseña se cambia en endpoint separado |
 | Nombre válido | Si se envía, no puede estar vacío (máx 100 caracteres) |
-| Teléfono válido | Si se envía, debe cumplir el mismo formato E.164 simplificado que en registro (`+` opcional, primer dígito 1–9, 2 a 15 dígitos en total) |
+| Teléfono válido | Si se envía, debe cumplir el mismo formato E.164 simplificado que en registro (`+` opcional, primer dígito 1–9, 7 a 15 dígitos en total, sin ser solo ceros) |
 | Foto de perfil | Si se envía, debe ser una URL válida |
 
 ### 4.5 Cambio de Contraseña

--- a/src/docs/business-rules/02-categories.md
+++ b/src/docs/business-rules/02-categories.md
@@ -80,7 +80,7 @@ Las categorías agrupan los servicios ofrecidos por el salón (ej: "Cortes", "Co
 
 | Método | Endpoint | Descripción | Permisos |
 |--------|----------|-------------|----------|
-| GET | /api/v1/categories | Listar todas las categorías | Público |
+| GET | /api/v1/categories | Listar categorías (activas por defecto; `?includeInactive=true` incluye también las inactivas — CAT-11) | Público |
 | GET | /api/v1/categories/active | Listar categorías activas | Público |
 | GET | /api/v1/categories/:id | Obtener por ID | Público |
 | POST | /api/v1/categories | Crear categoría | Admin |

--- a/src/docs/business-rules/04-stylists.md
+++ b/src/docs/business-rules/04-stylists.md
@@ -24,7 +24,7 @@ El módulo gestiona la relación entre estilistas y los servicios que ofrecen. L
 | createdAt | DateTime | Fecha de creación |
 | updatedAt | DateTime | Última actualización |
 
-> **Nota**: StylistService SÍ tiene campo `id` propio (UUID). `stylistId` y `serviceId` no son clave compuesta.
+> **Nota**: El schema de Prisma define `id` (UUID) como clave primaria de `StylistService` y además un `@@unique([stylistId, serviceId])`. Sin embargo, la **entidad de dominio** `StylistService.ts` no modela el campo `id`, y el repositorio usa el par `(stylistId, serviceId)` como clave de acceso en la práctica (`findByStylistAndService`, `delete(stylistId, serviceId)`, `existsAssignment`). En este sentido, `(stylistId, serviceId)` **es** la clave efectiva a nivel de dominio/aplicación, aunque a nivel de base de datos exista también un `id` propio.
 
 ---
 

--- a/src/docs/business-rules/05-schedules.md
+++ b/src/docs/business-rules/05-schedules.md
@@ -73,7 +73,7 @@ Los horarios definen los días y horas de operación del salón. Cada día de la
 | Incrementos | La duración debe ser en múltiplos de 15 minutos |
 | Duración por defecto | 30 minutos si no se especifica |
 | stylistId opcional | UUID válido para filtrar por estilista |
-| serviceIds opcional | Lista de UUIDs válidos para filtrar por servicios |
+| serviceIds opcional | Lista de UUIDs válidos. Si se proporciona, se filtra la disponibilidad: si además se especifica `stylistId`, se verifica que ese estilista ofrezca (`isOffering = true`) todos los servicios indicados; si no se especifica `stylistId`, se verifica que exista al menos un estilista que ofrezca todos los servicios. Si no se cumple, todos los slots del día se marcan `available: false` con el motivo correspondiente en `conflictReason` |
 
 ### 4.2 Proceso de Generación
 
@@ -88,7 +88,7 @@ Los horarios definen los días y horas de operación del salón. Cada día de la
 8. Retornar respuesta con slots y metadata
 ```
 
-> **Limitación conocida (ISSUE-12):** Actualmente, `GetAvailableSlots` solo consulta el `Schedule` regular por día de la semana. No consulta feriados (`IHolidayRepository`) ni excepciones de horario (`IScheduleExceptionRepository`). La lógica de prioridad `ScheduleException > Holiday > Schedule regular` está planificada como feature futura. Del mismo modo, `CreateAppointment` no valida contra feriados ni excepciones al crear una cita.
+> **Integración con feriados y excepciones (antes ISSUE-12, resuelto):** `GetAvailableSlots` consulta `ScheduleAvailabilityService.getEffectiveSchedule()`, que implementa la prioridad `ScheduleException > Holiday > Schedule regular`. Del mismo modo, `CreateAppointment` valida contra feriados y excepciones al crear una cita, usando el mismo servicio de dominio. Ver §7 y `06-appointments.md` §10 para el detalle del servicio.
 
 ### 4.3 Detección de Conflictos
 
@@ -143,4 +143,4 @@ La entidad Schedule no tiene endpoints propios. Se accede a través del módulo 
 ## 7. Relaciones con Otros Módulos
 
 - **Appointments**: Los horarios determinan cuándo se pueden crear citas. `GetAvailableSlots` es el endpoint público. `CreateAppointment` valida que la hora de la cita caiga dentro del horario laboral del día (`startTime`-`endTime`)
-- **Holidays**: Los feriados pueden vincular horarios especiales via `holidayId`. Las ScheduleExceptions modifican días específicos. **Nota:** La integración entre feriados/excepciones y disponibilidad de citas está diferida como feature futura (ver ISSUE-12 en INTERVENTION_PLAN.md)
+- **Holidays**: Los feriados pueden vincular horarios especiales via `holidayId`. Las ScheduleExceptions modifican días específicos. La integración entre feriados/excepciones y disponibilidad de citas está implementada vía `ScheduleAvailabilityService`, usado tanto por `GetAvailableSlots` como por `CreateAppointment`

--- a/src/docs/business-rules/06-appointments.md
+++ b/src/docs/business-rules/06-appointments.md
@@ -86,7 +86,7 @@ Todas las rutas de consulta y mutación (ver §3.3) requieren `authenticate` + `
 | Acción | ¿Quién puede? | Validación en código |
 |--------|--------------|---------------------|
 | Crear cita | Cualquier autenticado (ADMIN, STYLIST o CLIENT) | `authenticate` + `authorize(['ADMIN','STYLIST','CLIENT'])` |
-| Confirmar cita | El creador (`userId`) o el estilista asignado (`stylistId`) | `authenticate` + `authorize(['ADMIN','STYLIST','CLIENT'])`; `ConfirmAppointment` valida participación usando `roleName`/`requesterId` resueltos por `authorize` |
+| Confirmar cita | El creador (`userId`), el cliente (`clientId`) o el estilista asignado (`stylistId`) | `authenticate` + `authorize(['ADMIN','STYLIST','CLIENT'])`; `ConfirmAppointment.validateConfirmationPermissions` permite `userId \|\| clientId \|\| stylistId` (además de ADMIN), usando `roleName`/`requesterId` resueltos por `authorize` |
 | Cancelar cita | El creador (`userId`), cliente (`clientId`), o estilista (`stylistId`) | `authenticate` + `authorize(['ADMIN','STYLIST','CLIENT'])`; `CancelAppointment` valida participación usando `roleName`/`requesterId` resueltos por `authorize` |
 | Actualizar cita | Cualquier autenticado (ADMIN, STYLIST o CLIENT) | `authenticate` + `authorize(['ADMIN','STYLIST','CLIENT'])` |
 
@@ -136,7 +136,7 @@ Todas las rutas de consulta y mutación (ver §3.3) requieren `authenticate` + `
 | No completada | No se pueden confirmar citas con estado COMPLETED |
 | No en el pasado | No se pueden confirmar citas que ya pasaron |
 | Tiempo mínimo | Debe confirmarse al menos **1 hora antes** de la cita |
-| Permisos | El creador (`userId`) o el estilista asignado (`stylistId`) pueden confirmar |
+| Permisos | El creador (`userId`), el cliente (`clientId`) o el estilista asignado (`stylistId`) pueden confirmar |
 | Registro | Se guarda `confirmedAt` con la fecha de confirmación |
 | Notas | Opcionales, máximo 500 caracteres. Se almacenan en `confirmationNotes` |
 
@@ -159,7 +159,11 @@ Todas las rutas de consulta y mutación (ver §3.3) requieren `authenticate` + `
 |-------|-------------|
 | Ventana de tiempo | Solo se puede modificar si faltan al menos 24 horas para la cita (`canBeModified()`) |
 | Reprogramar | Se puede cambiar fecha/hora y opcionalmente duración. Nueva fecha no puede ser en el pasado |
+| Reprogramar: horario efectivo | Al cambiar `dateTime` y/o `duration`, se revalida contra el horario efectivo del día (`ScheduleAvailabilityService.getEffectiveSchedule`, misma prioridad `Exception > Holiday > Regular` que en creación); se rechaza si el día está cerrado o si la cita queda fuera del horario laboral |
+| Reprogramar: límite diario | Si cambia `dateTime`, se revalida el límite de 3 citas activas por cliente por día sobre la nueva fecha (excluyendo la propia cita que se está reprogramando) |
+| Reprogramar cita confirmada | Si la cita está en estado CONFIRMED y se cambia `dateTime`, se exige `notes` o `reason` en la actualización (`BusinessRuleError` si no se provee ninguno) |
 | Servicios | Se pueden agregar o remover servicios individuales. No se pueden duplicar |
+| Servicios: validación de disponibilidad | Al actualizar los servicios de la cita se revalida que cada servicio esté activo (`isActive = true`) y, si hay estilista asignado, que lo ofrezca activamente (`isOffering = true`) — misma validación que en creación (`CreateAppointment`) |
 | Estilista | Se puede reasignar a otro estilista |
 
 ---

--- a/src/docs/business-rules/07-notifications.md
+++ b/src/docs/business-rules/07-notifications.md
@@ -125,7 +125,7 @@ FAILED (Fallida)
     └── → PENDING (Reintento permitido)
 ```
 
-> Las transiciones se validan en código mediante `NotificationStatus.canTransitionTo()`
+> Las transiciones se validan en código mediante `NotificationStatus.canTransitionTo()`, **excepto** en el marcado de lectura (`MarkNotificationAsRead`, individual/batch), que actualiza el `statusId` directamente a READ sin invocar `canTransitionTo()`. En la práctica, una notificación puede pasar de PENDING a READ directamente (sin transicionar por SENT), ya que actualmente no existe un servicio de envío que ejecute la transición PENDING→SENT. Esta es una excepción intencional al diagrama de arriba: READ es alcanzable tanto desde SENT como directamente desde PENDING.
 
 ---
 

--- a/src/docs/business-rules/08-payments.md
+++ b/src/docs/business-rules/08-payments.md
@@ -49,11 +49,13 @@ El módulo de pagos gestiona el procesamiento de cobros asociados a las citas. S
 
 ## 3. Permisos por Rol
 
-> **Nota de ownership (F18):** para STYLIST y CLIENT, los permisos de esta tabla están además restringidos por ownership sobre la cita asociada al pago. STYLIST solo accede (lectura y mutaciones de proceso/cancelación) a pagos de citas donde es el estilista asignado; CLIENT solo accede en lectura a pagos de citas donde es el cliente o el creador (vía `/appointment/:id`, sin acceso de mutación). ADMIN no tiene restricción de ownership en ningún caso.
+> **Nota de ownership (F18):** para STYLIST y CLIENT, los permisos de esta tabla están además restringidos por ownership sobre la cita asociada al pago. STYLIST solo accede (lectura, creación y mutaciones de proceso/cancelación) a pagos de citas donde es el estilista asignado; CLIENT solo accede en lectura a pagos de citas donde es el cliente o el creador (vía `/appointment/:id`, sin acceso de mutación). ADMIN no tiene restricción de ownership en ningún caso.
+>
+> **Ownership en creación (PAY-25):** `CreatePayment` valida que, si el solicitante es STYLIST, sea el estilista asignado a la cita del pago (`ForbiddenError` si no); un estilista no puede crear pagos para citas de otros estilistas.
 
 | Acción | ADMIN | STYLIST | CLIENT | Público |
 |--------|-------|---------|--------|---------|
-| Crear pago | ✅ | ✅ | ❌ | ❌ |
+| Crear pago | ✅ | ✅ (solo su cita) | ❌ | ❌ |
 | Listar todos los pagos | ✅ | ❌ | ❌ | ❌ |
 | Ver pago por ID | ✅ | ✅ (solo su cita) | ❌ | ❌ |
 | Ver pagos por cita | ✅ | ✅ (solo su cita) | ✅ (solo su cita, vía `/appointment/:id`) | ❌ |
@@ -87,7 +89,7 @@ El módulo de pagos gestiona el procesamiento de cobros asociados a las citas. S
 | Solo pendientes | Solo se pueden procesar pagos en estado PENDING | 422 |
 | Método requerido | Se debe especificar el método de pago | 400 |
 | Método válido | El método debe ser uno de los valores del enum | 400 |
-| Fecha de pago | Se registra automáticamente `paidAt` | - |
+| Fecha de pago | Se registra automáticamente `paymentDate` (nombre real del campo en la entidad/DTO/schema) | - |
 | Estado final | El estado cambia a COMPLETED | - |
 
 ### 4.3 Reembolso de Pagos

--- a/src/modules/appointments/AppointmentContainer.ts
+++ b/src/modules/appointments/AppointmentContainer.ts
@@ -156,6 +156,8 @@ export class AppointmentContainer {
       this._appointmentRepository,
       this._scheduleRepository,
       scheduleAvailabilityService,
+      this._stylistServiceRepository,
+      this._userRepository,
     );
 
     this._confirmAppointment = new ConfirmAppointment(
@@ -168,6 +170,8 @@ export class AppointmentContainer {
       this._appointmentStatusRepository,
       this._serviceRepository,
       userRoleValidationService,
+      scheduleAvailabilityService,
+      this._stylistServiceRepository,
     );
 
     // HTTP Layer - Inyectamos los casos de uso implementados

--- a/src/modules/appointments/application/use-cases/GetAvailableSlots.ts
+++ b/src/modules/appointments/application/use-cases/GetAvailableSlots.ts
@@ -2,6 +2,8 @@ import { IAppointmentRepository } from '../../domain/repositories/IAppointmentRe
 import { Appointment } from '../../domain/entities/Appointment';
 import { IScheduleRepository } from '../../domain/repositories/IScheduleRepository';
 import { ScheduleAvailabilityService } from '../../domain/services/ScheduleAvailabilityService';
+import { IStylistServiceRepository } from '../../../services/domain/repositories/IStylistServiceRepository';
+import { IUserRepository } from '../../../auth/domain/repositories/IUserRepository';
 import { GetAvailableSlotsDto } from '../dto/request/GetAvailableSlotsDto';
 import { DayAvailabilityDto, AvailableSlotDto } from '../dto/response/AvailableSlotDto';
 import { ValidationError } from '../../../../shared/exceptions/ValidationError';
@@ -19,6 +21,8 @@ export class GetAvailableSlots {
     private appointmentRepository: IAppointmentRepository,
     private scheduleRepository: IScheduleRepository,
     private scheduleAvailabilityService: ScheduleAvailabilityService,
+    private stylistServiceRepository: IStylistServiceRepository,
+    private userRepository: IUserRepository,
   ) {}
 
   /**
@@ -60,22 +64,98 @@ export class GetAvailableSlots {
     // 8. Obtener citas existentes para el día
     const existingAppointments = await this.getExistingAppointments(targetDate, request.stylistId);
 
-    // 9. Calcular disponibilidad de cada slot
+    // 9. Resolver nombre real del estilista si se especifica (SCH-20)
+    const stylistName = request.stylistId
+      ? await this.resolveStylistName(request.stylistId)
+      : undefined;
+
+    // 10. Determinar si hay al menos un estilista que ofrezca todos los servicios solicitados (SCH-14)
+    const serviceFilterReason = await this.evaluateServiceFilter(
+      request.serviceIds,
+      request.stylistId,
+    );
+
+    // 11. Calcular disponibilidad de cada slot
     const availableSlots = await this.calculateSlotAvailability(
       baseSlots,
       existingAppointments,
       targetDate,
       duration,
       request.stylistId,
+      stylistName,
+      serviceFilterReason,
     );
 
-    // 10. Construir y retornar respuesta con horario efectivo
+    // 12. Construir y retornar respuesta con horario efectivo
     return this.buildDayAvailabilityResponse(
       request.date,
       dayOfWeek,
       { startTime: effectiveSchedule.startTime, endTime: effectiveSchedule.endTime },
       availableSlots,
     );
+  }
+
+  /**
+   * Resuelve el nombre real del estilista desde el repositorio (SCH-20)
+   * Si el usuario no existe (caso borde), retorna un fallback genérico en vez de fallar la consulta
+   */
+  private async resolveStylistName(stylistId: string): Promise<string> {
+    const user = await this.userRepository.findById(stylistId);
+    return user?.name ?? 'Unknown stylist';
+  }
+
+  /**
+   * Evalúa si los `serviceIds` solicitados son ofrecidos por al menos un estilista
+   * (o por el `stylistId` específico, si se proporciona). Implementa el filtro por
+   * servicio prometido en la documentación (SCH-14).
+   * @returns undefined si no aplica ningún filtro (no se pidieron serviceIds, o hay
+   * al menos un estilista elegible); un motivo de no-disponibilidad en caso contrario
+   */
+  private async evaluateServiceFilter(
+    serviceIds: string[] | undefined,
+    stylistId: string | undefined,
+  ): Promise<string | undefined> {
+    if (!serviceIds || serviceIds.length === 0) {
+      return undefined;
+    }
+
+    if (stylistId) {
+      // Verificar que el estilista específico ofrezca TODOS los servicios solicitados
+      for (const serviceId of serviceIds) {
+        const assignment = await this.stylistServiceRepository.findByStylistAndService(
+          stylistId,
+          serviceId,
+        );
+        if (!assignment || !assignment.isOffering) {
+          return 'Selected stylist does not offer the requested combination of services';
+        }
+      }
+      return undefined;
+    }
+
+    // Sin stylistId: verificar que exista AL MENOS un estilista que ofrezca todos los servicios
+    let eligibleStylistIds: Set<string> | undefined;
+    for (const serviceId of serviceIds) {
+      const offerings = await this.stylistServiceRepository.findStylistsOfferingService(serviceId);
+      const offeringStylistIds: Set<string> = new Set(
+        offerings.filter((o) => o.isOffering).map((o) => o.stylistId),
+      );
+
+      if (!eligibleStylistIds) {
+        eligibleStylistIds = offeringStylistIds;
+      } else {
+        const intersection: Set<string> = new Set(
+          [...eligibleStylistIds].filter((id) => offeringStylistIds.has(id)),
+        );
+        eligibleStylistIds = intersection;
+      }
+
+      if (eligibleStylistIds.size === 0) {
+        return 'No stylist currently offers the requested combination of services';
+      }
+    }
+
+    return undefined;
   }
 
   /**
@@ -258,6 +338,8 @@ export class GetAvailableSlots {
     targetDate: Date,
     duration: number,
     stylistId?: string,
+    stylistName?: string,
+    serviceFilterReason?: string,
   ): Promise<AvailableSlotDto[]> {
     const availableSlots: AvailableSlotDto[] = [];
 
@@ -268,19 +350,23 @@ export class GetAvailableSlots {
       // Verificar conflictos con citas existentes
       const conflict = this.checkForConflicts(slotDateTime, slotEndTime, existingAppointments);
 
+      // El filtro por servicio (SCH-14) tiene prioridad como motivo si aplica
+      const isAvailable = !conflict.hasConflict && !serviceFilterReason;
+      const reason = serviceFilterReason ?? conflict.reason;
+
       const slot: AvailableSlotDto = {
         time: slotTime,
-        available: !conflict.hasConflict,
+        available: isAvailable,
         duration,
-        conflictReason: conflict.reason,
+        conflictReason: reason,
       };
 
-      // Agregar información del estilista si se especifica
+      // Agregar información del estilista si se especifica (SCH-20: nombre real, no placeholder)
       if (stylistId) {
         slot.stylist = {
           id: stylistId,
-          name: 'Estilista', // En implementación real, obtener del repositorio
-          available: !conflict.hasConflict,
+          name: stylistName ?? 'Unknown stylist',
+          available: isAvailable,
         };
       }
 

--- a/src/modules/appointments/application/use-cases/UpdateAppointment.ts
+++ b/src/modules/appointments/application/use-cases/UpdateAppointment.ts
@@ -2,6 +2,7 @@ import { Appointment } from '../../domain/entities/Appointment';
 import { IAppointmentRepository } from '../../domain/repositories/IAppointmentRepository';
 import { IAppointmentStatusRepository } from '../../domain/repositories/IAppointmentStatusRepository';
 import { IServiceRepository } from '../../../services/domain/repositories/IServiceRepository';
+import { IStylistServiceRepository } from '../../../services/domain/repositories/IStylistServiceRepository';
 import { UserRoleValidationService } from '../../../auth/domain/services/UserRoleValidationService';
 import { RoleName } from '@prisma/client';
 import { AppointmentDto } from '../dto/response/AppointmentDto';
@@ -13,17 +14,26 @@ import { ForbiddenError } from '../../../../shared/exceptions/ForbiddenError';
 import { ConflictError } from '../../../../shared/exceptions/ConflictError';
 import { AppointmentStatusEnum } from '../../domain/entities/AppointmentStatus';
 import { assertValidUuid } from '../../../../shared/utils/validateUuid';
+import {
+  ScheduleAvailabilityService,
+  EffectiveSchedule,
+} from '../../domain/services/ScheduleAvailabilityService';
 
 /**
  * Caso de uso para actualizar una cita existente
  * Maneja la actualización con validaciones de reglas de negocio y detección de conflictos
  */
 export class UpdateAppointment {
+  /** Máximo de citas activas por cliente por día (alineado con CreateAppointment) */
+  private static readonly MAX_DAILY_APPOINTMENTS = 3;
+
   constructor(
     private appointmentRepository: IAppointmentRepository,
     private appointmentStatusRepository: IAppointmentStatusRepository,
     private serviceRepository: IServiceRepository,
     private userRoleValidationService: UserRoleValidationService,
+    private scheduleAvailabilityService: ScheduleAvailabilityService,
+    private stylistServiceRepository: IStylistServiceRepository,
   ) {}
 
   /**
@@ -70,6 +80,16 @@ export class UpdateAppointment {
 
     if (updateDto.serviceIds !== undefined) {
       await this.updateServices(appointment, updateDto.serviceIds);
+    }
+
+    // 6. Si cambió la fecha/hora o la duración, revalidar horario efectivo (día cerrado / fuera de horario laboral)
+    if (updateDto.dateTime || updateDto.duration !== undefined) {
+      await this.validateEffectiveSchedule(appointment);
+    }
+
+    // 6b. Si cambió la fecha, revalidar el límite diario de citas activas del cliente sobre la nueva fecha
+    if (updateDto.dateTime) {
+      await this.validateDailyAppointmentLimit(appointment, appointmentId);
     }
 
     // 7. Validar conflictos después de todos los cambios
@@ -293,13 +313,34 @@ export class UpdateAppointment {
 
   /**
    * Actualiza los servicios de la cita
+   * Revalida que cada servicio esté activo y, si hay estilista asignado, que lo
+   * siga ofreciendo activamente (misma validación que CreateAppointment — APT-29)
    */
   private async updateServices(appointment: Appointment, newServiceIds: string[]): Promise<void> {
-    // Verificar que todos los servicios existen
+    // Verificar que todos los servicios existen y están activos
     for (const serviceId of newServiceIds) {
       const service = await this.serviceRepository.findById(serviceId);
       if (!service) {
         throw new NotFoundError('Service', serviceId);
+      }
+      if (!service.isActive) {
+        throw new BusinessRuleError(`Service '${service.name}' is not currently active`);
+      }
+    }
+
+    // Verificar que el estilista (final, ya aplicado el posible cambio) ofrezca los servicios seleccionados
+    if (appointment.stylistId) {
+      for (const serviceId of newServiceIds) {
+        const assignment = await this.stylistServiceRepository.findByStylistAndService(
+          appointment.stylistId,
+          serviceId,
+        );
+        if (!assignment) {
+          throw new BusinessRuleError('Stylist does not offer one of the selected services');
+        }
+        if (!assignment.isOffering) {
+          throw new BusinessRuleError('Stylist is not currently offering one of the selected services');
+        }
       }
     }
 
@@ -307,6 +348,95 @@ export class UpdateAppointment {
     appointment.serviceIds = [];
     for (const serviceId of newServiceIds) {
       appointment.addService(serviceId);
+    }
+  }
+
+  /**
+   * Revalida que la cita (con la fecha/duración ya aplicadas) siga dentro del
+   * horario efectivo del día (prioridad Exception > Holiday > Regular),
+   * reusando ScheduleAvailabilityService.getEffectiveSchedule (APT-39)
+   */
+  private async validateEffectiveSchedule(appointment: Appointment): Promise<void> {
+    const effectiveSchedule = await this.scheduleAvailabilityService.getEffectiveSchedule(
+      appointment.dateTime,
+    );
+
+    if (!effectiveSchedule) {
+      throw new BusinessRuleError(
+        'The salon is closed on the selected date (holiday or no schedule available)',
+      );
+    }
+
+    this.validateWorkingHours(appointment.dateTime, appointment.duration, effectiveSchedule);
+  }
+
+  /**
+   * Valida que la cita completa (inicio + duración) esté dentro del horario laboral del día
+   * Equivalente a CreateAppointment.validateWorkingHours
+   */
+  private validateWorkingHours(
+    dateTime: Date,
+    duration: number,
+    schedule: EffectiveSchedule,
+  ): void {
+    const appointmentHours = dateTime.getUTCHours();
+    const appointmentMinutes = dateTime.getUTCMinutes();
+
+    const [startH, startM] = schedule.startTime.split(':').map(Number);
+    const [endH, endM] = schedule.endTime.split(':').map(Number);
+
+    const appointmentStartInMinutes = appointmentHours * 60 + appointmentMinutes;
+    const appointmentEndInMinutes = appointmentStartInMinutes + duration;
+    const scheduleStartInMinutes = startH * 60 + startM;
+    const scheduleEndInMinutes = endH * 60 + endM;
+
+    if (appointmentStartInMinutes < scheduleStartInMinutes) {
+      throw new BusinessRuleError(
+        `Appointment starts before working hours (${schedule.startTime})`,
+      );
+    }
+
+    if (appointmentEndInMinutes > scheduleEndInMinutes) {
+      throw new BusinessRuleError(
+        `Appointment ends after working hours (${schedule.endTime})`,
+      );
+    }
+  }
+
+  /**
+   * Revalida que el cliente no exceda el límite diario de citas activas en la
+   * nueva fecha, excluyendo la propia cita que se está reprogramando (APT-39)
+   */
+  private async validateDailyAppointmentLimit(
+    appointment: Appointment,
+    appointmentId: string,
+  ): Promise<void> {
+    const appointmentDate = appointment.dateTime;
+
+    const startOfDay = new Date(appointmentDate);
+    startOfDay.setHours(0, 0, 0, 0);
+
+    const endOfDay = new Date(appointmentDate);
+    endOfDay.setHours(23, 59, 59, 999);
+
+    const existingAppointments = await this.appointmentRepository.findByClientAndDateRange(
+      appointment.clientId,
+      startOfDay,
+      endOfDay,
+    );
+
+    const cancelledStatus = await this.appointmentStatusRepository.findByName('CANCELLED');
+
+    const activeAppointments = existingAppointments.filter((a) => {
+      if (a.id === appointmentId) return false; // excluir la propia cita
+      if (cancelledStatus && a.statusId === cancelledStatus.id) return false;
+      return true;
+    });
+
+    if (activeAppointments.length >= UpdateAppointment.MAX_DAILY_APPOINTMENTS) {
+      throw new BusinessRuleError(
+        `Maximum of ${UpdateAppointment.MAX_DAILY_APPOINTMENTS} appointments per day has been reached`,
+      );
     }
   }
 

--- a/src/modules/auth/domain/entities/User.ts
+++ b/src/modules/auth/domain/entities/User.ts
@@ -1,5 +1,5 @@
 import { generateUuid } from '../../../../shared/utils/uuid';
-import { isValidPhone } from '../../../../shared/utils/validation';
+import { isValidPhone, isValidUrl } from '../../../../shared/utils/validation';
 
 /**
  * Entidad de dominio User que representa un usuario del sistema
@@ -51,12 +51,20 @@ export class User {
       throw new Error('User name cannot be empty');
     }
 
+    if (name.trim().length > 100) {
+      throw new Error('User name cannot exceed 100 characters');
+    }
+
     if (!phone || phone.trim() === '') {
       throw new Error('Phone cannot be empty');
     }
 
     if (!isValidPhone(phone)) {
       throw new Error('Invalid phone format');
+    }
+
+    if (profilePicture && !isValidUrl(profilePicture)) {
+      throw new Error('Profile picture must be a valid URL');
     }
 
     this.id = id;
@@ -137,6 +145,9 @@ export class User {
       if (!name || name.trim() === '') {
         throw new Error('User name cannot be empty');
       }
+      if (name.trim().length > 100) {
+        throw new Error('User name cannot exceed 100 characters');
+      }
       this.name = name.trim();
     }
 
@@ -151,18 +162,12 @@ export class User {
     }
 
     if (profilePicture !== undefined) {
+      if (profilePicture && !isValidUrl(profilePicture)) {
+        throw new Error('Profile picture must be a valid URL');
+      }
       this.profilePicture = profilePicture;
     }
 
-    this.updatedAt = new Date();
-  }
-
-  /**
-   * Actualiza las preferencias del usuario
-   * @param preferences - Nuevas preferencias (null para eliminar)
-   */
-  updatePreferences(preferences: string | null): void {
-    this.preferences = preferences;
     this.updatedAt = new Date();
   }
 

--- a/src/modules/auth/presentation/validations/AuthValidations.ts
+++ b/src/modules/auth/presentation/validations/AuthValidations.ts
@@ -27,7 +27,7 @@ export class AuthValidations {
     body('phone')
       .notEmpty()
       .withMessage('Phone is required')
-      .matches(/^\+?[1-9]\d{1,14}$/)
+      .matches(/^\+?[1-9]\d{6,14}$/)
       .withMessage('Valid phone is required'),
 
     body('password')
@@ -90,7 +90,7 @@ export class AuthValidations {
 
     body('phone')
       .optional()
-      .matches(/^\+?[1-9]\d{1,14}$/)
+      .matches(/^\+?[1-9]\d{6,14}$/)
       .withMessage('Valid phone is required'),
 
     body('profilePicture')

--- a/src/modules/payments/application/use-cases/CreatePayment.ts
+++ b/src/modules/payments/application/use-cases/CreatePayment.ts
@@ -8,10 +8,13 @@ import { PaymentResponseDto } from '../dto/response/PaymentResponseDto';
 import { ValidationError } from '../../../../shared/exceptions/ValidationError';
 import { NotFoundError } from '../../../../shared/exceptions/NotFoundError';
 import { BusinessRuleError } from '../../../../shared/exceptions/BusinessRuleError';
+import { ForbiddenError } from '../../../../shared/exceptions/ForbiddenError';
 
 /**
  * Caso de uso para crear un pago
- * @description Crea un nuevo pago asociado a una cita
+ * @description Crea un nuevo pago asociado a una cita. Aplica control de acceso
+ * por ownership (PAY-25): ADMIN sin restricción, STYLIST solo puede crear pagos
+ * para citas donde es el estilista asignado (misma regla que process/cancel, F18)
  */
 export class CreatePayment {
   constructor(
@@ -23,9 +26,17 @@ export class CreatePayment {
   /**
    * Ejecuta el caso de uso
    * @param dto - Datos para crear el pago
+   * @param requesterId - ID del usuario que realiza la operación (opcional por compatibilidad;
+   * si se omite junto con requesterRole, no se aplica validación de ownership)
+   * @param requesterRole - Nombre del rol del usuario solicitante
    * @returns El pago creado
+   * @throws ForbiddenError si un STYLIST intenta crear un pago para una cita ajena
    */
-  async execute(dto: CreatePaymentDto): Promise<PaymentResponseDto> {
+  async execute(
+    dto: CreatePaymentDto,
+    requesterId?: string,
+    requesterRole?: string,
+  ): Promise<PaymentResponseDto> {
     // Validar que el monto sea positivo
     if (dto.amount <= 0) {
       throw new ValidationError('Amount must be greater than 0');
@@ -36,6 +47,9 @@ export class CreatePayment {
     if (!appointment) {
       throw new NotFoundError('Appointment', dto.appointmentId);
     }
+
+    // Validar ownership: STYLIST solo puede crear pagos de sus propias citas (PAY-25)
+    this.validateAccessPermissions(appointment, requesterId, requesterRole);
 
     // Validar que la cita esté en un estado válido para crear pago
     const status = await this.appointmentStatusRepository.findById(appointment.statusId);
@@ -58,6 +72,28 @@ export class CreatePayment {
 
     // Retornar DTO de respuesta
     return this.toResponseDto(savedPayment);
+  }
+
+  /**
+   * Valida que el usuario tenga permisos para crear un pago sobre la cita indicada.
+   * Si no se proporciona requesterId/requesterRole (compatibilidad hacia atrás), no
+   * se aplica ninguna restricción. ADMIN no tiene restricción; STYLIST solo puede
+   * crear pagos para citas donde es el estilista asignado (PAY-25, alineado con F18)
+   * @throws ForbiddenError si un STYLIST intenta crear un pago para una cita ajena
+   */
+  private validateAccessPermissions(
+    appointment: { stylistId?: string },
+    requesterId?: string,
+    requesterRole?: string,
+  ): void {
+    if (!requesterId || !requesterRole) return;
+    if (requesterRole === 'ADMIN') return;
+
+    if (requesterRole === 'STYLIST') {
+      if (appointment.stylistId !== requesterId) {
+        throw new ForbiddenError('You can only create payments for your own appointments');
+      }
+    }
   }
 
   private toResponseDto(payment: Payment): PaymentResponseDto {

--- a/src/modules/payments/presentation/controllers/PaymentController.ts
+++ b/src/modules/payments/presentation/controllers/PaymentController.ts
@@ -40,12 +40,20 @@ export class PaymentController {
    * @throws ValidationError si el monto no es válido
    */
   async create(req: AuthenticatedRequest, res: Response): Promise<Response> {
+    if (!req.user?.userId || !req.user?.roleName) {
+      throw new UnauthorizedError('Authentication required');
+    }
+
     const { amount, appointmentId } = req.body;
 
-    const payment = await this._createPayment.execute({
-      amount,
-      appointmentId,
-    });
+    const payment = await this._createPayment.execute(
+      {
+        amount,
+        appointmentId,
+      },
+      req.user.userId,
+      req.user.roleName,
+    );
 
     return res.status(201).json({
       success: true,

--- a/src/modules/services/application/use-cases/GetAllCategories.ts
+++ b/src/modules/services/application/use-cases/GetAllCategories.ts
@@ -3,18 +3,24 @@ import { CategoryDto } from '../dto/response/CategoryDto';
 import { Category } from '../../domain/entities/Category';
 
 /**
- * Caso de uso para obtener todas las categorías del sistema
+ * Caso de uso para obtener las categorías del sistema
+ * @description Endpoint público (GET /categories). Por defecto excluye las
+ * categorías inactivas (CAT-11), ya que este es el listado público — usar
+ * `includeInactive: true` para obtener también las inactivas (uso administrativo)
  */
 export class GetAllCategories {
   constructor(private categoryRepository: ICategoryRepository) {}
 
   /**
-   * Ejecuta la obtención de todas las categorías
-   * @returns Promise con la lista completa de categorías
+   * Ejecuta la obtención de categorías
+   * @param includeInactive - Si es true, incluye también las categorías inactivas.
+   * Por defecto false (solo activas, ver CAT-11)
+   * @returns Promise con la lista de categorías
    */
-  async execute(): Promise<CategoryDto[]> {
+  async execute(includeInactive = false): Promise<CategoryDto[]> {
     const categories = await this.categoryRepository.findAll();
-    return categories.map((category) => this.mapToDto(category));
+    const filtered = includeInactive ? categories : categories.filter((c) => c.isActive);
+    return filtered.map((category) => this.mapToDto(category));
   }
 
   /**

--- a/src/modules/services/domain/entities/Category.ts
+++ b/src/modules/services/domain/entities/Category.ts
@@ -49,6 +49,9 @@ export class Category {
    * Ejecuta todas las validaciones de negocio para la categoría
    * @throws ValidationError si alguna validación falla
    */
+  /** Solo letras (con acentos) y espacios, igual que CategoryValidations (capa HTTP) */
+  private static readonly NAME_FORMAT_REGEX = /^[a-zA-ZáéíóúÁÉÍÓÚñÑ\s]+$/;
+
   private validate(): void {
     if (!this.name || this.name.trim().length === 0) {
       throw new ValidationError('Category name cannot be empty');
@@ -56,6 +59,10 @@ export class Category {
 
     if (this.name.length > 100) {
       throw new ValidationError('Category name is too long');
+    }
+
+    if (!Category.NAME_FORMAT_REGEX.test(this.name)) {
+      throw new ValidationError('Category name can only contain letters and spaces');
     }
 
     if (this.description && this.description.length > 500) {

--- a/src/modules/services/domain/entities/Service.ts
+++ b/src/modules/services/domain/entities/Service.ts
@@ -22,7 +22,7 @@ export class Service {
    * @param categoryId - ID de la categoría a la que pertenece el servicio
    * @param name - Nombre del servicio (máximo 150 caracteres)
    * @param description - Descripción del servicio (requerida, máximo 1000 caracteres)
-   * @param duration - Duración base en minutos (positivo, máximo 600 minutos)
+   * @param duration - Duración base en minutos (positivo, máximo 480 minutos / 8 horas)
    * @param durationVariation - Variación de duración permitida en minutos
    * @param price - Precio del servicio (no puede ser negativo)
    * @returns Nueva instancia de Service con ID generado automáticamente

--- a/src/modules/services/presentation/controllers/CategoryController.ts
+++ b/src/modules/services/presentation/controllers/CategoryController.ts
@@ -78,13 +78,16 @@ export class CategoryController {
   };
 
   /**
-   * Obtiene todas las categorías del sistema
+   * Obtiene las categorías del sistema
    * @route GET /categories
+   * @description Endpoint público. Por defecto excluye las categorías inactivas (CAT-11).
+   * Acepta `?includeInactive=true` para incluirlas también (uso administrativo)
    * @responseStatus 200 - Categorías obtenidas exitosamente
    */
   getAllCategories = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
-      const categories = await this._getAllCategories.execute();
+      const includeInactive = req.query.includeInactive === 'true';
+      const categories = await this._getAllCategories.execute(includeInactive);
       res.status(200).json({ success: true, message: 'Categories retrieved successfully', data: categories });
     } catch (error) {
       next(error);

--- a/src/shared/utils/validation.ts
+++ b/src/shared/utils/validation.ts
@@ -71,6 +71,26 @@ export const isValidPassword = (password: string): boolean => {
   return true;
 };
 
+/**
+ * Valida que una cadena sea una URL bien formada con protocolo http o https
+ * @description Endurecimiento de dominio (observación transversal del audit):
+ * antes esta regla solo vivía en express-validator (`isURL()`), permitiendo que
+ * la entidad `User` aceptara cualquier string como `profilePicture` si se
+ * instanciaba fuera del flujo HTTP
+ */
+export const isValidUrl = (url: string): boolean => {
+  if (!url || typeof url !== 'string' || url.trim() === '') {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(url.trim());
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+
 export const isValidPhone = (phone: string): boolean => {
   if (!phone || typeof phone !== 'string' || phone.trim() === '') {
     return false;

--- a/tests/integration/auth/register.integration.test.ts
+++ b/tests/integration/auth/register.integration.test.ts
@@ -102,6 +102,39 @@ describe('Register Integration Tests', () => {
       expect(response.body.message).toContain('Valid phone is required');
     });
 
+    // Debería rechazar teléfonos con menos de 7 dígitos (AUTH-4/AUTH-16)
+    // (el rango canónico de dígitos es 7-15; antes 2-15 en express-validator,
+    // desalineado con isValidPhone del dominio que ya exigía 7-15)
+    it('should reject phone numbers with fewer than 7 digits (AUTH-4/AUTH-16)', async () => {
+      const response = await request(app)
+        .post('/api/v1/auth/register')
+        .send({
+          name: 'Test User',
+          email: `test-shortphone-${Date.now()}@example.com`,
+          phone: '+12345', // 5 dígitos, por debajo del mínimo de 7
+          password: 'TestPass123!',
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.success).toBe(false);
+      expect(response.body.message).toContain('Valid phone is required');
+    });
+
+    // Debería aceptar el mínimo de 7 dígitos (AUTH-4/AUTH-16)
+    it('should accept phone numbers with exactly 7 digits (AUTH-4/AUTH-16)', async () => {
+      const response = await request(app)
+        .post('/api/v1/auth/register')
+        .send({
+          name: 'Test User',
+          email: `test-minphone-${Date.now()}@example.com`,
+          phone: '+1234567', // exactamente 7 dígitos
+          password: 'TestPass123!',
+        });
+
+      expect(response.status).toBe(201);
+      expect(response.body.success).toBe(true);
+    });
+
     // Debería rechazar nombre de rol inválido
     it('should reject invalid roleName', async () => {
       const response = await request(app)

--- a/tests/integration/services/category-management.integration.test.ts
+++ b/tests/integration/services/category-management.integration.test.ts
@@ -193,22 +193,40 @@ describe('Category Management Integration Tests', () => {
         .set('Authorization', `Bearer ${adminToken}`);
     });
 
-    // Debería obtener todas las categorías
-    it('should get all categories', async () => {
+    // Debería excluir categorías inactivas por defecto (CAT-11: listado público)
+    it('should exclude inactive categories by default (CAT-11)', async () => {
       const response = await request(app).get('/api/v1/categories').expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(Array.isArray(response.body.data)).toBe(true);
+      expect(response.body.data.length).toBeGreaterThanOrEqual(1);
+
+      // Ninguna categoría inactiva debe aparecer en el listado público por defecto
+      const inactiveCategories = response.body.data.filter((c: any) => !c.isActive);
+      expect(inactiveCategories.length).toBe(0);
+
+      // Validar estructura de respuesta
+      response.body.data.forEach((category: any) => {
+        validateCategoryResponse(category);
+      });
+    });
+
+    // Debería incluir también las inactivas con ?includeInactive=true (CAT-11, uso administrativo)
+    it('should include inactive categories with includeInactive=true (CAT-11)', async () => {
+      const response = await request(app)
+        .get('/api/v1/categories?includeInactive=true')
+        .expect(200);
 
       expect(response.body.success).toBe(true);
       expect(Array.isArray(response.body.data)).toBe(true);
       expect(response.body.data.length).toBeGreaterThanOrEqual(2);
 
-      // Verificar que incluye categorías activas e inactivas
       const activeCategories = response.body.data.filter((c: any) => c.isActive);
       const inactiveCategories = response.body.data.filter((c: any) => !c.isActive);
 
       expect(activeCategories.length).toBeGreaterThanOrEqual(1);
       expect(inactiveCategories.length).toBeGreaterThanOrEqual(1);
 
-      // Validar estructura de respuesta
       response.body.data.forEach((category: any) => {
         validateCategoryResponse(category);
       });

--- a/tests/unit/appointments/application/use-cases/GetAvailableSlots.unit.test.ts
+++ b/tests/unit/appointments/application/use-cases/GetAvailableSlots.unit.test.ts
@@ -10,6 +10,8 @@ import { GetAvailableSlotsDto } from '../../../../../src/modules/appointments/ap
 import { ValidationError } from '../../../../../src/shared/exceptions/ValidationError';
 import { BusinessRuleError } from '../../../../../src/shared/exceptions/BusinessRuleError';
 import { ScheduleAvailabilityService } from '../../../../../src/modules/appointments/domain/services/ScheduleAvailabilityService';
+import { IStylistServiceRepository } from '../../../../../src/modules/services/domain/repositories/IStylistServiceRepository';
+import { IUserRepository } from '../../../../../src/modules/auth/domain/repositories/IUserRepository';
 import { generateUuid } from '../../../../../src/shared/utils/uuid';
 
 describe('GetAvailableSlots Use Case', () => {
@@ -17,6 +19,8 @@ describe('GetAvailableSlots Use Case', () => {
   let mockAppointmentRepository: jest.Mocked<IAppointmentRepository>;
   let mockScheduleRepository: jest.Mocked<IScheduleRepository>;
   let mockScheduleAvailabilityService: jest.Mocked<ScheduleAvailabilityService>;
+  let mockStylistServiceRepository: jest.Mocked<IStylistServiceRepository>;
+  let mockUserRepository: jest.Mocked<IUserRepository>;
 
   // Utilidades de fecha dinámicas
   const getFutureDateString = (daysFromNow: number = 7): string => {
@@ -196,10 +200,41 @@ describe('GetAvailableSlots Use Case', () => {
       isDayClosed: jest.fn().mockResolvedValue(false),
     } as unknown as jest.Mocked<ScheduleAvailabilityService>;
 
+    // Mock de IStylistServiceRepository (SCH-14): por defecto el estilista válido ofrece cualquier servicio
+    mockStylistServiceRepository = {
+      findByStylistAndService: jest.fn().mockResolvedValue({ isOffering: true }),
+      findByStylist: jest.fn(),
+      findByService: jest.fn(),
+      findActiveOfferings: jest.fn(),
+      findStylistsOfferingService: jest
+        .fn()
+        .mockResolvedValue([{ stylistId: validStylistId, isOffering: true }]),
+      save: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      existsAssignment: jest.fn(),
+    } as unknown as jest.Mocked<IStylistServiceRepository>;
+
+    // Mock de IUserRepository (SCH-20): por defecto resuelve un nombre real
+    mockUserRepository = {
+      findById: jest.fn().mockResolvedValue({ id: validStylistId, name: 'Jane Stylist' }),
+      findByIdWithRole: jest.fn(),
+      findByEmail: jest.fn(),
+      findByEmailWithRole: jest.fn(),
+      existsByEmail: jest.fn(),
+      save: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      findAll: jest.fn(),
+      findByRole: jest.fn(),
+    } as unknown as jest.Mocked<IUserRepository>;
+
     useCase = new GetAvailableSlots(
       mockAppointmentRepository,
       mockScheduleRepository,
       mockScheduleAvailabilityService,
+      mockStylistServiceRepository,
+      mockUserRepository,
     );
   });
 
@@ -295,6 +330,34 @@ describe('GetAvailableSlots Use Case', () => {
         expect(slot.stylist).toBeDefined();
         expect(slot.stylist!.id).toBe(validStylistId);
       });
+    });
+
+    // SCH-20: el nombre del estilista debe resolverse desde el repositorio, no ser un placeholder
+    it('should resolve the real stylist name from the repository (SCH-20)', async () => {
+      const dateString = getFutureDateString(7);
+      const dto = createValidDto({ date: dateString, stylistId: validStylistId });
+      setupSuccessfulMocks(dateString);
+      mockUserRepository.findById.mockResolvedValue({ id: validStylistId, name: 'Jane Stylist' } as any);
+
+      const result = await useCase.execute(dto);
+
+      expect(mockUserRepository.findById).toHaveBeenCalledWith(validStylistId);
+      result.slots.forEach((slot) => {
+        expect(slot.stylist!.name).toBe('Jane Stylist');
+        expect(slot.stylist!.name).not.toBe('Estilista');
+      });
+    });
+
+    // SCH-20: si el usuario no existe, no debe fallar la consulta completa
+    it('should fall back gracefully if the stylist user is not found', async () => {
+      const dateString = getFutureDateString(7);
+      const dto = createValidDto({ date: dateString, stylistId: validStylistId });
+      setupSuccessfulMocks(dateString);
+      mockUserRepository.findById.mockResolvedValue(null);
+
+      const result = await useCase.execute(dto);
+
+      expect(result.slots[0].stylist!.name).toBe('Unknown stylist');
     });
 
     // Debería calcular correctamente availableSlots count
@@ -552,6 +615,112 @@ describe('GetAvailableSlots Use Case', () => {
       const result = await useCase.execute(dto);
 
       expect(result).toBeDefined();
+    });
+  });
+
+  describe('SCH-14: Service Filter', () => {
+    // Debería marcar todos los slots como no disponibles si el estilista indicado no ofrece los servicios solicitados
+    it('should mark all slots unavailable when the specified stylist does not offer the requested services', async () => {
+      const dateString = getFutureDateString(7);
+      const dto = createValidDto({
+        date: dateString,
+        stylistId: validStylistId,
+        serviceIds: [validServiceId1],
+      });
+      setupSuccessfulMocks(dateString);
+      mockStylistServiceRepository.findByStylistAndService.mockResolvedValue(null);
+
+      const result = await useCase.execute(dto);
+
+      expect(result.availableSlots).toBe(0);
+      result.slots.forEach((slot) => {
+        expect(slot.available).toBe(false);
+        expect(slot.conflictReason).toBe(
+          'Selected stylist does not offer the requested combination of services',
+        );
+      });
+    });
+
+    // Debería marcar todos los slots como no disponibles si el estilista indicado dejó de ofrecer un servicio solicitado
+    it('should mark all slots unavailable when the specified stylist has stopped offering a requested service', async () => {
+      const dateString = getFutureDateString(7);
+      const dto = createValidDto({
+        date: dateString,
+        stylistId: validStylistId,
+        serviceIds: [validServiceId1],
+      });
+      setupSuccessfulMocks(dateString);
+      mockStylistServiceRepository.findByStylistAndService.mockResolvedValue({
+        isOffering: false,
+      } as any);
+
+      const result = await useCase.execute(dto);
+
+      expect(result.availableSlots).toBe(0);
+    });
+
+    // Debería mantener los slots disponibles si el estilista indicado ofrece todos los servicios solicitados
+    it('should keep slots available when the specified stylist offers all requested services', async () => {
+      const dateString = getFutureDateString(7);
+      const dto = createValidDto({
+        date: dateString,
+        stylistId: validStylistId,
+        serviceIds: [validServiceId1, validServiceId2],
+      });
+      setupSuccessfulMocks(dateString);
+      mockStylistServiceRepository.findByStylistAndService.mockResolvedValue({
+        isOffering: true,
+      } as any);
+
+      const result = await useCase.execute(dto);
+
+      expect(result.availableSlots).toBeGreaterThan(0);
+      expect(mockStylistServiceRepository.findByStylistAndService).toHaveBeenCalledWith(
+        validStylistId,
+        validServiceId1,
+      );
+      expect(mockStylistServiceRepository.findByStylistAndService).toHaveBeenCalledWith(
+        validStylistId,
+        validServiceId2,
+      );
+    });
+
+    // Debería marcar todos los slots como no disponibles si ningún estilista (sin filtrar) ofrece la combinación de servicios solicitada
+    it('should mark all slots unavailable when no stylist (unfiltered) offers the requested combination of services', async () => {
+      const dateString = getFutureDateString(7);
+      const dto = createValidDto({
+        date: dateString,
+        serviceIds: [validServiceId1, validServiceId2],
+      });
+      setupSuccessfulMocks(dateString);
+      // Ningún estilista ofrece serviceId1
+      mockStylistServiceRepository.findStylistsOfferingService.mockImplementation(
+        async (serviceId: string) => {
+          if (serviceId === validServiceId1) return [];
+          return [{ stylistId: validStylistId, isOffering: true } as any];
+        },
+      );
+
+      const result = await useCase.execute(dto);
+
+      expect(result.availableSlots).toBe(0);
+      result.slots.forEach((slot) => {
+        expect(slot.conflictReason).toBe(
+          'No stylist currently offers the requested combination of services',
+        );
+      });
+    });
+
+    // Debería no aplicar ningún filtro si no se proporcionan serviceIds
+    it('should not apply any filter when serviceIds is not provided', async () => {
+      const dateString = getFutureDateString(7);
+      const dto = createValidDto({ date: dateString });
+      setupSuccessfulMocks(dateString);
+
+      await useCase.execute(dto);
+
+      expect(mockStylistServiceRepository.findByStylistAndService).not.toHaveBeenCalled();
+      expect(mockStylistServiceRepository.findStylistsOfferingService).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/appointments/application/use-cases/UpdateAppointment.unit.test.ts
+++ b/tests/unit/appointments/application/use-cases/UpdateAppointment.unit.test.ts
@@ -2,7 +2,9 @@ import { UpdateAppointment } from '../../../../../src/modules/appointments/appli
 import { IAppointmentRepository } from '../../../../../src/modules/appointments/domain/repositories/IAppointmentRepository';
 import { IAppointmentStatusRepository } from '../../../../../src/modules/appointments/domain/repositories/IAppointmentStatusRepository';
 import { IServiceRepository } from '../../../../../src/modules/services/domain/repositories/IServiceRepository';
+import { IStylistServiceRepository } from '../../../../../src/modules/services/domain/repositories/IStylistServiceRepository';
 import { UserRoleValidationService } from '../../../../../src/modules/auth/domain/services/UserRoleValidationService';
+import { ScheduleAvailabilityService } from '../../../../../src/modules/appointments/domain/services/ScheduleAvailabilityService';
 import { Appointment } from '../../../../../src/modules/appointments/domain/entities/Appointment';
 import {
   AppointmentStatus,
@@ -23,6 +25,8 @@ describe('UpdateAppointment Use Case', () => {
   let mockAppointmentStatusRepository: jest.Mocked<IAppointmentStatusRepository>;
   let mockServiceRepository: jest.Mocked<IServiceRepository>;
   let mockUserRoleValidationService: jest.Mocked<UserRoleValidationService>;
+  let mockScheduleAvailabilityService: jest.Mocked<ScheduleAvailabilityService>;
+  let mockStylistServiceRepository: jest.Mocked<IStylistServiceRepository>;
 
   const getFutureDate = (hoursFromNow: number = 48): Date => {
     const future = new Date();
@@ -183,11 +187,40 @@ describe('UpdateAppointment Use Case', () => {
       ensureUserHasRole: jest.fn().mockResolvedValue(undefined),
     } as unknown as jest.Mocked<UserRoleValidationService>;
 
+    // Mock de ScheduleAvailabilityService: por defecto un horario amplio y permisivo (APT-39)
+    mockScheduleAvailabilityService = {
+      getEffectiveSchedule: jest.fn().mockResolvedValue({
+        startTime: '00:00',
+        endTime: '23:59',
+        source: 'regular',
+      }),
+      isDayClosed: jest.fn().mockResolvedValue(false),
+    } as unknown as jest.Mocked<ScheduleAvailabilityService>;
+
+    // Mock de IStylistServiceRepository: por defecto el estilista ofrece cualquier servicio (APT-29)
+    mockStylistServiceRepository = {
+      findByStylistAndService: jest.fn().mockResolvedValue({ isOffering: true }),
+      findByStylist: jest.fn(),
+      findByService: jest.fn(),
+      findActiveOfferings: jest.fn(),
+      findStylistsOfferingService: jest.fn(),
+      save: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      existsAssignment: jest.fn(),
+    } as unknown as jest.Mocked<IStylistServiceRepository>;
+
+    // Defaults para la revalidación de límite diario al reprogramar (APT-39)
+    mockAppointmentRepository.findByClientAndDateRange.mockResolvedValue([]);
+    mockAppointmentStatusRepository.findByName.mockResolvedValue(null);
+
     useCase = new UpdateAppointment(
       mockAppointmentRepository,
       mockAppointmentStatusRepository,
       mockServiceRepository,
       mockUserRoleValidationService,
+      mockScheduleAvailabilityService,
+      mockStylistServiceRepository,
     );
   });
 
@@ -196,6 +229,7 @@ describe('UpdateAppointment Use Case', () => {
   });
 
   describe('Successful Execution', () => {
+    // Debería actualizar la cita exitosamente con datos completos
     it('should update appointment successfully with complete data', async () => {
       const completeUpdateDto: UpdateAppointmentDto = {
         dateTime: getFutureISOString(72),
@@ -226,6 +260,7 @@ describe('UpdateAppointment Use Case', () => {
       expect(result.id).toBe(appointment.id);
     });
 
+    // Debería actualizar la cita exitosamente con cambios mínimos
     it('should update appointment successfully with minimal changes', async () => {
       const appointment = createMockAppointment({
         userId: validRequesterId,
@@ -245,6 +280,7 @@ describe('UpdateAppointment Use Case', () => {
       expect(mockUserRoleValidationService.ensureUserHasRole).not.toHaveBeenCalled();
     });
 
+    // Debería permitir la actualización por parte del estilista asignado
     it('should allow update by assigned stylist', async () => {
       const appointment = createMockAppointment({
         stylistId: validRequesterId,
@@ -298,18 +334,21 @@ describe('UpdateAppointment Use Case', () => {
   });
 
   describe('Input Validation', () => {
+    // Debería lanzar error si el appointmentId está vacío
     it('should throw error for empty appointmentId', async () => {
       await expect(
         useCase.execute('', minimalUpdateDto, validRequesterId, adminRole),
       ).rejects.toThrow(new ValidationError('Appointment ID is required'));
     });
 
+    // Debería lanzar error si el formato UUID del appointmentId es inválido
     it('should throw error for invalid appointmentId UUID format', async () => {
       await expect(
         useCase.execute('invalid-uuid', minimalUpdateDto, validRequesterId, adminRole),
       ).rejects.toThrow(new ValidationError('Appointment ID must be a valid UUID'));
     });
 
+    // Debería lanzar error si no se proporciona ningún campo para actualizar
     it('should throw error if no fields provided for update', async () => {
       const emptyDto: UpdateAppointmentDto = {};
       await expect(
@@ -317,6 +356,7 @@ describe('UpdateAppointment Use Case', () => {
       ).rejects.toThrow(new ValidationError('At least one field must be provided for update'));
     });
 
+    // Debería lanzar error si la fecha/hora está en el pasado
     it('should throw error for past dateTime', async () => {
       const pastDate = new Date();
       pastDate.setHours(pastDate.getHours() - 1);
@@ -326,6 +366,7 @@ describe('UpdateAppointment Use Case', () => {
       ).rejects.toThrow(new ValidationError('Appointment cannot be rescheduled to the past'));
     });
 
+    // Debería lanzar error para valores de duración inválidos
     it('should throw error for invalid duration values', async () => {
       const testCases = [
         { duration: 0, expectedError: 'Duration must be greater than 0' },
@@ -341,6 +382,7 @@ describe('UpdateAppointment Use Case', () => {
       }
     });
 
+    // Debería lanzar error si las notas son demasiado largas
     it('should throw error for notes too long', async () => {
       const longNotesDto: UpdateAppointmentDto = { notes: 'x'.repeat(501) };
       await expect(
@@ -350,7 +392,8 @@ describe('UpdateAppointment Use Case', () => {
   });
 
   describe('Business Rules Validation', () => {
-    // Usar rol CLIENT para que no tenga ADMIN override
+    // Debería lanzar ForbiddenError para un usuario sin permisos
+    // (usa rol CLIENT para que no tenga ADMIN override)
     it('should throw ForbiddenError for user without permissions', async () => {
       const unauthorizedUserId = generateUuid();
       const appointment = createMockAppointment({ userId: validUserId, stylistId: validStylistId });
@@ -363,6 +406,7 @@ describe('UpdateAppointment Use Case', () => {
       );
     });
 
+    // Debería lanzar BusinessRuleError para citas en estado terminal
     it('should throw BusinessRuleError for terminal status appointments', async () => {
       const terminalStatuses = ['COMPLETED', 'CANCELLED', 'NO_SHOW'];
       for (const statusName of terminalStatuses) {
@@ -379,6 +423,7 @@ describe('UpdateAppointment Use Case', () => {
       }
     });
 
+    // Debería exigir una nota al cambiar la fecha/hora de una cita confirmada
     it('should require note for dateTime changes in confirmed appointments', async () => {
       const appointment = createMockAppointment({
         userId: validRequesterId,
@@ -400,6 +445,7 @@ describe('UpdateAppointment Use Case', () => {
       );
     });
 
+    // Debería lanzar BusinessRuleError si la modificación es demasiado tardía
     it('should throw BusinessRuleError for too late modifications', async () => {
       const appointment = createMockAppointment({ userId: validRequesterId });
       const confirmedStatus = createMockAppointmentStatus(AppointmentStatusEnum.CONFIRMED);
@@ -414,6 +460,7 @@ describe('UpdateAppointment Use Case', () => {
   });
 
   describe('Not Found Handling', () => {
+    // Debería lanzar NotFoundError si la cita no existe
     it('should throw NotFoundError when appointment does not exist', async () => {
       mockAppointmentRepository.findById.mockResolvedValue(null);
       await expect(
@@ -421,6 +468,7 @@ describe('UpdateAppointment Use Case', () => {
       ).rejects.toThrow(new NotFoundError('Appointment', validAppointmentId));
     });
 
+    // Debería lanzar NotFoundError si el estilista no existe
     it('should throw NotFoundError when stylist does not exist', async () => {
       const appointment = createMockAppointment({
         userId: validRequesterId,
@@ -438,6 +486,7 @@ describe('UpdateAppointment Use Case', () => {
       ).rejects.toThrow(new NotFoundError('Stylist', validNewStylistId));
     });
 
+    // Debería lanzar NotFoundError si el servicio no existe
     it('should throw NotFoundError when service does not exist', async () => {
       const appointment = createMockAppointment({
         userId: validRequesterId,
@@ -455,6 +504,7 @@ describe('UpdateAppointment Use Case', () => {
   });
 
   describe('Conflict Detection', () => {
+    // Debería lanzar ConflictError por conflictos de horario
     it('should throw ConflictError for scheduling conflicts', async () => {
       const appointment = createMockAppointment({
         userId: validRequesterId,
@@ -480,6 +530,7 @@ describe('UpdateAppointment Use Case', () => {
   });
 
   describe('Repository Integration', () => {
+    // Debería llamar a los repositorios con los parámetros correctos
     it('should call repositories with correct parameters', async () => {
       const appointment = createMockAppointment({
         userId: validRequesterId,
@@ -495,7 +546,183 @@ describe('UpdateAppointment Use Case', () => {
     });
   });
 
+  describe('APT-39: Effective Schedule Revalidation on Reschedule', () => {
+    // Debería lanzar BusinessRuleError si la nueva fecha cae en un día cerrado (feriado)
+    it('should throw BusinessRuleError when the new date falls on a closed day (holiday)', async () => {
+      const appointment = createMockAppointment({
+        userId: validRequesterId,
+        dateTime: getFutureDate(96),
+      });
+      jest.spyOn(appointment, 'canBeModified').mockReturnValue(true);
+      setupBasicSuccessfulMocks(appointment);
+      mockScheduleAvailabilityService.getEffectiveSchedule.mockResolvedValue(null);
+
+      const rescheduleDto: UpdateAppointmentDto = {
+        dateTime: getFutureISOString(120),
+        notes: 'Reschedule to closed day',
+      };
+
+      await expect(
+        useCase.execute(validAppointmentId, rescheduleDto, validRequesterId, adminRole),
+      ).rejects.toThrow(
+        new BusinessRuleError(
+          'The salon is closed on the selected date (holiday or no schedule available)',
+        ),
+      );
+    });
+
+    // Debería lanzar BusinessRuleError si el horario reprogramado cae fuera del horario laboral
+    it('should throw BusinessRuleError when the rescheduled time falls outside working hours', async () => {
+      const futureDate = getFutureDate(96);
+      // Fuerza una hora (UTC) fuera del rango de horario efectivo simulado (09:00-17:00)
+      futureDate.setUTCHours(20, 0, 0, 0);
+      const appointment = createMockAppointment({
+        userId: validRequesterId,
+        dateTime: getFutureDate(48),
+      });
+      jest.spyOn(appointment, 'canBeModified').mockReturnValue(true);
+      setupBasicSuccessfulMocks(appointment);
+      mockScheduleAvailabilityService.getEffectiveSchedule.mockResolvedValue({
+        startTime: '09:00',
+        endTime: '17:00',
+        source: 'regular',
+      });
+
+      const rescheduleDto: UpdateAppointmentDto = {
+        dateTime: futureDate.toISOString(),
+        notes: 'Reschedule outside working hours',
+      };
+
+      await expect(
+        useCase.execute(validAppointmentId, rescheduleDto, validRequesterId, adminRole),
+      ).rejects.toThrow(BusinessRuleError);
+    });
+
+    // Debería lanzar BusinessRuleError si se alcanza el límite diario de citas en la nueva fecha
+    it('should throw BusinessRuleError when the daily appointment limit is reached on the new date', async () => {
+      const appointment = createMockAppointment({
+        userId: validRequesterId,
+        dateTime: getFutureDate(96),
+      });
+      jest.spyOn(appointment, 'canBeModified').mockReturnValue(true);
+      setupBasicSuccessfulMocks(appointment);
+
+      const otherAppointment1 = createMockAppointment({ id: generateUuid() });
+      const otherAppointment2 = createMockAppointment({ id: generateUuid() });
+      const otherAppointment3 = createMockAppointment({ id: generateUuid() });
+      mockAppointmentRepository.findByClientAndDateRange.mockResolvedValue([
+        otherAppointment1,
+        otherAppointment2,
+        otherAppointment3,
+      ]);
+
+      const rescheduleDto: UpdateAppointmentDto = {
+        dateTime: getFutureISOString(120),
+        notes: 'Reschedule hitting daily limit',
+      };
+
+      await expect(
+        useCase.execute(validAppointmentId, rescheduleDto, validRequesterId, adminRole),
+      ).rejects.toThrow(
+        new BusinessRuleError('Maximum of 3 appointments per day has been reached'),
+      );
+    });
+
+    // Debería excluir la propia cita del conteo del límite diario
+    it('should exclude the appointment itself from the daily limit count', async () => {
+      const appointment = createMockAppointment({
+        userId: validRequesterId,
+        dateTime: getFutureDate(96),
+      });
+      jest.spyOn(appointment, 'canBeModified').mockReturnValue(true);
+      setupBasicSuccessfulMocks(appointment);
+
+      // La propia cita ya existe en el rango de fechas consultado; no debe contarse a sí misma
+      mockAppointmentRepository.findByClientAndDateRange.mockResolvedValue([appointment]);
+
+      const rescheduleDto: UpdateAppointmentDto = {
+        dateTime: getFutureISOString(120),
+        notes: 'Reschedule same day',
+      };
+
+      const result = await useCase.execute(
+        validAppointmentId,
+        rescheduleDto,
+        validRequesterId,
+        adminRole,
+      );
+
+      expect(result.id).toBe(appointment.id);
+    });
+  });
+
+  describe('APT-29: Service Offering Revalidation on Update', () => {
+    // Debería lanzar BusinessRuleError si un servicio actualizado ya no está activo
+    it('should throw BusinessRuleError when an updated service is no longer active', async () => {
+      const appointment = createMockAppointment({
+        userId: validRequesterId,
+        dateTime: getFutureDate(96),
+      });
+      jest.spyOn(appointment, 'canBeModified').mockReturnValue(true);
+      setupBasicSuccessfulMocks(appointment);
+      const inactiveService = createMockService(validNewServiceId);
+      (inactiveService as any).isActive = false;
+      mockServiceRepository.findById.mockResolvedValue(inactiveService);
+
+      const updateServicesDto: UpdateAppointmentDto = { serviceIds: [validNewServiceId] };
+
+      await expect(
+        useCase.execute(validAppointmentId, updateServicesDto, validRequesterId, adminRole),
+      ).rejects.toThrow(BusinessRuleError);
+    });
+
+    // Debería lanzar BusinessRuleError si el estilista asignado no ofrece el servicio actualizado
+    it('should throw BusinessRuleError when the assigned stylist does not offer the updated service', async () => {
+      const appointment = createMockAppointment({
+        userId: validRequesterId,
+        dateTime: getFutureDate(96),
+        stylistId: validStylistId,
+      });
+      jest.spyOn(appointment, 'canBeModified').mockReturnValue(true);
+      setupBasicSuccessfulMocks(appointment);
+      mockServiceRepository.findById.mockResolvedValue(createMockService(validNewServiceId));
+      mockStylistServiceRepository.findByStylistAndService.mockResolvedValue(null);
+
+      const updateServicesDto: UpdateAppointmentDto = { serviceIds: [validNewServiceId] };
+
+      await expect(
+        useCase.execute(validAppointmentId, updateServicesDto, validRequesterId, adminRole),
+      ).rejects.toThrow(
+        new BusinessRuleError('Stylist does not offer one of the selected services'),
+      );
+    });
+
+    // Debería lanzar BusinessRuleError si el estilista dejó de ofrecer el servicio actualizado
+    it('should throw BusinessRuleError when the stylist has stopped offering the updated service', async () => {
+      const appointment = createMockAppointment({
+        userId: validRequesterId,
+        dateTime: getFutureDate(96),
+        stylistId: validStylistId,
+      });
+      jest.spyOn(appointment, 'canBeModified').mockReturnValue(true);
+      setupBasicSuccessfulMocks(appointment);
+      mockServiceRepository.findById.mockResolvedValue(createMockService(validNewServiceId));
+      mockStylistServiceRepository.findByStylistAndService.mockResolvedValue({
+        isOffering: false,
+      } as any);
+
+      const updateServicesDto: UpdateAppointmentDto = { serviceIds: [validNewServiceId] };
+
+      await expect(
+        useCase.execute(validAppointmentId, updateServicesDto, validRequesterId, adminRole),
+      ).rejects.toThrow(
+        new BusinessRuleError('Stylist is not currently offering one of the selected services'),
+      );
+    });
+  });
+
   describe('Data Mapping', () => {
+    // Debería mapear las fechas al formato ISO string
     it('should map dates to ISO string format', async () => {
       const appointment = createMockAppointment({
         userId: validRequesterId,
@@ -515,6 +742,7 @@ describe('UpdateAppointment Use Case', () => {
       expect(result.createdAt).toBe(appointment.createdAt.toISOString());
     });
 
+    // Debería mantener intacta la estructura del array
     it('should maintain array structure intact', async () => {
       const appointment = createMockAppointment({
         userId: validRequesterId,

--- a/tests/unit/auth/User.unit.test.ts
+++ b/tests/unit/auth/User.unit.test.ts
@@ -106,19 +106,12 @@ describe('User Entity', () => {
       }, 10);
     });
 
-    // Debería actualizar preferencias con un valor string
-    it('should update preferences with a string value', () => {
-      user.updatePreferences('dark-mode');
-      expect(user.preferences).toBe('dark-mode');
+    // Debería no exponer un método updatePreferences (AUTH-31, código muerto eliminado)
+    // (updatePreferences() no tenía caso de uso/endpoint asociado)
+    it('should not expose an updatePreferences method (AUTH-31, removed dead code)', () => {
+      expect((user as any).updatePreferences).toBeUndefined();
     });
 
-    // Debería mantener null al actualizar preferencias con null (no convertir a undefined)
-    it('should keep null when updating preferences with null', () => {
-      user.updatePreferences('dark-mode');
-      user.updatePreferences(null);
-      expect(user.preferences).toBeNull();
-      expect(user.preferences).not.toBeUndefined();
-    });
   });
 
   describe('User Validation', () => {
@@ -165,6 +158,104 @@ describe('User Entity', () => {
           validUserData.isActive,
         );
       }).toThrow('Phone cannot be empty');
+    });
+
+    // Debería lanzar error para nombre de más de 100 caracteres
+    // (endurecimiento de dominio: aplica aunque la entidad se instancie fuera del flujo HTTP)
+    it('should throw error for name longer than 100 characters', () => {
+      expect(() => {
+        new User(
+          validUserData.id,
+          validUserData.roleId,
+          'a'.repeat(101),
+          validUserData.email,
+          validUserData.phone,
+          validUserData.password,
+          validUserData.isActive,
+        );
+      }).toThrow('User name cannot exceed 100 characters');
+    });
+
+    // Debería lanzar error para una URL de foto de perfil inválida
+    // (endurecimiento de dominio: profilePicture debe ser una URL válida si se proporciona)
+    it('should throw error for invalid profile picture URL', () => {
+      expect(() => {
+        new User(
+          validUserData.id,
+          validUserData.roleId,
+          validUserData.name,
+          validUserData.email,
+          validUserData.phone,
+          validUserData.password,
+          validUserData.isActive,
+          'not-a-url',
+        );
+      }).toThrow('Profile picture must be a valid URL');
+    });
+
+    // Debería aceptar una URL de foto de perfil válida
+    it('should accept a valid profile picture URL', () => {
+      const user = new User(
+        validUserData.id,
+        validUserData.roleId,
+        validUserData.name,
+        validUserData.email,
+        validUserData.phone,
+        validUserData.password,
+        validUserData.isActive,
+        'https://example.com/photo.jpg',
+      );
+      expect(user.profilePicture).toBe('https://example.com/photo.jpg');
+    });
+
+    // Debería permitir omitir profilePicture (opcional)
+    it('should allow omitting profilePicture', () => {
+      const user = new User(
+        validUserData.id,
+        validUserData.roleId,
+        validUserData.name,
+        validUserData.email,
+        validUserData.phone,
+        validUserData.password,
+        validUserData.isActive,
+      );
+      expect(user.profilePicture).toBeUndefined();
+    });
+  });
+
+  describe('Domain Hardening - updateProfile', () => {
+    let user: User;
+
+    beforeEach(() => {
+      user = new User(
+        validUserData.id,
+        validUserData.roleId,
+        validUserData.name,
+        validUserData.email,
+        validUserData.phone,
+        validUserData.password,
+        validUserData.isActive,
+      );
+    });
+
+    // Debería lanzar error al actualizar el nombre a más de 100 caracteres
+    it('should throw error when updating name to longer than 100 characters', () => {
+      expect(() => {
+        user.updateProfile('a'.repeat(101));
+      }).toThrow('User name cannot exceed 100 characters');
+    });
+
+    // Debería lanzar error al actualizar profilePicture con una URL inválida
+    it('should throw error when updating profilePicture to an invalid URL', () => {
+      expect(() => {
+        user.updateProfile(undefined, undefined, 'not-a-url');
+      }).toThrow('Profile picture must be a valid URL');
+    });
+
+    // Debería aceptar actualizar profilePicture con una URL válida
+    it('should accept updating profilePicture to a valid URL', () => {
+      user.updateProfile(undefined, undefined, 'https://example.com/new-photo.jpg');
+      expect(user.profilePicture).toBe('https://example.com/new-photo.jpg');
     });
   });
 });

--- a/tests/unit/payments/application/use-cases/CreatePayment.unit.test.ts
+++ b/tests/unit/payments/application/use-cases/CreatePayment.unit.test.ts
@@ -5,6 +5,7 @@ import { IAppointmentStatusRepository } from '../../../../../src/modules/appoint
 import { Payment, PaymentStatusEnum } from '../../../../../src/modules/payments/domain/entities/Payment';
 import { NotFoundError } from '../../../../../src/shared/exceptions/NotFoundError';
 import { BusinessRuleError } from '../../../../../src/shared/exceptions/BusinessRuleError';
+import { ForbiddenError } from '../../../../../src/shared/exceptions/ForbiddenError';
 
 describe('CreatePayment Use Case', () => {
   let createPayment: CreatePayment;
@@ -215,5 +216,69 @@ describe('CreatePayment Use Case', () => {
 
     expect(result.amount).toBe(100);
     expect(mockPaymentRepository.save).toHaveBeenCalledTimes(1);
+  });
+
+  describe('PAY-25: Ownership Validation', () => {
+    const stylistId = mockAppointment.userId; // reutilizamos un UUID válido del fixture
+    const otherStylistId = '123e4567-e89b-12d3-a456-426614174099';
+
+    // Debería lanzar ForbiddenError si un STYLIST crea un pago para la cita de otro estilista
+    it('should throw ForbiddenError when a STYLIST creates a payment for another stylist\'s appointment', async () => {
+      const dto = { amount: 100, appointmentId: validAppointmentId };
+      mockAppointmentRepository.findById.mockResolvedValue({
+        ...mockAppointment,
+        stylistId,
+      } as any);
+
+      await expect(
+        createPayment.execute(dto, otherStylistId, 'STYLIST'),
+      ).rejects.toThrow(ForbiddenError);
+      expect(mockPaymentRepository.save).not.toHaveBeenCalled();
+    });
+
+    // Debería permitir que un STYLIST cree un pago para su propia cita
+    it('should allow a STYLIST to create a payment for their own appointment', async () => {
+      const dto = { amount: 100, appointmentId: validAppointmentId };
+      mockAppointmentRepository.findById.mockResolvedValue({
+        ...mockAppointment,
+        stylistId,
+      } as any);
+      mockPaymentRepository.save.mockImplementation(async (payment: Payment) => payment);
+
+      const result = await createPayment.execute(dto, stylistId, 'STYLIST');
+
+      expect(result.amount).toBe(100);
+      expect(mockPaymentRepository.save).toHaveBeenCalledTimes(1);
+    });
+
+    // Debería permitir que ADMIN cree un pago para cualquier cita sin importar el estilista
+    it('should allow ADMIN to create a payment for any appointment regardless of stylist', async () => {
+      const dto = { amount: 100, appointmentId: validAppointmentId };
+      mockAppointmentRepository.findById.mockResolvedValue({
+        ...mockAppointment,
+        stylistId,
+      } as any);
+      mockPaymentRepository.save.mockImplementation(async (payment: Payment) => payment);
+
+      const result = await createPayment.execute(dto, otherStylistId, 'ADMIN');
+
+      expect(result.amount).toBe(100);
+      expect(mockPaymentRepository.save).toHaveBeenCalledTimes(1);
+    });
+
+    // Debería no aplicar la validación de ownership si se omiten requesterId/requesterRole (compatibilidad hacia atrás)
+    it('should not apply ownership validation when requesterId/requesterRole are omitted (backward compatibility)', async () => {
+      const dto = { amount: 100, appointmentId: validAppointmentId };
+      mockAppointmentRepository.findById.mockResolvedValue({
+        ...mockAppointment,
+        stylistId,
+      } as any);
+      mockPaymentRepository.save.mockImplementation(async (payment: Payment) => payment);
+
+      const result = await createPayment.execute(dto);
+
+      expect(result.amount).toBe(100);
+      expect(mockPaymentRepository.save).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/tests/unit/services/Category.unit.test.ts
+++ b/tests/unit/services/Category.unit.test.ts
@@ -46,6 +46,28 @@ describe('Category Entity', () => {
         Category.create('Valid Name', longDescription);
       }).toThrow(ValidationError);
     });
+
+    // Endurecimiento de dominio (observación transversal del audit): el formato
+    // del nombre (solo letras y espacios) antes solo se validaba en express-validator
+    // Debería lanzar error si el nombre contiene dígitos
+    it('should throw error if name contains digits', () => {
+      expect(() => {
+        Category.create('Hair Services 2');
+      }).toThrow('Category name can only contain letters and spaces');
+    });
+
+    // Debería lanzar error si el nombre contiene caracteres especiales
+    it('should throw error if name contains special characters', () => {
+      expect(() => {
+        Category.create('Hair & Nails');
+      }).toThrow('Category name can only contain letters and spaces');
+    });
+
+    // Debería aceptar nombres con letras acentuadas
+    it('should accept names with accented letters', () => {
+      const category = Category.create('Peluquería Señoras');
+      expect(category.name).toBe('Peluquería Señoras');
+    });
   });
 
   describe('Updates', () => {

--- a/tests/unit/services/CategoryUseCases.unit.test.ts
+++ b/tests/unit/services/CategoryUseCases.unit.test.ts
@@ -57,6 +57,7 @@ describe('Category Use Cases', () => {
       description: 'Professional hair styling services',
     };
 
+    // Debería crear la categoría exitosamente
     it('should create category successfully', async () => {
       const mockCategory = Category.create(validCreateDto.name, validCreateDto.description);
       mockCategoryRepository.existsByName.mockResolvedValue(false);
@@ -70,11 +71,13 @@ describe('Category Use Cases', () => {
       expect(result.description).toBe(validCreateDto.description);
     });
 
+    // Debería lanzar ValidationError si el nombre está vacío
     it('should throw ValidationError for empty name', async () => {
       const invalidDto = { ...validCreateDto, name: '' };
       await expect(createCategory.execute(invalidDto)).rejects.toThrow(ValidationError);
     });
 
+    // Debería lanzar ConflictError si el nombre ya existe
     it('should throw ConflictError if name already exists', async () => {
       mockCategoryRepository.existsByName.mockResolvedValue(true);
       await expect(createCategory.execute(validCreateDto)).rejects.toThrow(ConflictError);
@@ -93,6 +96,7 @@ describe('Category Use Cases', () => {
       description: 'Updated description',
     };
 
+    // Debería actualizar la categoría exitosamente
     it('should update category successfully', async () => {
       const existingCategory = Category.create('Hair Services', 'Original description');
       const updatedCategory = Category.create(validUpdateDto.name!, validUpdateDto.description);
@@ -108,11 +112,13 @@ describe('Category Use Cases', () => {
       expect(result.name).toBe(validUpdateDto.name);
     });
 
+    // Debería lanzar NotFoundError si la categoría no existe
     it('should throw NotFoundError if category not found', async () => {
       mockCategoryRepository.findById.mockResolvedValue(null);
       await expect(updateCategory.execute('non-existent-id', validUpdateDto)).rejects.toThrow(NotFoundError);
     });
 
+    // Debería lanzar ConflictError si el nuevo nombre ya existe
     it('should throw ConflictError if new name already exists', async () => {
       const existingCategory = Category.create('Hair Services');
       mockCategoryRepository.findById.mockResolvedValue(existingCategory);
@@ -128,6 +134,7 @@ describe('Category Use Cases', () => {
       getCategoryById = new GetCategoryById(mockCategoryRepository);
     });
 
+    // Debería devolver la categoría cuando existe
     it('should return category when found', async () => {
       const mockCategory = Category.create('Hair Services');
       mockCategoryRepository.findById.mockResolvedValue(mockCategory);
@@ -138,6 +145,7 @@ describe('Category Use Cases', () => {
       expect(result.id).toBe(mockCategory.id);
     });
 
+    // Debería lanzar NotFoundError cuando la categoría no existe
     it('should throw NotFoundError when category not found', async () => {
       mockCategoryRepository.findById.mockResolvedValue(null);
       await expect(getCategoryById.execute('non-existent-id')).rejects.toThrow(NotFoundError);
@@ -151,6 +159,7 @@ describe('Category Use Cases', () => {
       getAllCategories = new GetAllCategories(mockCategoryRepository);
     });
 
+    // Debería devolver todas las categorías
     it('should return all categories', async () => {
       const mockCategories = [Category.create('Hair Services'), Category.create('Nail Services')];
       mockCategoryRepository.findAll.mockResolvedValue(mockCategories);
@@ -158,6 +167,31 @@ describe('Category Use Cases', () => {
       const result = await getAllCategories.execute();
 
       expect(mockCategoryRepository.findAll).toHaveBeenCalled();
+      expect(result).toHaveLength(2);
+    });
+
+    // Debería excluir categorías inactivas por defecto (CAT-11: listado público)
+    it('should exclude inactive categories by default (CAT-11)', async () => {
+      const activeCategory = Category.create('Hair Services');
+      const inactiveCategory = Category.create('Discontinued Services');
+      inactiveCategory.deactivate();
+      mockCategoryRepository.findAll.mockResolvedValue([activeCategory, inactiveCategory]);
+
+      const result = await getAllCategories.execute();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('Hair Services');
+    });
+
+    // Debería incluir también las inactivas cuando includeInactive es true (CAT-11, uso administrativo)
+    it('should include inactive categories when includeInactive is true (CAT-11)', async () => {
+      const activeCategory = Category.create('Hair Services');
+      const inactiveCategory = Category.create('Discontinued Services');
+      inactiveCategory.deactivate();
+      mockCategoryRepository.findAll.mockResolvedValue([activeCategory, inactiveCategory]);
+
+      const result = await getAllCategories.execute(true);
+
       expect(result).toHaveLength(2);
     });
   });
@@ -169,6 +203,7 @@ describe('Category Use Cases', () => {
       getActiveCategories = new GetActiveCategories(mockCategoryRepository);
     });
 
+    // Debería devolver solo las categorías activas
     it('should return only active categories', async () => {
       const mockCategories = [Category.create('Hair Services'), Category.create('Nail Services')];
       mockCategoryRepository.findActive.mockResolvedValue(mockCategories);
@@ -187,6 +222,7 @@ describe('Category Use Cases', () => {
       activateCategory = new ActivateCategory(mockCategoryRepository);
     });
 
+    // Debería activar la categoría exitosamente
     it('should activate category successfully', async () => {
       const category = Category.create('Hair Services');
       category.deactivate();
@@ -201,6 +237,7 @@ describe('Category Use Cases', () => {
       expect(result.isActive).toBe(true);
     });
 
+    // Debería lanzar NotFoundError si la categoría no existe
     it('should throw NotFoundError if category not found', async () => {
       mockCategoryRepository.findById.mockResolvedValue(null);
       await expect(activateCategory.execute('non-existent-id')).rejects.toThrow(NotFoundError);
@@ -214,6 +251,7 @@ describe('Category Use Cases', () => {
       deactivateCategory = new DeactivateCategory(mockCategoryRepository);
     });
 
+    // Debería desactivar la categoría exitosamente
     it('should deactivate category successfully', async () => {
       const category = Category.create('Hair Services');
 
@@ -235,6 +273,7 @@ describe('Category Use Cases', () => {
       deleteCategory = new DeleteCategory(mockCategoryRepository, mockServiceRepository);
     });
 
+    // Debería eliminar la categoría exitosamente
     it('should delete category successfully', async () => {
       mockCategoryRepository.existsById.mockResolvedValue(true);
       mockServiceRepository.findByCategory.mockResolvedValue([]);
@@ -247,11 +286,13 @@ describe('Category Use Cases', () => {
       expect(mockCategoryRepository.delete).toHaveBeenCalledWith('test-id');
     });
 
+    // Debería lanzar NotFoundError si la categoría no existe
     it('should throw NotFoundError if category not found', async () => {
       mockCategoryRepository.existsById.mockResolvedValue(false);
       await expect(deleteCategory.execute('non-existent-id')).rejects.toThrow(NotFoundError);
     });
 
+    // Debería lanzar BusinessRuleError si la categoría tiene servicios asociados
     it('should throw BusinessRuleError if category has associated services', async () => {
       mockCategoryRepository.existsById.mockResolvedValue(true);
       mockServiceRepository.findByCategory.mockResolvedValue([{ id: 'service-1' }]);

--- a/tests/unit/shared/validation.unit.test.ts
+++ b/tests/unit/shared/validation.unit.test.ts
@@ -1,4 +1,4 @@
-import { isValidEmail, isValidPassword, isValidPhone } from '../../../src/shared/utils/validation';
+import { isValidEmail, isValidPassword, isValidPhone, isValidUrl } from '../../../src/shared/utils/validation';
 
 describe('Validation Utils Unit Tests', () => {
   describe('isValidEmail', () => {
@@ -83,6 +83,31 @@ describe('Validation Utils Unit Tests', () => {
 
       invalidPhones.forEach((phone) => {
         expect(isValidPhone(phone)).toBe(false);
+      });
+    });
+  });
+
+  // Endurecimiento de dominio (observación transversal del audit): usado por User.profilePicture
+  describe('isValidUrl', () => {
+    // Debería devolver true para URLs http/https válidas
+    it('should return true for valid http/https URLs', () => {
+      const validUrls = [
+        'https://example.com/photo.jpg',
+        'http://example.com',
+        'https://sub.domain.co/path?query=1',
+      ];
+
+      validUrls.forEach((url) => {
+        expect(isValidUrl(url)).toBe(true);
+      });
+    });
+
+    // Debería devolver false para URLs inválidas
+    it('should return false for invalid URLs', () => {
+      const invalidUrls = ['not-a-url', 'ftp://example.com', 'javascript:alert(1)', '', '   '];
+
+      invalidUrls.forEach((url) => {
+        expect(isValidUrl(url)).toBe(false);
       });
     });
   });


### PR DESCRIPTION
## Descripción
 
### Resumen
 
Implementa todos los hallazgos  de business-rules-audit: 9 divergencias, entre código y documentación, 6 gaps funcionales, y el endurecimiento de validaciones de dominio propuesto al cierre de la auditoría. Incluye 8 decisiones de producto consultadas y resueltas durante la implementación. No se modificó ninguna regla transversal ya validada (cascada AUTH-23, ScheduleAvailabilityService, HOL-6, PAY-4).
 
### Divergencias corregidas (código y/o docs desalineados con el comportamiento real)
 
- **AUTH-4/AUTH-16** — unifica el rango de dígitos del teléfono a 7–15 en `AuthValidations` (antes 2–15 en express-validator, desalineado con `isValidPhone` del dominio).
- **PAY-12** — corrige el nombre del campo documentado `paidAt` → `paymentDate`.
- **STY-18** — reescribe la documentación de `StylistService` para reflejar la clave efectiva real (`stylistId`, `serviceId`).
- **SCH-19** — retira nota de ISSUE-12 ya resuelta en la documentación de horarios.
- **SVC-20** — corrige JSDoc de `Service.create` (tope real 480 minutos, documentaba 600).
- **APT-40** — documenta la exigencia de `notes`/`reason` en cancelaciones (§4.5).
- **APT-20** — documenta que el cliente puede confirmar su propia cita.
- **NOT-19** — documenta el atajo PENDING→READ sin paso intermedio por SENT.
- **AUTH-30** — documenta el rechazo de teléfonos "solo ceros".
### Gaps funcionales implementados
 
- **APT-39** — `UpdateAppointment` revalida el horario efectivo (`ScheduleAvailabilityService`) y el límite diario al reprogramar una cita.
- **APT-29** — `UpdateAppointment` revalida que el servicio siga activo y ofrecido por el estilista al reprogramar.
- **SCH-20** — `GetAvailableSlots` resuelve el nombre real del estilista vía `IUserRepository` (antes placeholder).
- **SCH-14** — `GetAvailableSlots` agrega filtro opcional por `serviceIds` vía `IStylistServiceRepository`.
- **PAY-25** — `CreatePayment` valida ownership: un STYLIST solo puede crear pagos de sus propias citas (ADMIN sin restricción).
- **CAT-11** — `GET /categories` excluye categorías inactivas por defecto; nuevo parámetro `includeInactive` para uso administrativo.
### Decisiones de producto resueltas.
 
8 decisiones de alcance/comportamiento se consultaron antes de implementar (criterios de ownership en pagos, manejo de categorías inactivas, alcance de la revalidación en reprogramación, entre otras) y quedan reflejadas en el código y la documentación de cada hallazgo correspondiente.
 
### Endurecimiento de dominio
 
Implementado además de lo inicialmente propuesto:

- **AUTH-31** — elimina `User.updatePreferences()` (código muerto, sin caso de uso ni endpoint asociado).
- **User** — valida en el dominio (constructor y `updateProfile`) que `name` no exceda 100 caracteres y que `profilePicture`, si se provee, sea una URL http/https válida.
- **Category** — valida en el dominio que `name` contenga solo letras y espacios (incluye acentos/ñ), evitando depender únicamente de la validación HTTP.
- Nueva utilidad `isValidUrl` en `shared/utils/validation.ts`.
### Testing
 
- Suite completa verificada localmente: **86 test suites, 1337 tests, todos en verde**.
- Tests nuevos/actualizados para cada hallazgo de código (APT-39, APT-29, SCH-20, SCH-14, PAY-25, AUTH-4/16, CAT-11, AUTH-31, endurecimiento de User y Category).
- Se agregaron traducciones al español (`// Debería...`) sobre cada `it(...)` en los archivos de test tocados, siguiendo la convención existente del repo.
### Notas
 
- No se tocaron reglas transversales ya certificadas como ✅ en la auditoría.
- La documentación de negocio (`01-auth.md`, `02-categories.md`, `04-stylists.md`, `05-schedules.md`, `06-appointments.md`, `07-notifications.md`, `08-payments.md`) se actualizó en el mismo PR para mantener código y docs consistentes.