### PR TITLE
feat(auth): sesiones seguras y revocables — refresh rotativo + cookie httpOnly + CSRF

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,24 @@ TEST_DATABASE_URL="postgresql://username:password@host:port/database_test?schema
 JWT_ACCESS_SECRET=your_jwt_access_secret_key_here
 JWT_REFRESH_SECRET=your_jwt_refresh_secret_key_here
 JWT_ACCESS_EXPIRY=15m
+# JWT_REFRESH_EXPIRY: LEGACY / en deprecacion. El refresh ya NO es un JWT: es
+# opaco, rotativo y hasheado en DB; su expiracion la define REFRESH_TOKEN_TTL_DAYS.
+# Se conserva por compatibilidad de config hasta retirarlo por completo.
 JWT_REFRESH_EXPIRY=7d
+
+# Refresh token opaco (sesiones seguras) | Secure sessions
+# Vida del refresh token rotativo, en dias.
+REFRESH_TOKEN_TTL_DAYS=7
+
+# Cookies de autenticacion (refresh httpOnly + CSRF) | Auth cookies
+# COOKIE_SECURE: true | false. Si se deja vacio se deriva de NODE_ENV (true solo
+# en produccion). En desarrollo por HTTP debe ser false para que la cookie viaje.
+COOKIE_SECURE=false
+# COOKIE_SAMESITE: strict | lax | none. Usar 'lax' si la SPA y la API comparten
+# dominio; 'none' (con secure=true) si van en dominios distintos.
+COOKIE_SAMESITE=lax
+# COOKIE_DOMAIN: dominio de las cookies (ej. .turnity.com). Vacio en local.
+COOKIE_DOMAIN=
 
 # CORS Configuration | Configuración de CORS
 FRONTEND_URL=http://localhost:3000

--- a/package-lock.json
+++ b/package-lock.json
@@ -2374,9 +2374,9 @@
       }
     },
     "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4192,20 +4192,20 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -4215,10 +4215,23 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -6991,9 +7004,9 @@
       }
     },
     "node_modules/jest-config/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8091,9 +8104,9 @@
       }
     },
     "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8853,9 +8866,9 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -9304,19 +9317,23 @@
       }
     },
     "node_modules/morgan": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
-      "integrity": "sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.11.0.tgz",
+      "integrity": "sha512-zSkVu3t18r39pw4ixfBKvfZi3y2UOqr7d4WYwcj3m8nXpEQK4rPO6GLzs/CExoRgmX3y9EjmmcXqv6jq0SK46g==",
       "license": "MIT",
       "dependencies": {
         "basic-auth": "~2.0.1",
         "debug": "2.6.9",
         "depd": "~2.0.0",
-        "on-finished": "~2.3.0",
+        "on-finished": "~2.4.1",
         "on-headers": "~1.1.0"
       },
       "engines": {
         "node": ">= 0.8.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/morgan/node_modules/debug": {
@@ -9331,17 +9348,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-    },
-    "node_modules/morgan/node_modules/on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -11139,16 +11145,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typedarray": {
@@ -13133,9 +13157,9 @@
           "dev": true
         },
         "brace-expansion": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-          "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+          "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0"
@@ -14450,25 +14474,32 @@
       }
     },
     "body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "requires": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "dependencies": {
+        "content-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+          "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="
+        }
       }
     },
     "brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -16403,9 +16434,9 @@
           }
         },
         "brace-expansion": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-          "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+          "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0"
@@ -17171,9 +17202,9 @@
           "dev": true
         },
         "brace-expansion": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-          "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+          "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0"
@@ -17681,9 +17712,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "requires": {
         "argparse": "^2.0.1"
       }
@@ -18014,14 +18045,14 @@
       }
     },
     "morgan": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
-      "integrity": "sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.11.0.tgz",
+      "integrity": "sha512-zSkVu3t18r39pw4ixfBKvfZi3y2UOqr7d4WYwcj3m8nXpEQK4rPO6GLzs/CExoRgmX3y9EjmmcXqv6jq0SK46g==",
       "requires": {
         "basic-auth": "~2.0.1",
         "debug": "2.6.9",
         "depd": "~2.0.0",
-        "on-finished": "~2.3.0",
+        "on-finished": "~2.4.1",
         "on-headers": "~1.1.0"
       },
       "dependencies": {
@@ -18037,14 +18068,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-        },
-        "on-finished": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-          "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
-          "requires": {
-            "ee-first": "1.1.1"
-          }
         }
       }
     },
@@ -19245,13 +19268,20 @@
       "dev": true
     },
     "type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "requires": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
+      },
+      "dependencies": {
+        "content-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+          "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="
+        }
       }
     },
     "typedarray": {

--- a/prisma/migrations/20260720010640_add_refresh_token_sessions/migration.sql
+++ b/prisma/migrations/20260720010640_add_refresh_token_sessions/migration.sql
@@ -1,0 +1,33 @@
+-- CreateTable
+CREATE TABLE "RefreshToken" (
+    "id" TEXT NOT NULL,
+    "familyId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "revokedAt" TIMESTAMP(3),
+    "replacedById" TEXT,
+    "userAgent" TEXT,
+    "ipAddress" TEXT,
+    "issuedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RefreshToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RefreshToken_tokenHash_key" ON "RefreshToken"("tokenHash");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RefreshToken_replacedById_key" ON "RefreshToken"("replacedById");
+
+-- CreateIndex
+CREATE INDEX "RefreshToken_userId_idx" ON "RefreshToken"("userId");
+
+-- CreateIndex
+CREATE INDEX "RefreshToken_familyId_idx" ON "RefreshToken"("familyId");
+
+-- CreateIndex
+CREATE INDEX "RefreshToken_expiresAt_idx" ON "RefreshToken"("expiresAt");
+
+-- AddForeignKey
+ALTER TABLE "RefreshToken" ADD CONSTRAINT "RefreshToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,7 +32,30 @@ model User {
   stylistAppointments  Appointment[] @relation("AppointmentStylist")
   notifications  Notification[]
   stylistServices StylistService[]
+  refreshTokens  RefreshToken[]
   role           Role           @relation(fields: [roleId], references: [id])
+}
+
+// Sesiones de refresh token (F3 seguridad). Refresh opaco de alta entropia,
+// persistido SOLO como hash SHA-256 (tokenHash). Soporta rotacion + reuse
+// detection revocando toda la familia (familyId) -- RFC 9700 Sec. 4.14.
+model RefreshToken {
+  id           String    @id @default(uuid()) // = jti de la sesion
+  familyId     String                          // agrupa la cadena de rotacion (reuse detection)
+  userId       String
+  tokenHash    String    @unique               // SHA-256 del refresh opaco (nunca en claro)
+  expiresAt    DateTime
+  revokedAt    DateTime?
+  replacedById String?   @unique               // rotation lineage: apunta al token que lo reemplazo
+  userAgent    String?                         // auditoria (RFC 6819)
+  ipAddress    String?                         // auditoria (RFC 6819)
+  issuedAt     DateTime  @default(now())
+
+  user         User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([familyId])
+  @@index([expiresAt])
 }
 
 model Category {

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,7 @@ import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
 import morgan from 'morgan';
+import cookieParser from 'cookie-parser';
 import { errorHandler } from './shared/middleware/ErrorHandler';
 import { requestIdMiddleware } from './shared/middleware/RequestIdMiddleware';
 import { prisma } from './shared/config/Prisma';
@@ -69,6 +70,10 @@ class App {
         credentials: true,
       }),
     );
+
+    // Parseo de cookies: habilita req.cookies para el refresh httpOnly y el
+    // token CSRF (double-submit). -- F5b
+    this.app.use(cookieParser());
 
     this.app.use(express.json({ limit: '10mb' }));
     this.app.use(express.urlencoded({ extended: true }));

--- a/src/docs/postman/auth_postman_collection.json
+++ b/src/docs/postman/auth_postman_collection.json
@@ -22,6 +22,11 @@
       "type": "string"
     },
     {
+      "key": "csrf_token",
+      "value": "",
+      "type": "string"
+    },
+    {
       "key": "user_id_to_deactivate",
       "value": "",
       "type": "string"
@@ -98,6 +103,8 @@
                   "if (pm.response.code === 201) {",
                   "    const response = pm.response.json();",
                   "    console.log('Estilista registrado:', response.data.email);",
+                  "    pm.collectionVariables.set('user_id_to_deactivate', response.data.id);",
+                  "    console.log('user_id_to_deactivate seteado:', response.data.id);",
                   "    pm.test('Estilista registrado con rol correcto', function () {",
                   "        pm.expect(response.data.role.name).to.eql('STYLIST');",
                   "    });",
@@ -174,7 +181,8 @@
                   "if (pm.response.code === 200) {",
                   "    const response = pm.response.json();",
                   "    pm.collectionVariables.set('jwt_token', response.data.token);",
-                  "    pm.collectionVariables.set('refresh_token', response.data.refreshToken);",
+                  "    const csrf = pm.cookies.get('csrfToken');",
+                  "    if (csrf) pm.collectionVariables.set('csrf_token', csrf);",
                   "    console.log('Login exitoso:', response.data.user.email);",
                   "    console.log('Token guardado automáticamente');",
                   "    pm.test('Login exitoso', function () {",
@@ -216,7 +224,8 @@
                   "if (pm.response.code === 200) {",
                   "    const response = pm.response.json();",
                   "    pm.collectionVariables.set('jwt_token', response.data.token);",
-                  "    pm.collectionVariables.set('refresh_token', response.data.refreshToken);",
+                  "    const csrf = pm.cookies.get('csrfToken');",
+                  "    if (csrf) pm.collectionVariables.set('csrf_token', csrf);",
                   "    console.log('Token renovado exitosamente');",
                   "    pm.test('Token renovado', function () {",
                   "        pm.expect(response.data.token).to.not.be.empty;",
@@ -230,20 +239,115 @@
             "method": "POST",
             "header": [
               {
-                "key": "Content-Type",
-                "value": "application/json"
+                "key": "X-CSRF-Token",
+                "value": "{{csrf_token}}"
               }
             ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"refreshToken\": \"{{refresh_token}}\"\n}"
-            },
             "url": {
               "raw": "{{base_url}}/auth/refresh-token",
               "host": ["{{base_url}}"],
               "path": ["auth", "refresh-token"]
             },
-            "description": "Renueva el JWT token usando el refresh token guardado"
+            "description": "Renueva el access token por ROTACION. El refresh viaja por la cookie httpOnly 'refreshToken' (Postman la envia desde su cookie jar); requiere el header X-CSRF-Token (double-submit). El body ya no lleva el refresh."
+          }
+        },
+        {
+          "name": "Logout",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Logout exitoso', function () {",
+                  "    pm.expect(pm.response.code).to.eql(200);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              },
+              {
+                "key": "X-CSRF-Token",
+                "value": "{{csrf_token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/auth/logout",
+              "host": ["{{base_url}}"],
+              "path": ["auth", "logout"]
+            },
+            "description": "Revoca la sesion actual (cookie refreshToken) y borra las cookies. Requiere Bearer + header CSRF. Nota: al borrar la cookie csrfToken, si luego se llama a otro endpoint con CSRF hay que reobtenerla (Get CSRF Token)."
+          }
+        },
+        {
+          "name": "Get CSRF Token",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    const csrf = pm.cookies.get('csrfToken') || pm.response.json().data.csrfToken;",
+                  "    if (csrf) pm.collectionVariables.set('csrf_token', csrf);",
+                  "    console.log('CSRF token emitido');",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "auth": { "type": "noauth" },
+            "url": {
+              "raw": "{{base_url}}/auth/csrf",
+              "host": ["{{base_url}}"],
+              "path": ["auth", "csrf"]
+            },
+            "description": "Emite la cookie csrfToken (y la devuelve en el body). Guarda csrf_token para el header X-CSRF-Token de refresh/logout."
+          }
+        },
+        {
+          "name": "Logout All",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Logout-all exitoso', function () {",
+                  "    pm.expect(pm.response.code).to.eql(200);",
+                  "    pm.expect(pm.response.json().data).to.have.property('revokedCount');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{jwt_token}}",
+                "type": "text"
+              },
+              {
+                "key": "X-CSRF-Token",
+                "value": "{{csrf_token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/auth/logout-all",
+              "host": ["{{base_url}}"],
+              "path": ["auth", "logout-all"]
+            },
+            "description": "Revoca todas las sesiones del usuario (logout de todos los dispositivos). Requiere Bearer + header CSRF."
           }
         }
       ]
@@ -427,6 +531,41 @@
       "description": "Gestión de usuarios por administradores",
       "item": [
         {
+          "name": "Setup: Login Admin (para deactivate)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    pm.collectionVariables.set('jwt_token', pm.response.json().data.token);",
+                  "    console.log('Admin logueado para pruebas de deactivate');",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"admin@turnity.com\",\n  \"password\": \"admin123\"\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/auth/login",
+              "host": ["{{base_url}}"],
+              "path": ["auth", "login"]
+            },
+            "description": "Deja jwt_token con un token ADMIN antes de los tests de desactivacion (los requests siguientes requieren rol ADMIN)."
+          }
+        },
+        {
           "name": "Deactivate User (STYLIST cascade)",
           "event": [
             {
@@ -593,7 +732,8 @@
                   "if (pm.response.code === 200) {",
                   "    const response = pm.response.json();",
                   "    pm.collectionVariables.set('jwt_token', response.data.token);",
-                  "    pm.collectionVariables.set('refresh_token', response.data.refreshToken);",
+                  "    const csrf = pm.cookies.get('csrfToken');",
+                  "    if (csrf) pm.collectionVariables.set('csrf_token', csrf);",
                   "    console.log('Admin login exitoso');",
                   "}"
                 ]
@@ -630,7 +770,8 @@
                   "if (pm.response.code === 200) {",
                   "    const response = pm.response.json();",
                   "    pm.collectionVariables.set('jwt_token', response.data.token);",
-                  "    pm.collectionVariables.set('refresh_token', response.data.refreshToken);",
+                  "    const csrf = pm.cookies.get('csrfToken');",
+                  "    if (csrf) pm.collectionVariables.set('csrf_token', csrf);",
                   "    console.log('Cliente María login exitoso');",
                   "}"
                 ]
@@ -667,7 +808,8 @@
                   "if (pm.response.code === 200) {",
                   "    const response = pm.response.json();",
                   "    pm.collectionVariables.set('jwt_token', response.data.token);",
-                  "    pm.collectionVariables.set('refresh_token', response.data.refreshToken);",
+                  "    const csrf = pm.cookies.get('csrfToken');",
+                  "    if (csrf) pm.collectionVariables.set('csrf_token', csrf);",
                   "    console.log('Estilista Lucía login exitoso');",
                   "}"
                 ]

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -84,7 +84,10 @@ paths:
                   example: "MiPassword123!"
       responses:
         '200':
-          description: Login exitoso
+          description: >-
+            Login exitoso. El refresh token se entrega en una cookie httpOnly
+            (refreshToken); ademas se setea la cookie csrfToken (legible por JS)
+            para el patron double-submit. El body solo incluye el access token.
           content:
             application/json:
               schema:
@@ -100,9 +103,6 @@ paths:
                     type: object
                     properties:
                       token:
-                        type: string
-                        example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
-                      refreshToken:
                         type: string
                         example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
                       user:
@@ -139,41 +139,107 @@ paths:
         '429':
           $ref: '#/components/responses/Error429'
 
-  /auth/refresh-token:
-    post:
+  /auth/csrf:
+    get:
       tags: [Authentication]
-      summary: Renovar token de acceso
+      summary: Emitir token CSRF
       description: >-
-        Renueva el par de tokens a partir de un refresh token válido. Un token corrupto o
-        expirado devuelve 401. Si el usuario asociado tiene un rol inexistente (corrupción de
-        datos referencial), devuelve 404 en vez de enmascararlo como 401.
+        Setea la cookie 'csrfToken' (legible por JS) y devuelve el token en el body.
+        El cliente debe reenviarlo en el header X-CSRF-Token en /refresh-token,
+        /logout y /logout-all (patron double-submit).
       security: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required: [refreshToken]
-              properties:
-                refreshToken:
-                  type: string
-                  example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
       responses:
         '200':
-          description: Token renovado exitosamente
+          description: Token CSRF emitido (cookie csrfToken + body)
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
-        '400':
-          $ref: '#/components/responses/Error400'
+
+  /auth/refresh-token:
+    post:
+      tags: [Authentication]
+      summary: Renovar token de acceso (rotacion)
+      description: >-
+        Rota la sesion: emite un access token nuevo y un refresh nuevo. El refresh
+        viaja por la cookie httpOnly 'refreshToken' (no en el body) y se rota en cada
+        uso; reusar un refresh ya rotado revoca toda la familia (RFC 9700 4.14).
+        Requiere el header CSRF (double-submit). El body solo incluye el access token.
+      security: []
+      parameters:
+        - name: X-CSRF-Token
+          in: header
+          required: true
+          schema:
+            type: string
+          description: Debe coincidir con la cookie csrfToken (double-submit)
+      responses:
+        '200':
+          description: Token renovado (access nuevo en body, refresh nuevo en cookie)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
         '401':
           $ref: '#/components/responses/Error401'
+        '403':
+          description: Token CSRF invalido o ausente
         '404':
           $ref: '#/components/responses/Error404'
         '429':
           $ref: '#/components/responses/Error429'
+
+  /auth/logout:
+    post:
+      tags: [Authentication]
+      summary: Cerrar la sesion actual
+      description: >-
+        Revoca la sesion del refresh token (cookie 'refreshToken') y borra las
+        cookies de auth. Idempotente. Requiere autenticacion (Bearer) y header CSRF.
+      parameters:
+        - name: X-CSRF-Token
+          in: header
+          required: true
+          schema:
+            type: string
+          description: Debe coincidir con la cookie csrfToken (double-submit)
+      responses:
+        '200':
+          description: Sesion cerrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '401':
+          $ref: '#/components/responses/Error401'
+        '403':
+          description: Token CSRF invalido o ausente
+
+  /auth/logout-all:
+    post:
+      tags: [Authentication]
+      summary: Cerrar todas las sesiones
+      description: >-
+        Revoca todas las sesiones activas del usuario ("logout de todos los
+        dispositivos") y borra las cookies. Requiere autenticacion (Bearer) y header CSRF.
+      parameters:
+        - name: X-CSRF-Token
+          in: header
+          required: true
+          schema:
+            type: string
+          description: Debe coincidir con la cookie csrfToken (double-submit)
+      responses:
+        '200':
+          description: Sesiones revocadas (incluye revokedCount)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '401':
+          $ref: '#/components/responses/Error401'
+        '403':
+          description: Token CSRF invalido o ausente
 
   /auth/profile:
     get:

--- a/src/modules/auth/AuthContainer.ts
+++ b/src/modules/auth/AuthContainer.ts
@@ -9,6 +9,8 @@ import { GetUserProfile } from './application/use-cases/GetUserProfile';
 import { UpdateUserProfile } from './application/use-cases/UpdateUserProfile';
 import { ChangeUserPassword } from './application/use-cases/ChangeUserPassword';
 import { DeactivateUser } from './application/use-cases/DeactivateUser';
+import { LogoutUser } from './application/use-cases/LogoutUser';
+import { LogoutAllSessions } from './application/use-cases/LogoutAllSessions';
 import { PrismaUserRepository } from './infrastructure/persistence/PrismaUserRepository';
 import { PrismaRoleRepository } from './infrastructure/persistence/PrismaRolRepository';
 import { PrismaStylistServiceRepository } from '../services/infrastructure/persistence/PrismaStylistServiceRepository';
@@ -47,6 +49,8 @@ export class AuthContainer {
   private _updateUserProfile: UpdateUserProfile;
   private _changeUserPassword: ChangeUserPassword;
   private _deactivateUser: DeactivateUser;
+  private _logoutUser: LogoutUser;
+  private _logoutAll: LogoutAllSessions;
 
   /**
    * Constructor privado que inicializa todas las dependencias del módulo
@@ -119,6 +123,8 @@ export class AuthContainer {
       appointmentRepository,
       appointmentStatusRepository,
     );
+    this._logoutUser = new LogoutUser(refreshTokenRepository, refreshTokenService);
+    this._logoutAll = new LogoutAllSessions(refreshTokenRepository);
 
     // HTTP Layer - Inyectamos los casos de uso directamente
     this._authController = new AuthController(
@@ -129,6 +135,8 @@ export class AuthContainer {
       this._updateUserProfile,
       this._changeUserPassword,
       this._deactivateUser,
+      this._logoutUser,
+      this._logoutAll,
     );
 
     this._authMiddleware = new AuthMiddleware(jwtService, roleRepository);

--- a/src/modules/auth/AuthContainer.ts
+++ b/src/modules/auth/AuthContainer.ts
@@ -23,6 +23,10 @@ import { BcryptHashService } from './infrastructure/services/BcryptHashService';
 import { JwtTokenService } from './infrastructure/services/JwtTokenService';
 import { JwtService } from './application/services/JwtService';
 import { HashService } from './application/services/HashService';
+import { PrismaRefreshTokenRepository } from './infrastructure/persistence/PrismaRefreshTokenRepository';
+import { CryptoRefreshTokenService } from './infrastructure/services/CryptoRefreshTokenService';
+import { IRefreshTokenRepository } from './domain/repositories/IRefreshTokenRepository';
+import { RefreshTokenService } from './application/services/RefreshTokenService';
 
 /**
  * Contenedor de dependencias para el módulo de autenticación
@@ -84,9 +88,19 @@ export class AuthContainer {
     // Services
     const hashService: HashService = new BcryptHashService();
     const jwtService: JwtService = new JwtTokenService();
+    const refreshTokenRepository: IRefreshTokenRepository = new PrismaRefreshTokenRepository(
+      this.prisma,
+    );
+    const refreshTokenService: RefreshTokenService = new CryptoRefreshTokenService();
 
     // Use Cases
-    this._loginUser = new LoginUser(userRepository, hashService, jwtService);
+    this._loginUser = new LoginUser(
+      userRepository,
+      hashService,
+      jwtService,
+      refreshTokenRepository,
+      refreshTokenService,
+    );
     this._registerUser = new RegisterUser(userRepository, roleRepository, hashService);
     this._refreshToken = new RefreshToken(userRepository, roleRepository, jwtService);
     this._getUserProfile = new GetUserProfile(userRepository, roleRepository);

--- a/src/modules/auth/AuthContainer.ts
+++ b/src/modules/auth/AuthContainer.ts
@@ -102,7 +102,13 @@ export class AuthContainer {
       refreshTokenService,
     );
     this._registerUser = new RegisterUser(userRepository, roleRepository, hashService);
-    this._refreshToken = new RefreshToken(userRepository, roleRepository, jwtService);
+    this._refreshToken = new RefreshToken(
+      userRepository,
+      roleRepository,
+      jwtService,
+      refreshTokenRepository,
+      refreshTokenService,
+    );
     this._getUserProfile = new GetUserProfile(userRepository, roleRepository);
     this._updateUserProfile = new UpdateUserProfile(userRepository, roleRepository);
     this._changeUserPassword = new ChangeUserPassword(userRepository, hashService);

--- a/src/modules/auth/application/services/RefreshTokenService.ts
+++ b/src/modules/auth/application/services/RefreshTokenService.ts
@@ -1,0 +1,31 @@
+/**
+ * Resultado de generar un refresh token opaco.
+ * `token` se entrega al cliente (vía cookie httpOnly); `hash` es lo único
+ * que se persiste en la base (nunca el token en claro).
+ */
+export interface GeneratedRefreshToken {
+  /** Token opaco de alta entropía, entregado al cliente */
+  token: string;
+  /** SHA-256 del token, para persistir y comparar */
+  hash: string;
+}
+
+/**
+ * Puerto para la generación y hashing de refresh tokens opacos.
+ * A diferencia del access (JWT firmado), el refresh es aleatorio y revocable,
+ * por lo que solo se guarda su hash.
+ */
+export interface RefreshTokenService {
+  /**
+   * Genera un refresh token opaco nuevo junto con su hash
+   * @returns `{ token, hash }`
+   */
+  generate(): GeneratedRefreshToken;
+
+  /**
+   * Calcula el hash de un token recibido, para buscarlo/compararlo en la base
+   * @param token - Refresh opaco en claro
+   * @returns Hash SHA-256 en hexadecimal
+   */
+  hash(token: string): string;
+}

--- a/src/modules/auth/application/services/RefreshTokenService.ts
+++ b/src/modules/auth/application/services/RefreshTokenService.ts
@@ -8,6 +8,8 @@ export interface GeneratedRefreshToken {
   token: string;
   /** SHA-256 del token, para persistir y comparar */
   hash: string;
+  /** Momento de expiración calculado a partir del TTL configurado */
+  expiresAt: Date;
 }
 
 /**

--- a/src/modules/auth/application/use-cases/LoginUser.ts
+++ b/src/modules/auth/application/use-cases/LoginUser.ts
@@ -1,12 +1,24 @@
 import { IUserRepository, UserWithRole } from '../../domain/repositories/IUserRepository';
+import { IRefreshTokenRepository } from '../../domain/repositories/IRefreshTokenRepository';
 import { HashService } from '../services/HashService';
 import { JwtPayload, JwtService } from '../services/JwtService';
+import { RefreshTokenService } from '../services/RefreshTokenService';
 import { LoginDto } from '../dto/request/LoginDto';
 import { LoginResponseDto } from '../dto/response/LoginResponseDto';
 import { UserDto } from '../dto/response/UserDto';
 import { isValidEmail } from '../../../../shared/utils/validation';
+import { generateUuid } from '../../../../shared/utils/uuid';
 import { ValidationError } from '../../../../shared/exceptions/ValidationError';
 import { UnauthorizedError } from '../../../../shared/exceptions/UnauthorizedError';
+
+/**
+ * Contexto opcional de la request para auditar la sesión (RFC 6819).
+ * Lo provee la capa HTTP.
+ */
+export interface LoginContext {
+  userAgent?: string | null;
+  ipAddress?: string | null;
+}
 
 /**
  * Caso de uso para autenticar usuarios en el sistema
@@ -17,6 +29,8 @@ export class LoginUser {
     private userRepository: IUserRepository,
     private hashService: HashService,
     private jwtService: JwtService,
+    private refreshTokenRepository: IRefreshTokenRepository,
+    private refreshTokenService: RefreshTokenService,
   ) {}
 
   /**
@@ -27,7 +41,7 @@ export class LoginUser {
    * @throws UnauthorizedError si las credenciales son incorrectas o el usuario está inactivo
    * @description Valida formato de email, verifica credenciales, genera tokens JWT y retorna datos del usuario
    */
-  async execute(loginDto: LoginDto): Promise<LoginResponseDto> {
+  async execute(loginDto: LoginDto, context?: LoginContext): Promise<LoginResponseDto> {
     if (!loginDto.email || !isValidEmail(loginDto.email)) {
       throw new ValidationError('Invalid email format');
     }
@@ -66,11 +80,24 @@ export class LoginUser {
     };
 
     const token = this.jwtService.generateAccessToken(jwtPayload);
-    const refreshToken = this.jwtService.generateRefreshToken(jwtPayload);
+
+    // Refresh opaco + persistencia de la sesión (nueva familia por login).
+    // El token en claro se devuelve para que la capa HTTP lo entregue al
+    // cliente (en F5b pasará a cookie httpOnly); en la base solo queda su hash.
+    // La rotación/reuse se maneja en el caso de uso RefreshToken (F4).
+    const generated = this.refreshTokenService.generate();
+    await this.refreshTokenRepository.create({
+      familyId: generateUuid(),
+      userId: userWithRole.id,
+      tokenHash: generated.hash,
+      expiresAt: generated.expiresAt,
+      userAgent: context?.userAgent ?? null,
+      ipAddress: context?.ipAddress ?? null,
+    });
 
     return {
       token,
-      refreshToken,
+      refreshToken: generated.token,
       user: this.mapUserToDto(userWithRole, role),
     };
   }

--- a/src/modules/auth/application/use-cases/LogoutAllSessions.ts
+++ b/src/modules/auth/application/use-cases/LogoutAllSessions.ts
@@ -1,0 +1,19 @@
+import { IRefreshTokenRepository } from '../../domain/repositories/IRefreshTokenRepository';
+
+/**
+ * Caso de uso para cerrar todas las sesiones activas del usuario
+ * ("logout de todos los dispositivos"). Revoca en bloque todos los refresh
+ * tokens vigentes del usuario (ASVS 5.0 V7 / NIST SP 800-63B).
+ */
+export class LogoutAllSessions {
+  constructor(private refreshTokenRepository: IRefreshTokenRepository) {}
+
+  /**
+   * Revoca todas las sesiones activas del usuario
+   * @param userId - ID del usuario autenticado
+   * @returns Cantidad de sesiones revocadas
+   */
+  async execute(userId: string): Promise<number> {
+    return this.refreshTokenRepository.revokeAllForUser(userId);
+  }
+}

--- a/src/modules/auth/application/use-cases/LogoutUser.ts
+++ b/src/modules/auth/application/use-cases/LogoutUser.ts
@@ -1,0 +1,36 @@
+import { RefreshTokenService } from '../services/RefreshTokenService';
+import { IRefreshTokenRepository } from '../../domain/repositories/IRefreshTokenRepository';
+
+/**
+ * Caso de uso para cerrar la sesión actual del usuario.
+ *
+ * Revoca únicamente la sesión asociada al refresh token recibido (RFC 7009,
+ * revocación por token). Es idempotente: si la sesión no existe, ya está
+ * revocada o pertenece a otro usuario, no hace nada y no falla (tampoco
+ * filtra información sobre tokens ajenos).
+ */
+export class LogoutUser {
+  constructor(
+    private refreshTokenRepository: IRefreshTokenRepository,
+    private refreshTokenService: RefreshTokenService,
+  ) {}
+
+  /**
+   * Revoca la sesión del refresh token recibido si pertenece al usuario
+   * @param userId - ID del usuario autenticado (del access token)
+   * @param refreshToken - Refresh token opaco a revocar
+   */
+  async execute(userId: string, refreshToken: string): Promise<void> {
+    if (!refreshToken) {
+      return;
+    }
+
+    const tokenHash = this.refreshTokenService.hash(refreshToken);
+    const session = await this.refreshTokenRepository.findByTokenHash(tokenHash);
+
+    // Solo revoca si la sesión existe y es del usuario autenticado.
+    if (session && session.userId === userId) {
+      await this.refreshTokenRepository.revokeById(session.id);
+    }
+  }
+}

--- a/src/modules/auth/application/use-cases/RefreshToken.ts
+++ b/src/modules/auth/application/use-cases/RefreshToken.ts
@@ -1,38 +1,83 @@
 import { JwtService, JwtPayload } from '../services/JwtService';
+import { RefreshTokenService } from '../services/RefreshTokenService';
 import { UnauthorizedError } from '../../../../shared/exceptions/UnauthorizedError';
 import { NotFoundError } from '../../../../shared/exceptions/NotFoundError';
+import { logger } from '../../../../shared/logger/logger';
 import { LoginResponseDto } from '../dto/response/LoginResponseDto';
 import { IUserRepository } from '../../domain/repositories/IUserRepository';
 import { IRoleRepository } from '../../domain/repositories/IRoleRepository';
+import { IRefreshTokenRepository } from '../../domain/repositories/IRefreshTokenRepository';
 
 /**
- * Caso de uso para renovar tokens de acceso usando un refresh token
- * Valida el refresh token y genera nuevos tokens de acceso y renovación
+ * Contexto opcional de la request para auditar la rotación (RFC 6819).
+ * Lo provee la capa HTTP; puede venir vacío.
+ */
+export interface RefreshContext {
+  requestId?: string;
+  userAgent?: string | null;
+  ipAddress?: string | null;
+}
+
+/**
+ * Caso de uso para renovar tokens usando un refresh token opaco y rotativo.
+ *
+ * Implementa el patrón de refresh token rotation con detección de reuse
+ * (RFC 9700 4.14): cada uso válido rota el token (emite uno nuevo e invalida
+ * el anterior). Si se presenta un refresh ya rotado/revocado, se interpreta
+ * como reuse (token robado o cliente desincronizado) y se revoca TODA la
+ * familia de sesiones como medida fail-safe.
  */
 export class RefreshToken {
   constructor(
     private userRepository: IUserRepository,
     private roleRepository: IRoleRepository,
     private jwtService: JwtService,
+    private refreshTokenRepository: IRefreshTokenRepository,
+    private refreshTokenService: RefreshTokenService,
   ) {}
 
   /**
-   * Ejecuta el proceso de renovación de tokens
-   * @param refreshToken - Token de renovación válido del usuario
+   * Ejecuta la renovación con rotación
+   * @param refreshToken - Refresh token opaco recibido del cliente
+   * @param context - Contexto opcional de la request (requestId, userAgent, ip)
    * @returns Promise con nuevos tokens y datos actualizados del usuario
-   * @throws UnauthorizedError si el refresh token es inválido, expirado o el usuario está inactivo
-   * @throws NotFoundError si el usuario o rol asociado no existen
-   * @description Verifica el refresh token, valida el estado del usuario y genera nuevos tokens.
-   * No hay catch-all: JwtTokenService ya lanza UnauthorizedError (no un Error genérico) cuando el
-   * token es inválido, así que no hace falta convertir nada acá. Cualquier error inesperado (p.ej.
-   * de base de datos) se propaga tal cual y termina en 500 vía el ErrorHandler global, en vez de
-   * enmascararse como 401.
+   * @throws UnauthorizedError si el refresh es inválido, expirado, reusado o el usuario está inactivo
+   * @throws NotFoundError si el rol asociado no existe
    */
-  async execute(refreshToken: string): Promise<LoginResponseDto> {
-    const payload = this.jwtService.verifyRefreshToken(refreshToken);
+  async execute(refreshToken: string, context?: RefreshContext): Promise<LoginResponseDto> {
+    const tokenHash = this.refreshTokenService.hash(refreshToken);
+    const session = await this.refreshTokenRepository.findByTokenHash(tokenHash);
 
-    const user = await this.userRepository.findById(payload.userId);
+    // 1. No existe ninguna sesión con ese hash -> token inválido
+    if (!session) {
+      throw new UnauthorizedError('Invalid refresh token');
+    }
+
+    // 2. Reuse detection: la sesión existe pero ya fue revocada/rotada.
+    // Se revoca toda la familia y se rechaza (RFC 9700 4.14).
+    if (session.isRevoked()) {
+      await this.refreshTokenRepository.revokeFamily(session.familyId);
+      logger.warn('refresh_reuse_detected', {
+        event: 'refresh_reuse_detected',
+        userId: session.userId,
+        familyId: session.familyId,
+        sessionId: session.id,
+        requestId: context?.requestId,
+        ip: context?.ipAddress,
+        userAgent: context?.userAgent,
+      });
+      throw new UnauthorizedError('Invalid refresh token');
+    }
+
+    // 3. Sesión expirada -> token inválido
+    if (session.isExpired()) {
+      throw new UnauthorizedError('Invalid refresh token');
+    }
+
+    // 4. Validar estado del usuario. Si está inactivo, se revoca la sesión.
+    const user = await this.userRepository.findById(session.userId);
     if (!user || !user.isActive) {
+      await this.refreshTokenRepository.revokeById(session.id);
       throw new UnauthorizedError('Invalid refresh token');
     }
 
@@ -41,18 +86,29 @@ export class RefreshToken {
       throw new NotFoundError('Role', user.roleId);
     }
 
-    const newJwtPayload: JwtPayload = {
+    // 5. Rotación: emitir access nuevo + refresh opaco nuevo, y rotar la sesión
+    // (revoca la actual y crea la nueva en la misma familia, atómicamente).
+    const jwtPayload: JwtPayload = {
       userId: user.id,
       roleId: user.roleId,
       email: user.email,
     };
 
-    const newToken = this.jwtService.generateAccessToken(newJwtPayload);
-    const newRefreshToken = this.jwtService.generateRefreshToken(newJwtPayload);
+    const newAccessToken = this.jwtService.generateAccessToken(jwtPayload);
+    const generated = this.refreshTokenService.generate();
+
+    await this.refreshTokenRepository.rotate(session.id, {
+      familyId: session.familyId,
+      userId: user.id,
+      tokenHash: generated.hash,
+      expiresAt: generated.expiresAt,
+      userAgent: context?.userAgent ?? null,
+      ipAddress: context?.ipAddress ?? null,
+    });
 
     return {
-      token: newToken,
-      refreshToken: newRefreshToken,
+      token: newAccessToken,
+      refreshToken: generated.token,
       user: {
         id: user.id,
         name: user.name,

--- a/src/modules/auth/application/use-cases/RefreshToken.ts
+++ b/src/modules/auth/application/use-cases/RefreshToken.ts
@@ -97,7 +97,7 @@ export class RefreshToken {
     const newAccessToken = this.jwtService.generateAccessToken(jwtPayload);
     const generated = this.refreshTokenService.generate();
 
-    await this.refreshTokenRepository.rotate(session.id, {
+    const rotated = await this.refreshTokenRepository.rotate(session.id, {
       familyId: session.familyId,
       userId: user.id,
       tokenHash: generated.hash,
@@ -105,6 +105,13 @@ export class RefreshToken {
       userAgent: context?.userAgent ?? null,
       ipAddress: context?.ipAddress ?? null,
     });
+
+    // Carrera: otra request concurrente ya rotó esta sesión entre la
+    // verificación y este punto. Se rechaza sin revocar la familia (el token
+    // era válido al momento del check; no es un reuse malicioso).
+    if (!rotated) {
+      throw new UnauthorizedError('Invalid refresh token');
+    }
 
     return {
       token: newAccessToken,

--- a/src/modules/auth/domain/entities/RefreshTokenSession.ts
+++ b/src/modules/auth/domain/entities/RefreshTokenSession.ts
@@ -1,0 +1,57 @@
+/**
+ * Entidad de dominio que representa una sesión de refresh token.
+ *
+ * El refresh en sí es opaco y NUNCA se guarda en claro: esta entidad solo
+ * contiene su hash (`tokenHash`). Soporta rotación con detección de reuse
+ * (RFC 9700 4.14): todas las rotaciones descendientes de un mismo login
+ * comparten `familyId`, y `replacedById` traza la cadena de reemplazos.
+ */
+export class RefreshTokenSession {
+  /**
+   * @param id - Identificador de la sesión (= jti)
+   * @param familyId - Agrupa la cadena de rotación (para revocar toda la familia ante reuse)
+   * @param userId - Usuario dueño de la sesión
+   * @param tokenHash - SHA-256 del refresh opaco (nunca el token en claro)
+   * @param expiresAt - Momento de expiración
+   * @param revokedAt - Momento de revocación, o null si sigue vigente
+   * @param replacedById - ID del token que reemplazó a este al rotar, o null
+   * @param userAgent - User-Agent del cliente al emitir (auditoría), o null
+   * @param ipAddress - IP del cliente al emitir (auditoría), o null
+   * @param issuedAt - Momento de emisión
+   */
+  constructor(
+    public readonly id: string,
+    public readonly familyId: string,
+    public readonly userId: string,
+    public readonly tokenHash: string,
+    public readonly expiresAt: Date,
+    public readonly revokedAt: Date | null,
+    public readonly replacedById: string | null,
+    public readonly userAgent: string | null,
+    public readonly ipAddress: string | null,
+    public readonly issuedAt: Date,
+  ) {}
+
+  /**
+   * Indica si la sesión ya expiró
+   * @param now - Momento de referencia (default: ahora)
+   */
+  isExpired(now: Date = new Date()): boolean {
+    return this.expiresAt.getTime() <= now.getTime();
+  }
+
+  /**
+   * Indica si la sesión fue revocada (logout, rotación o reuse)
+   */
+  isRevoked(): boolean {
+    return this.revokedAt !== null;
+  }
+
+  /**
+   * Indica si la sesión es utilizable: ni revocada ni expirada
+   * @param now - Momento de referencia (default: ahora)
+   */
+  isActive(now: Date = new Date()): boolean {
+    return !this.isRevoked() && !this.isExpired(now);
+  }
+}

--- a/src/modules/auth/domain/repositories/IRefreshTokenRepository.ts
+++ b/src/modules/auth/domain/repositories/IRefreshTokenRepository.ts
@@ -39,9 +39,10 @@ export interface IRefreshTokenRepository {
    * transacción. Núcleo de la rotación de refresh (RFC 9700 4.14).
    * @param oldId - ID de la sesión a revocar
    * @param newData - Datos de la nueva sesión (misma `familyId`)
-   * @returns La nueva sesión creada
+   * @returns La nueva sesión creada, o `null` si la sesión ya fue rotada por
+   *   otra request concurrente (se perdió la carrera; el llamador debe rechazar)
    */
-  rotate(oldId: string, newData: CreateRefreshTokenData): Promise<RefreshTokenSession>;
+  rotate(oldId: string, newData: CreateRefreshTokenData): Promise<RefreshTokenSession | null>;
 
   /**
    * Revoca una sesión puntual por su ID (idempotente)

--- a/src/modules/auth/domain/repositories/IRefreshTokenRepository.ts
+++ b/src/modules/auth/domain/repositories/IRefreshTokenRepository.ts
@@ -1,0 +1,72 @@
+import { RefreshTokenSession } from '../entities/RefreshTokenSession';
+
+/**
+ * Datos necesarios para persistir una nueva sesión de refresh token.
+ * `id` es opcional: si no se provee, la implementación deja que la base
+ * genere el uuid por default.
+ */
+export interface CreateRefreshTokenData {
+  id?: string;
+  familyId: string;
+  userId: string;
+  tokenHash: string;
+  expiresAt: Date;
+  userAgent?: string | null;
+  ipAddress?: string | null;
+}
+
+/**
+ * Contrato de persistencia para sesiones de refresh token.
+ * Abstrae el almacenamiento sin exponer detalles de Prisma/DB.
+ */
+export interface IRefreshTokenRepository {
+  /**
+   * Crea una nueva sesión de refresh token
+   * @param data - Datos de la sesión (el token ya viene hasheado en `tokenHash`)
+   */
+  create(data: CreateRefreshTokenData): Promise<RefreshTokenSession>;
+
+  /**
+   * Busca una sesión por el hash de su token
+   * @param tokenHash - SHA-256 del refresh recibido
+   * @returns La sesión o null si no existe
+   */
+  findByTokenHash(tokenHash: string): Promise<RefreshTokenSession | null>;
+
+  /**
+   * Rota una sesión de forma atómica: revoca la sesión `oldId`
+   * (setea `revokedAt` y `replacedById`) y crea la nueva en una única
+   * transacción. Núcleo de la rotación de refresh (RFC 9700 4.14).
+   * @param oldId - ID de la sesión a revocar
+   * @param newData - Datos de la nueva sesión (misma `familyId`)
+   * @returns La nueva sesión creada
+   */
+  rotate(oldId: string, newData: CreateRefreshTokenData): Promise<RefreshTokenSession>;
+
+  /**
+   * Revoca una sesión puntual por su ID (idempotente)
+   * @param id - ID de la sesión
+   */
+  revokeById(id: string): Promise<void>;
+
+  /**
+   * Revoca toda una familia de sesiones (respuesta a reuse detection).
+   * Solo afecta las que aún no estén revocadas.
+   * @param familyId - Familia a revocar
+   */
+  revokeFamily(familyId: string): Promise<void>;
+
+  /**
+   * Revoca todas las sesiones activas de un usuario ("logout de todos los dispositivos")
+   * @param userId - Usuario cuyas sesiones se revocan
+   * @returns Cantidad de sesiones revocadas
+   */
+  revokeAllForUser(userId: string): Promise<number>;
+
+  /**
+   * Elimina sesiones ya expiradas (barrido de mantenimiento)
+   * @param now - Momento de referencia
+   * @returns Cantidad de sesiones eliminadas
+   */
+  deleteExpired(now: Date): Promise<number>;
+}

--- a/src/modules/auth/infrastructure/persistence/PrismaRefreshTokenRepository.ts
+++ b/src/modules/auth/infrastructure/persistence/PrismaRefreshTokenRepository.ts
@@ -1,0 +1,138 @@
+import { PrismaClient, RefreshToken as PrismaRefreshToken } from '@prisma/client';
+import { RefreshTokenSession } from '../../domain/entities/RefreshTokenSession';
+import {
+  IRefreshTokenRepository,
+  CreateRefreshTokenData,
+} from '../../domain/repositories/IRefreshTokenRepository';
+
+/**
+ * Implementación de IRefreshTokenRepository con Prisma.
+ * La rotación y la revocación de familia se apoyan en índices y en
+ * transacciones para garantizar atomicidad frente a reuse concurrente.
+ */
+export class PrismaRefreshTokenRepository implements IRefreshTokenRepository {
+  /**
+   * @param prisma - Cliente Prisma inyectado
+   */
+  constructor(private prisma: PrismaClient) {}
+
+  /**
+   * Crea una nueva sesión de refresh token
+   */
+  async create(data: CreateRefreshTokenData): Promise<RefreshTokenSession> {
+    const row = await this.prisma.refreshToken.create({
+      data: this.toCreateData(data),
+    });
+    return this.toDomain(row);
+  }
+
+  /**
+   * Busca una sesión por el hash de su token
+   */
+  async findByTokenHash(tokenHash: string): Promise<RefreshTokenSession | null> {
+    const row = await this.prisma.refreshToken.findUnique({
+      where: { tokenHash },
+    });
+    return row ? this.toDomain(row) : null;
+  }
+
+  /**
+   * Rota de forma atómica: crea la nueva sesión y revoca la anterior
+   * (revokedAt + replacedById) dentro de una única transacción.
+   */
+  async rotate(oldId: string, newData: CreateRefreshTokenData): Promise<RefreshTokenSession> {
+    const created = await this.prisma.$transaction(async (tx) => {
+      const newRow = await tx.refreshToken.create({
+        data: this.toCreateData(newData),
+      });
+
+      await tx.refreshToken.update({
+        where: { id: oldId },
+        data: { revokedAt: new Date(), replacedById: newRow.id },
+      });
+
+      return newRow;
+    });
+
+    return this.toDomain(created);
+  }
+
+  /**
+   * Revoca una sesión puntual por ID (idempotente: si ya estaba revocada,
+   * simplemente vuelve a fijar revokedAt sin fallar).
+   */
+  async revokeById(id: string): Promise<void> {
+    await this.prisma.refreshToken.updateMany({
+      where: { id, revokedAt: null },
+      data: { revokedAt: new Date() },
+    });
+  }
+
+  /**
+   * Revoca todas las sesiones aún activas de una familia (reuse detection)
+   */
+  async revokeFamily(familyId: string): Promise<void> {
+    await this.prisma.refreshToken.updateMany({
+      where: { familyId, revokedAt: null },
+      data: { revokedAt: new Date() },
+    });
+  }
+
+  /**
+   * Revoca todas las sesiones activas de un usuario (logout de todos los dispositivos)
+   * @returns Cantidad de sesiones revocadas
+   */
+  async revokeAllForUser(userId: string): Promise<number> {
+    const result = await this.prisma.refreshToken.updateMany({
+      where: { userId, revokedAt: null },
+      data: { revokedAt: new Date() },
+    });
+    return result.count;
+  }
+
+  /**
+   * Elimina sesiones ya expiradas
+   * @returns Cantidad de sesiones eliminadas
+   */
+  async deleteExpired(now: Date): Promise<number> {
+    const result = await this.prisma.refreshToken.deleteMany({
+      where: { expiresAt: { lt: now } },
+    });
+    return result.count;
+  }
+
+  /**
+   * Arma el objeto `data` para Prisma a partir del DTO de creación
+   * @private
+   */
+  private toCreateData(data: CreateRefreshTokenData) {
+    return {
+      ...(data.id ? { id: data.id } : {}),
+      familyId: data.familyId,
+      userId: data.userId,
+      tokenHash: data.tokenHash,
+      expiresAt: data.expiresAt,
+      userAgent: data.userAgent ?? null,
+      ipAddress: data.ipAddress ?? null,
+    };
+  }
+
+  /**
+   * Mapea un registro Prisma a la entidad de dominio
+   * @private
+   */
+  private toDomain(row: PrismaRefreshToken): RefreshTokenSession {
+    return new RefreshTokenSession(
+      row.id,
+      row.familyId,
+      row.userId,
+      row.tokenHash,
+      row.expiresAt,
+      row.revokedAt,
+      row.replacedById,
+      row.userAgent,
+      row.ipAddress,
+      row.issuedAt,
+    );
+  }
+}

--- a/src/modules/auth/infrastructure/persistence/PrismaRefreshTokenRepository.ts
+++ b/src/modules/auth/infrastructure/persistence/PrismaRefreshTokenRepository.ts
@@ -6,6 +6,12 @@ import {
 } from '../../domain/repositories/IRefreshTokenRepository';
 
 /**
+ * Error interno: la sesión ya fue revocada/rotada concurrentemente entre la
+ * verificación y el intento de rotación. No se propaga: se traduce a `null`.
+ */
+class RotateConflict extends Error {}
+
+/**
  * Implementación de IRefreshTokenRepository con Prisma.
  * La rotación y la revocación de familia se apoyan en índices y en
  * transacciones para garantizar atomicidad frente a reuse concurrente.
@@ -40,21 +46,43 @@ export class PrismaRefreshTokenRepository implements IRefreshTokenRepository {
    * Rota de forma atómica: crea la nueva sesión y revoca la anterior
    * (revokedAt + replacedById) dentro de una única transacción.
    */
-  async rotate(oldId: string, newData: CreateRefreshTokenData): Promise<RefreshTokenSession> {
-    const created = await this.prisma.$transaction(async (tx) => {
-      const newRow = await tx.refreshToken.create({
-        data: this.toCreateData(newData),
+  async rotate(
+    oldId: string,
+    newData: CreateRefreshTokenData,
+  ): Promise<RefreshTokenSession | null> {
+    try {
+      const created = await this.prisma.$transaction(async (tx) => {
+        // Revocación condicional y atómica: solo prospera si la sesión aún
+        // estaba activa. Bajo concurrencia, la segunda transacción ve 0 filas
+        // (ya revocada) y aborta -> se traduce a null (carrera perdida).
+        const revoked = await tx.refreshToken.updateMany({
+          where: { id: oldId, revokedAt: null },
+          data: { revokedAt: new Date() },
+        });
+
+        if (revoked.count === 0) {
+          throw new RotateConflict();
+        }
+
+        const newRow = await tx.refreshToken.create({
+          data: this.toCreateData(newData),
+        });
+
+        await tx.refreshToken.update({
+          where: { id: oldId },
+          data: { replacedById: newRow.id },
+        });
+
+        return newRow;
       });
 
-      await tx.refreshToken.update({
-        where: { id: oldId },
-        data: { revokedAt: new Date(), replacedById: newRow.id },
-      });
-
-      return newRow;
-    });
-
-    return this.toDomain(created);
+      return this.toDomain(created);
+    } catch (error) {
+      if (error instanceof RotateConflict) {
+        return null;
+      }
+      throw error;
+    }
   }
 
   /**

--- a/src/modules/auth/infrastructure/services/CryptoRefreshTokenService.ts
+++ b/src/modules/auth/infrastructure/services/CryptoRefreshTokenService.ts
@@ -3,12 +3,13 @@ import {
   RefreshTokenService,
   GeneratedRefreshToken,
 } from '../../application/services/RefreshTokenService';
+import { env } from '../../../../shared/config/env';
 
 /**
  * Implementación de RefreshTokenService usando el módulo `crypto` de Node.
  *
  * El token es aleatorio de 256 bits (32 bytes) codificado en base64url, y se
- * hashea con SHA-256 para persistirlo. SHA-256 alcanza porque el token ya es
+ * hashea con SHA-256 para persistirlo. SHA-256 porque el token ya es
  * de alta entropía; bcrypt/Argon2 (usados para passwords) solo agregarían
  * latencia sin beneficio de seguridad real en este caso.
  */
@@ -22,7 +23,9 @@ export class CryptoRefreshTokenService implements RefreshTokenService {
    */
   generate(): GeneratedRefreshToken {
     const token = randomBytes(this.tokenBytes).toString('base64url');
-    return { token, hash: this.hash(token) };
+    const ttlMs = env.REFRESH_TOKEN_TTL_DAYS * 24 * 60 * 60 * 1000;
+    const expiresAt = new Date(Date.now() + ttlMs);
+    return { token, hash: this.hash(token), expiresAt };
   }
 
   /**

--- a/src/modules/auth/infrastructure/services/CryptoRefreshTokenService.ts
+++ b/src/modules/auth/infrastructure/services/CryptoRefreshTokenService.ts
@@ -1,0 +1,36 @@
+import { randomBytes, createHash } from 'node:crypto';
+import {
+  RefreshTokenService,
+  GeneratedRefreshToken,
+} from '../../application/services/RefreshTokenService';
+
+/**
+ * Implementación de RefreshTokenService usando el módulo `crypto` de Node.
+ *
+ * El token es aleatorio de 256 bits (32 bytes) codificado en base64url, y se
+ * hashea con SHA-256 para persistirlo. SHA-256 alcanza porque el token ya es
+ * de alta entropía; bcrypt/Argon2 (usados para passwords) solo agregarían
+ * latencia sin beneficio de seguridad real en este caso.
+ */
+export class CryptoRefreshTokenService implements RefreshTokenService {
+  /** Bytes de entropía del token opaco (32 = 256 bits) */
+  private readonly tokenBytes = 32;
+
+  /**
+   * Genera un refresh token opaco nuevo y su hash
+   * @returns `{ token, hash }` — `token` va al cliente, `hash` a la base
+   */
+  generate(): GeneratedRefreshToken {
+    const token = randomBytes(this.tokenBytes).toString('base64url');
+    return { token, hash: this.hash(token) };
+  }
+
+  /**
+   * Calcula el hash SHA-256 (hex) de un token
+   * @param token - Refresh opaco en claro
+   * @returns Hash en hexadecimal
+   */
+  hash(token: string): string {
+    return createHash('sha256').update(token).digest('hex');
+  }
+}

--- a/src/modules/auth/infrastructure/services/JwtTokenService.ts
+++ b/src/modules/auth/infrastructure/services/JwtTokenService.ts
@@ -2,6 +2,7 @@ import * as jwt from 'jsonwebtoken';
 import { JwtService, JwtPayload } from '../../application/services/JwtService';
 import { env } from '../../../../shared/config/env';
 import { UnauthorizedError } from '../../../../shared/exceptions/UnauthorizedError';
+import { generateUuid } from '../../../../shared/utils/uuid';
 
 /**
  * Implementación del servicio JWT usando jsonwebtoken
@@ -36,10 +37,15 @@ export class JwtTokenService implements JwtService {
    * @description Crea token con expiración corta, issuer y audience específicos
    */
   generateAccessToken(payload: JwtPayload): string {
+    // subject (sub) y jwtid (jti) siguen el perfil RFC 9068 de access tokens.
+    // Se agregan via SignOptions para no alterar la forma de JwtPayload ni la
+    // verificacion existente (que ignora estos claims estandar).
     return jwt.sign(payload, this.accessTokenSecret, {
       expiresIn: this.accessTokenExpiry,
       issuer: 'turnity-api',
       audience: 'turnity-app',
+      subject: payload.userId,
+      jwtid: generateUuid(),
     } as jwt.SignOptions);
   }
 

--- a/src/modules/auth/presentation/controllers/AuthController.ts
+++ b/src/modules/auth/presentation/controllers/AuthController.ts
@@ -10,6 +10,15 @@ import { DeactivateUser } from '../../application/use-cases/DeactivateUser';
 import { LogoutUser } from '../../application/use-cases/LogoutUser';
 import { LogoutAllSessions } from '../../application/use-cases/LogoutAllSessions';
 import { AuthenticatedRequest } from '../middleware/AuthMiddleware';
+import { generateCsrfToken } from '../middleware/CsrfMiddleware';
+import {
+  REFRESH_COOKIE_NAME,
+  CSRF_COOKIE_NAME,
+  refreshCookieOptions,
+  refreshClearOptions,
+  csrfCookieOptions,
+  csrfClearOptions,
+} from '../utils/cookieOptions';
 import { RegisterDto } from '../../application/dto/request/RegisterDto';
 import { LoginDto } from '../../application/dto/request/LoginDto';
 import { UpdateProfileDto } from '../../application/dto/request/UpdateProfileDto';
@@ -48,11 +57,16 @@ export class AuthController {
    */
   async login(req: Request, res: Response): Promise<Response> {
     const loginDto: LoginDto = req.body;
-    const result = await this.loginUser.execute(loginDto);
+    const result = await this.loginUser.execute(loginDto, this.requestContext(req));
+
+    // El refresh viaja en cookie httpOnly (no en el body). Se emite ademas la
+    // cookie CSRF (legible por JS) para el patron double-submit.
+    this.issueRefreshCookie(res, result.refreshToken);
+    this.issueCsrfCookie(res);
 
     return res.status(200).json({
       success: true,
-      data: result,
+      data: { token: result.token, user: result.user },
       message: 'Login successful',
     });
   }
@@ -92,13 +106,33 @@ export class AuthController {
    * @throws UnauthorizedError si el refresh token es inválido o expirado
    */
   async refreshToken(req: Request, res: Response): Promise<Response> {
-    const { refreshToken } = req.body;
-    const result = await this.refreshTokenUseCase.execute(refreshToken);
+    const refreshToken: string = req.cookies?.[REFRESH_COOKIE_NAME] ?? '';
+    const result = await this.refreshTokenUseCase.execute(refreshToken, this.requestContext(req));
+
+    // Rotacion: se reemplaza la cookie de refresh por el token nuevo.
+    // La cookie CSRF se mantiene (no hace falta rotarla en cada refresh).
+    this.issueRefreshCookie(res, result.refreshToken);
 
     return res.status(200).json({
       success: true,
-      data: result,
+      data: { token: result.token, user: result.user },
       message: 'Token refreshed successfully',
+    });
+  }
+
+  /**
+   * Emite un token CSRF (patron double-submit)
+   * @route GET /auth/csrf
+   * @description Setea la cookie 'csrfToken' (legible por JS) y devuelve el token
+   * en el body para que el cliente lo reenvie en el header X-CSRF-Token.
+   * @responseStatus 200 - Token CSRF emitido
+   */
+  async csrf(req: Request, res: Response): Promise<Response> {
+    const csrfToken = this.issueCsrfCookie(res);
+    return res.status(200).json({
+      success: true,
+      data: { csrfToken },
+      message: 'CSRF token issued',
     });
   }
 
@@ -223,8 +257,9 @@ export class AuthController {
       throw new UnauthorizedError('Authentication required');
     }
 
-    const { refreshToken } = req.body;
+    const refreshToken: string = req.cookies?.[REFRESH_COOKIE_NAME] ?? '';
     await this.logoutUseCase.execute(req.user.userId, refreshToken);
+    this.clearAuthCookies(res);
 
     return res.status(200).json({
       success: true,
@@ -248,11 +283,51 @@ export class AuthController {
     }
 
     const revokedCount = await this.logoutAllUseCase.execute(req.user.userId);
+    this.clearAuthCookies(res);
 
     return res.status(200).json({
       success: true,
       data: { revokedCount },
       message: 'All sessions revoked successfully',
     });
+  }
+
+  /**
+   * Arma el contexto de la request para auditoria de la sesion (RFC 6819)
+   * @private
+   */
+  private requestContext(req: Request) {
+    return {
+      requestId: req.id,
+      userAgent: req.get('user-agent') ?? null,
+      ipAddress: req.ip ?? null,
+    };
+  }
+
+  /**
+   * Setea la cookie httpOnly con el refresh token opaco
+   * @private
+   */
+  private issueRefreshCookie(res: Response, token: string): void {
+    res.cookie(REFRESH_COOKIE_NAME, token, refreshCookieOptions());
+  }
+
+  /**
+   * Genera y setea la cookie CSRF (legible por JS); devuelve el token
+   * @private
+   */
+  private issueCsrfCookie(res: Response): string {
+    const token = generateCsrfToken();
+    res.cookie(CSRF_COOKIE_NAME, token, csrfCookieOptions());
+    return token;
+  }
+
+  /**
+   * Borra las cookies de refresh y CSRF (logout)
+   * @private
+   */
+  private clearAuthCookies(res: Response): void {
+    res.clearCookie(REFRESH_COOKIE_NAME, refreshClearOptions());
+    res.clearCookie(CSRF_COOKIE_NAME, csrfClearOptions());
   }
 }

--- a/src/modules/auth/presentation/controllers/AuthController.ts
+++ b/src/modules/auth/presentation/controllers/AuthController.ts
@@ -7,6 +7,8 @@ import { GetUserProfile } from '../../application/use-cases/GetUserProfile';
 import { UpdateUserProfile } from '../../application/use-cases/UpdateUserProfile';
 import { ChangeUserPassword } from '../../application/use-cases/ChangeUserPassword';
 import { DeactivateUser } from '../../application/use-cases/DeactivateUser';
+import { LogoutUser } from '../../application/use-cases/LogoutUser';
+import { LogoutAllSessions } from '../../application/use-cases/LogoutAllSessions';
 import { AuthenticatedRequest } from '../middleware/AuthMiddleware';
 import { RegisterDto } from '../../application/dto/request/RegisterDto';
 import { LoginDto } from '../../application/dto/request/LoginDto';
@@ -29,6 +31,8 @@ export class AuthController {
     private updateUserProfile: UpdateUserProfile,
     private changeUserPassword: ChangeUserPassword,
     private deactivateUserUseCase: DeactivateUser,
+    private logoutUseCase: LogoutUser,
+    private logoutAllUseCase: LogoutAllSessions,
   ) {}
 
   /**
@@ -201,6 +205,54 @@ export class AuthController {
       success: true,
       data: result,
       message: 'User deactivated successfully',
+    });
+  }
+
+  /**
+   * Cierra la sesión actual revocando el refresh token recibido
+   * @route POST /auth/logout
+   * @param req - Request autenticado; refreshToken en el body
+   * @param res - Response de Express
+   * @returns Promise<Response>
+   * @description Revoca la sesión del refresh token. Idempotente.
+   * @responseStatus 200 - Sesión cerrada
+   * @throws UnauthorizedError si el request no está autenticado
+   */
+  async logout(req: AuthenticatedRequest, res: Response): Promise<Response> {
+    if (!req.user?.userId) {
+      throw new UnauthorizedError('Authentication required');
+    }
+
+    const { refreshToken } = req.body;
+    await this.logoutUseCase.execute(req.user.userId, refreshToken);
+
+    return res.status(200).json({
+      success: true,
+      message: 'Logged out successfully',
+    });
+  }
+
+  /**
+   * Cierra todas las sesiones del usuario (logout de todos los dispositivos)
+   * @route POST /auth/logout-all
+   * @param req - Request autenticado
+   * @param res - Response de Express
+   * @returns Promise<Response>
+   * @description Revoca todas las sesiones activas del usuario
+   * @responseStatus 200 - Sesiones revocadas con su cantidad
+   * @throws UnauthorizedError si el request no está autenticado
+   */
+  async logoutAll(req: AuthenticatedRequest, res: Response): Promise<Response> {
+    if (!req.user?.userId) {
+      throw new UnauthorizedError('Authentication required');
+    }
+
+    const revokedCount = await this.logoutAllUseCase.execute(req.user.userId);
+
+    return res.status(200).json({
+      success: true,
+      data: { revokedCount },
+      message: 'All sessions revoked successfully',
     });
   }
 }

--- a/src/modules/auth/presentation/middleware/CsrfMiddleware.ts
+++ b/src/modules/auth/presentation/middleware/CsrfMiddleware.ts
@@ -1,0 +1,48 @@
+import { Request, Response, NextFunction } from 'express';
+import { randomBytes, timingSafeEqual } from 'node:crypto';
+import { ForbiddenError } from '../../../../shared/exceptions/ForbiddenError';
+import { CSRF_COOKIE_NAME } from '../utils/cookieOptions';
+
+/** Header en el que el cliente reenvía el token CSRF (patrón double-submit) */
+const CSRF_HEADER = 'X-CSRF-Token';
+
+/**
+ * Genera un token CSRF opaco de alta entropía
+ */
+export function generateCsrfToken(): string {
+  return randomBytes(32).toString('base64url');
+}
+
+/**
+ * Comparación en tiempo constante de dos strings (evita timing attacks)
+ */
+function safeEqual(a: string, b: string): boolean {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) {
+    return false;
+  }
+  return timingSafeEqual(bufA, bufB);
+}
+
+/**
+ * Middleware de protección CSRF con el patrón double-submit cookie.
+ *
+ * Aplica a los endpoints que autentican vía cookie (refresh, logout, logout-all):
+ * requiere que el valor del header `X-CSRF-Token` coincida con la cookie
+ * `csrfToken`. Un sitio atacante puede provocar el envío de la cookie, pero no
+ * puede leerla (ni setear el header con su valor) por la Same-Origin Policy.
+ *
+ * El resto de la API no lo necesita porque usa el access token vía Bearer.
+ */
+export const csrfProtection = (req: Request, res: Response, next: NextFunction): void => {
+  const cookieToken: string | undefined = req.cookies?.[CSRF_COOKIE_NAME];
+  const headerToken = req.get(CSRF_HEADER);
+
+  if (!cookieToken || !headerToken || !safeEqual(cookieToken, headerToken)) {
+    next(new ForbiddenError('Invalid or missing CSRF token'));
+    return;
+  }
+
+  next();
+};

--- a/src/modules/auth/presentation/routes/AuthRoutes.ts
+++ b/src/modules/auth/presentation/routes/AuthRoutes.ts
@@ -70,6 +70,26 @@ export class AuthRoutes {
       },
     );
 
+    // POST /logout - Cerrar la sesión actual (requiere autenticación)
+    this.router.post(
+      '/logout',
+      this.authMiddleware.authenticate.bind(this.authMiddleware),
+      AuthValidations.logout,
+      ValidationMiddleware.handleValidationErrors,
+      (req: Request, res: Response, next: NextFunction) => {
+        this.authController.logout(req, res).catch(next);
+      },
+    );
+
+    // POST /logout-all - Cerrar todas las sesiones (requiere autenticación)
+    this.router.post(
+      '/logout-all',
+      this.authMiddleware.authenticate.bind(this.authMiddleware),
+      (req: Request, res: Response, next: NextFunction) => {
+        this.authController.logoutAll(req, res).catch(next);
+      },
+    );
+
     // GET /profile - Obtener perfil (requiere autenticación)
     this.router.get(
       '/profile',

--- a/src/modules/auth/presentation/routes/AuthRoutes.ts
+++ b/src/modules/auth/presentation/routes/AuthRoutes.ts
@@ -8,6 +8,7 @@ import {
   registerRateLimiter,
   refreshTokenRateLimiter,
 } from '../../../../shared/middleware/RateLimiter';
+import { csrfProtection } from '../middleware/CsrfMiddleware';
 
 /**
  * Configurador de rutas para el módulo de autenticación
@@ -37,6 +38,11 @@ export class AuthRoutes {
    * - PATCH /auth/users/:id/deactivate - Desactivar usuario (solo ADMIN)
    */
   private setupRoutes(): void {
+    // GET /csrf - Emitir token CSRF (público; setea la cookie csrfToken)
+    this.router.get('/csrf', (req: Request, res: Response, next: NextFunction) => {
+      this.authController.csrf(req, res).catch(next);
+    });
+
     // POST /login - Inicio de sesión (público)
     this.router.post(
       '/login',
@@ -59,23 +65,21 @@ export class AuthRoutes {
       },
     );
 
-    // POST /refresh-token - Renovar token (público)
+    // POST /refresh-token - Renovar token (público; refresh via cookie httpOnly)
     this.router.post(
       '/refresh-token',
       refreshTokenRateLimiter,
-      AuthValidations.refreshToken,
-      ValidationMiddleware.handleValidationErrors,
+      csrfProtection,
       (req: Request, res: Response, next: NextFunction) => {
         this.authController.refreshToken(req, res).catch(next);
       },
     );
 
-    // POST /logout - Cerrar la sesión actual (requiere autenticación)
+    // POST /logout - Cerrar la sesión actual (requiere autenticación; refresh via cookie)
     this.router.post(
       '/logout',
       this.authMiddleware.authenticate.bind(this.authMiddleware),
-      AuthValidations.logout,
-      ValidationMiddleware.handleValidationErrors,
+      csrfProtection,
       (req: Request, res: Response, next: NextFunction) => {
         this.authController.logout(req, res).catch(next);
       },
@@ -85,6 +89,7 @@ export class AuthRoutes {
     this.router.post(
       '/logout-all',
       this.authMiddleware.authenticate.bind(this.authMiddleware),
+      csrfProtection,
       (req: Request, res: Response, next: NextFunction) => {
         this.authController.logoutAll(req, res).catch(next);
       },

--- a/src/modules/auth/presentation/utils/cookieOptions.ts
+++ b/src/modules/auth/presentation/utils/cookieOptions.ts
@@ -1,0 +1,68 @@
+import { CookieOptions } from 'express';
+import { env } from '../../../../shared/config/env';
+
+/**
+ * Nombres y atributos centralizados de las cookies de autenticación.
+ *
+ * - refreshToken: httpOnly (no legible por JS), acotada al path de auth.
+ *   Transporta el refresh opaco (OWASP OAuth for Browser-Based Apps).
+ * - csrfToken: NO httpOnly (legible por JS), para el patrón double-submit
+ *   contra CSRF. El front la lee y la reenvía en el header X-CSRF-Token.
+ */
+export const REFRESH_COOKIE_NAME = 'refreshToken';
+export const CSRF_COOKIE_NAME = 'csrfToken';
+
+/** Path al que se acota la cookie de refresh (solo se envía a /api/v1/auth) */
+export const AUTH_COOKIE_PATH = '/api/v1/auth';
+
+/**
+ * `secure` efectivo: si COOKIE_SECURE está seteado se respeta; si no, se activa
+ * solo en producción. Así en desarrollo local (HTTP) las cookies funcionan.
+ */
+const secure = env.COOKIE_SECURE ?? env.NODE_ENV === 'production';
+const domain = env.COOKIE_DOMAIN;
+
+/** Vida de la cookie en ms, alineada al TTL del refresh */
+const maxAge = env.REFRESH_TOKEN_TTL_DAYS * 24 * 60 * 60 * 1000;
+
+/** Atributos base de la cookie de refresh (sin maxAge, para poder reutilizar en clear) */
+function baseRefreshOptions(): CookieOptions {
+  return {
+    httpOnly: true,
+    secure,
+    sameSite: env.COOKIE_SAMESITE,
+    path: AUTH_COOKIE_PATH,
+    ...(domain ? { domain } : {}),
+  };
+}
+
+/** Atributos base de la cookie CSRF (legible por JS, disponible en todo el sitio) */
+function baseCsrfOptions(): CookieOptions {
+  return {
+    httpOnly: false,
+    secure,
+    sameSite: env.COOKIE_SAMESITE,
+    path: '/',
+    ...(domain ? { domain } : {}),
+  };
+}
+
+/** Opciones para SETEAR la cookie de refresh (incluye maxAge) */
+export function refreshCookieOptions(): CookieOptions {
+  return { ...baseRefreshOptions(), maxAge };
+}
+
+/** Opciones para BORRAR la cookie de refresh (mismo path/domain, sin maxAge) */
+export function refreshClearOptions(): CookieOptions {
+  return baseRefreshOptions();
+}
+
+/** Opciones para SETEAR la cookie CSRF (incluye maxAge) */
+export function csrfCookieOptions(): CookieOptions {
+  return { ...baseCsrfOptions(), maxAge };
+}
+
+/** Opciones para BORRAR la cookie CSRF */
+export function csrfClearOptions(): CookieOptions {
+  return baseCsrfOptions();
+}

--- a/src/modules/auth/presentation/validations/AuthValidations.ts
+++ b/src/modules/auth/presentation/validations/AuthValidations.ts
@@ -78,6 +78,18 @@ export class AuthValidations {
   ];
 
   /**
+   * Validación para cerrar la sesión actual (logout).
+   * En F5b el refresh pasará a leerse de cookie y esta validación de body se retira.
+   */
+  static logout = [
+    body('refreshToken')
+      .notEmpty()
+      .withMessage('Refresh token is required')
+      .isString()
+      .withMessage('Refresh token must be a string'),
+  ];
+
+  /**
    * Validación para actualizar el perfil de usuario
    */
   static updateProfile = [

--- a/src/shared/config/env.ts
+++ b/src/shared/config/env.ts
@@ -39,6 +39,16 @@ const envSchema = z.object({
   // legacy en deprecacion. -- F3/F6
   REFRESH_TOKEN_TTL_DAYS: z.coerce.number().int().min(1).default(7),
 
+  // Config de la cookie httpOnly del refresh (y de la cookie CSRF). -- F5b/F6
+  // COOKIE_SECURE: si no se define, se deriva de NODE_ENV (true solo en prod),
+  // para permitir pruebas por HTTP en desarrollo local.
+  COOKIE_SECURE: z
+    .enum(['true', 'false'])
+    .optional()
+    .transform((v) => (v === undefined ? undefined : v === 'true')),
+  COOKIE_SAMESITE: z.enum(['strict', 'lax', 'none']).default('lax'),
+  COOKIE_DOMAIN: z.string().optional(),
+
   FRONTEND_URL: z.url().default('http://localhost:3000'),
 });
 

--- a/src/shared/config/env.ts
+++ b/src/shared/config/env.ts
@@ -42,12 +42,19 @@ const envSchema = z.object({
   // Config de la cookie httpOnly del refresh (y de la cookie CSRF). -- F5b/F6
   // COOKIE_SECURE: si no se define, se deriva de NODE_ENV (true solo en prod),
   // para permitir pruebas por HTTP en desarrollo local.
+  // Los preprocess convierten string vacio ('') en undefined, para que dejar una
+  // COOKIE_* vacia en el .env no rompa el boot y se aplique el default/derivado.
   COOKIE_SECURE: z
-    .enum(['true', 'false'])
-    .optional()
+    .preprocess(
+      (v) => (v === '' ? undefined : v),
+      z.enum(['true', 'false']).optional(),
+    )
     .transform((v) => (v === undefined ? undefined : v === 'true')),
-  COOKIE_SAMESITE: z.enum(['strict', 'lax', 'none']).default('lax'),
-  COOKIE_DOMAIN: z.string().optional(),
+  COOKIE_SAMESITE: z.preprocess(
+    (v) => (v === '' ? undefined : v),
+    z.enum(['strict', 'lax', 'none']).default('lax'),
+  ),
+  COOKIE_DOMAIN: z.preprocess((v) => (v === '' ? undefined : v), z.string().optional()),
 
   FRONTEND_URL: z.url().default('http://localhost:3000'),
 });

--- a/src/shared/config/env.ts
+++ b/src/shared/config/env.ts
@@ -34,6 +34,11 @@ const envSchema = z.object({
     .regex(/^\d+[smhd]$/, "JWT_REFRESH_EXPIRY debe tener formato como '15m', '1h', '7d'")
     .default('7d'),
 
+  // TTL del refresh token opaco (dias). El refresh ya no es JWT: se persiste
+  // hasheado y este valor define su expiracion. JWT_REFRESH_EXPIRY queda como
+  // legacy en deprecacion. -- F3/F6
+  REFRESH_TOKEN_TTL_DAYS: z.coerce.number().int().min(1).default(7),
+
   FRONTEND_URL: z.url().default('http://localhost:3000'),
 });
 

--- a/tests/e2e/auth-complete-flow.e2e.test.ts
+++ b/tests/e2e/auth-complete-flow.e2e.test.ts
@@ -15,9 +15,15 @@ describe('Auth Complete Flow E2E Tests', () => {
     });
 
     expect(loginResponse.status).toBe(200);
-    const { token, refreshToken } = loginResponse.body.data;
+    const { token } = loginResponse.body.data;
     expect(token).toBeDefined();
-    expect(refreshToken).toBeDefined();
+
+    // El refresh y el CSRF viajan por cookie (F5b)
+    const setCookie = loginResponse.headers['set-cookie'] as unknown as string[];
+    const refreshCookie = setCookie.find((c) => c.startsWith('refreshToken='))!.split(';')[0];
+    const csrfCookie = setCookie.find((c) => c.startsWith('csrfToken='))!.split(';')[0];
+    const csrfValue = csrfCookie.split('=')[1];
+    expect(refreshCookie).toBeDefined();
 
     // 3. Obtener perfil
     const profileResponse = await request(app)
@@ -27,10 +33,11 @@ describe('Auth Complete Flow E2E Tests', () => {
     expect(profileResponse.status).toBe(200);
     expect(profileResponse.body.data.email).toBe(userData.email);
 
-    // 4. Refresh token
+    // 4. Refresh token (cookie httpOnly + header CSRF)
     const refreshResponse = await request(app)
       .post('/api/v1/auth/refresh-token')
-      .send({ refreshToken });
+      .set('Cookie', [refreshCookie, csrfCookie])
+      .set('X-CSRF-Token', csrfValue);
 
     expect(refreshResponse.status).toBe(200);
     expect(refreshResponse.body.data.token).toBeDefined();

--- a/tests/integration/auth/login.integration.test.ts
+++ b/tests/integration/auth/login.integration.test.ts
@@ -13,10 +13,18 @@ describe('Login Integration Tests', () => {
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
       expect(response.body.data).toHaveProperty('token');
-      expect(response.body.data).toHaveProperty('refreshToken');
+      // El refresh ya no viaja en el body, sino en cookie httpOnly (F5b)
+      expect(response.body.data).not.toHaveProperty('refreshToken');
       expect(response.body.data).toHaveProperty('user');
       expect(response.body.data.user.email).toBe('admin@turnity.com');
       expect(response.body.data.user.role.name).toBe('ADMIN');
+
+      const setCookie = response.headers['set-cookie'] as unknown as string[];
+      const refreshCookie = setCookie.find((c) => c.startsWith('refreshToken='));
+      const csrfCookie = setCookie.find((c) => c.startsWith('csrfToken='));
+      expect(refreshCookie).toBeDefined();
+      expect(refreshCookie).toContain('HttpOnly');
+      expect(csrfCookie).toBeDefined();
     });
 
     // Debería rechazar credenciales inválidas

--- a/tests/integration/auth/refresh-token.integration.test.ts
+++ b/tests/integration/auth/refresh-token.integration.test.ts
@@ -2,55 +2,93 @@ import request from 'supertest';
 import app from '../../../src/app';
 import { loginTestUser } from '../../setup/helpers';
 
-describe('Refresh Token Integration Tests', () => {
-  describe('POST /api/v1/auth/refresh-token', () => {
-    // Debería refrescar el token con un token de refresco válido
-    it('should refresh token with valid refresh token', async () => {
-      const { refreshToken } = await loginTestUser();
+/**
+ * Helper: POST /refresh-token con cookies y (opcional) header CSRF.
+ * Si `csrfHeader` es undefined, no se envía el header (para probar el 403).
+ */
+const refresh = (cookies: string[], csrfHeader?: string) => {
+  const req = request(app).post('/api/v1/auth/refresh-token').set('Cookie', cookies);
+  return csrfHeader !== undefined ? req.set('X-CSRF-Token', csrfHeader) : req;
+};
 
-      const response = await request(app).post('/api/v1/auth/refresh-token').send({ refreshToken });
+describe('Refresh Token Integration Tests (cookie httpOnly + CSRF)', () => {
+  describe('POST /api/v1/auth/refresh-token', () => {
+    // Rota y renueva con cookie de refresh válida + header CSRF correcto
+    it('should rotate and refresh with a valid refresh cookie and CSRF header', async () => {
+      const { refreshToken, csrfToken } = await loginTestUser();
+
+      const response = await refresh(
+        [`refreshToken=${refreshToken}`, `csrfToken=${csrfToken}`],
+        csrfToken,
+      );
 
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
       expect(response.body.data.token).toBeDefined();
+      // No debe exponer el refresh en el body
+      expect(response.body.data).not.toHaveProperty('refreshToken');
+      // Debe rotar: setea una nueva cookie de refresh
+      const setCookie = response.headers['set-cookie'] as unknown as string[];
+      expect(setCookie.some((c) => c.startsWith('refreshToken='))).toBe(true);
     });
 
-    // Debería rechazar un token de refresco inválido
-    it('should reject invalid refresh token', async () => {
-      const response = await request(app)
-        .post('/api/v1/auth/refresh-token')
-        .send({ refreshToken: 'invalid-token' });
+    // CSRF ausente -> 403
+    it('should reject with 403 when the CSRF header is missing', async () => {
+      const { refreshToken, csrfToken } = await loginTestUser();
+
+      const response = await refresh([`refreshToken=${refreshToken}`, `csrfToken=${csrfToken}`]);
+
+      expect(response.status).toBe(403);
+    });
+
+    // CSRF header != cookie -> 403
+    it('should reject with 403 when the CSRF header does not match the cookie', async () => {
+      const { refreshToken, csrfToken } = await loginTestUser();
+
+      const response = await refresh(
+        [`refreshToken=${refreshToken}`, `csrfToken=${csrfToken}`],
+        'not-the-cookie-value',
+      );
+
+      expect(response.status).toBe(403);
+    });
+
+    // Sin cookie de refresh (CSRF ok) -> 401
+    it('should reject with 401 when the refresh cookie is missing', async () => {
+      const response = await refresh(['csrfToken=abc'], 'abc');
 
       expect(response.status).toBe(401);
-      expect(response.body.success).toBe(false);
     });
 
-    // Debería rechazar un token de refresco mal formado
-    it('should reject malformed refresh token', async () => {
-      const response = await request(app)
-        .post('/api/v1/auth/refresh-token')
-        .send({ refreshToken: 'malformed.token.here' });
+    // Refresh inexistente -> 401
+    it('should reject with 401 for an invalid refresh token', async () => {
+      const response = await refresh(['refreshToken=invalid-token', 'csrfToken=abc'], 'abc');
 
       expect(response.status).toBe(401);
-      expect(response.body.success).toBe(false);
     });
 
-    // Debería rechazar un token de refresco vacío
-    it('should reject empty refresh token', async () => {
-      const response = await request(app)
-        .post('/api/v1/auth/refresh-token')
-        .send({ refreshToken: '' });
+    // Reuse detection: reusar un token ya rotado -> 401
+    it('should return 401 when reusing an already-rotated refresh token', async () => {
+      const { refreshToken, csrfToken } = await loginTestUser();
+      const cookies = [`refreshToken=${refreshToken}`, `csrfToken=${csrfToken}`];
 
-      expect(response.status).toBe(400);
-      expect(response.body.success).toBe(false);
+      const first = await refresh(cookies, csrfToken);
+      expect(first.status).toBe(200);
+
+      const reuse = await refresh(cookies, csrfToken);
+      expect(reuse.status).toBe(401);
     });
 
-    // Debería rechazar la solicitud sin token de refresco
-    it('should reject request without refresh token', async () => {
-      const response = await request(app).post('/api/v1/auth/refresh-token').send({});
+    // Concurrencia: dos refresh en paralelo con el mismo token -> uno gana (200),
+    // el otro pierde la carrera y es rechazado (401). Valida la atomicidad del rotate.
+    it('should handle concurrent refresh of the same token safely (only one wins)', async () => {
+      const { refreshToken, csrfToken } = await loginTestUser();
+      const cookies = [`refreshToken=${refreshToken}`, `csrfToken=${csrfToken}`];
 
-      expect(response.status).toBe(400);
-      expect(response.body.success).toBe(false);
+      const [a, b] = await Promise.all([refresh(cookies, csrfToken), refresh(cookies, csrfToken)]);
+      const statuses = [a.status, b.status].sort();
+
+      expect(statuses).toEqual([200, 401]);
     });
   });
 });

--- a/tests/setup/helpers.ts
+++ b/tests/setup/helpers.ts
@@ -54,6 +54,16 @@ export const createTestUser = async (roleType: 'CLIENT' | 'ADMIN' | 'STYLIST' = 
   return response.body.data;
 };
 
+// Extrae el valor de una cookie desde el array Set-Cookie de una respuesta
+export const extractCookie = (
+  setCookie: string[] | undefined,
+  name: string,
+): string | undefined => {
+  if (!setCookie) return undefined;
+  const found = setCookie.find((c) => c.startsWith(`${name}=`));
+  return found ? found.split(';')[0].slice(name.length + 1) : undefined;
+};
+
 export const loginTestUser = async () => {
   const userData = await createTestUser('CLIENT');
 
@@ -68,9 +78,13 @@ export const loginTestUser = async () => {
     throw new Error(`Login falló: ${response.status}`);
   }
 
+  const setCookie = response.headers['set-cookie'] as unknown as string[] | undefined;
+
   return {
     token: response.body.data.token,
-    refreshToken: response.body.data.refreshToken,
+    // El refresh y el CSRF ahora viajan por cookie (F5b), no en el body.
+    refreshToken: extractCookie(setCookie, 'refreshToken'),
+    csrfToken: extractCookie(setCookie, 'csrfToken'),
     user: response.body.data.user,
   };
 };

--- a/tests/unit/appointments/application/use-cases/UpdateAppointment.unit.test.ts
+++ b/tests/unit/appointments/application/use-cases/UpdateAppointment.unit.test.ts
@@ -31,6 +31,11 @@ describe('UpdateAppointment Use Case', () => {
   const getFutureDate = (hoursFromNow: number = 48): Date => {
     const future = new Date();
     future.setHours(future.getHours() + hoursFromNow);
+    // Fija una hora del dia segura (10:00 UTC) para que la cita nunca cruce el
+    // fin de jornada del horario simulado. Sin esto, correr la suite de noche
+    // (UTC tardio) hacia que la cita terminara despues de las 23:59 y disparara
+    // BusinessRuleError('ends after working hours'), volviendo estos tests flaky.
+    future.setUTCHours(10, 0, 0, 0);
     return future;
   };
 

--- a/tests/unit/auth/RefreshToken.unit.test.ts
+++ b/tests/unit/auth/RefreshToken.unit.test.ts
@@ -1,24 +1,26 @@
 import { RoleName } from '@prisma/client';
 import { RefreshToken } from '../../../src/modules/auth/application/use-cases/RefreshToken';
-import { JwtService, JwtPayload } from '../../../src/modules/auth/application/services/JwtService';
+import { JwtService } from '../../../src/modules/auth/application/services/JwtService';
+import { RefreshTokenService } from '../../../src/modules/auth/application/services/RefreshTokenService';
 import { IUserRepository } from '../../../src/modules/auth/domain/repositories/IUserRepository';
 import { IRoleRepository } from '../../../src/modules/auth/domain/repositories/IRoleRepository';
+import { IRefreshTokenRepository } from '../../../src/modules/auth/domain/repositories/IRefreshTokenRepository';
+import { RefreshTokenSession } from '../../../src/modules/auth/domain/entities/RefreshTokenSession';
 import { User } from '../../../src/modules/auth/domain/entities/User';
 import { Role } from '../../../src/modules/auth/domain/entities/Role';
 import { UnauthorizedError } from '../../../src/shared/exceptions/UnauthorizedError';
 import { NotFoundError } from '../../../src/shared/exceptions/NotFoundError';
 
-describe('RefreshToken Use Case', () => {
+describe('RefreshToken Use Case (rotacion + reuse detection)', () => {
   let refreshToken: RefreshToken;
   let mockUserRepository: jest.Mocked<IUserRepository>;
   let mockRoleRepository: jest.Mocked<IRoleRepository>;
   let mockJwtService: jest.Mocked<JwtService>;
+  let mockRefreshTokenRepository: jest.Mocked<IRefreshTokenRepository>;
+  let mockRefreshTokenService: jest.Mocked<RefreshTokenService>;
 
-  const validPayload: JwtPayload = {
-    userId: 'user-id',
-    roleId: 'role-id',
-    email: 'test@example.com',
-  };
+  const future = new Date(Date.now() + 60 * 60 * 1000);
+  const past = new Date(Date.now() - 60 * 60 * 1000);
 
   const activeUser = new User(
     'user-id',
@@ -31,6 +33,10 @@ describe('RefreshToken Use Case', () => {
   );
 
   const clientRole = Role.fromPersistence('role-id', RoleName.CLIENT, 'Cliente');
+
+  // Sesion vigente (no revocada, no expirada) para el hash 'hash-1'
+  const activeSession = () =>
+    new RefreshTokenSession('sess-id', 'fam-id', 'user-id', 'hash-1', future, null, null, null, null, past);
 
   beforeEach(() => {
     mockUserRepository = {
@@ -62,66 +68,126 @@ describe('RefreshToken Use Case', () => {
       verifyRefreshToken: jest.fn(),
     };
 
-    refreshToken = new RefreshToken(mockUserRepository, mockRoleRepository, mockJwtService);
+    mockRefreshTokenRepository = {
+      create: jest.fn(),
+      findByTokenHash: jest.fn(),
+      rotate: jest.fn(),
+      revokeById: jest.fn(),
+      revokeFamily: jest.fn(),
+      revokeAllForUser: jest.fn(),
+      deleteExpired: jest.fn(),
+    };
+
+    mockRefreshTokenService = {
+      generate: jest.fn(),
+      hash: jest.fn(),
+    };
+
+    refreshToken = new RefreshToken(
+      mockUserRepository,
+      mockRoleRepository,
+      mockJwtService,
+      mockRefreshTokenRepository,
+      mockRefreshTokenService,
+    );
   });
 
-  // Debería renovar los tokens exitosamente con datos válidos
-  it('should refresh tokens successfully with valid data', async () => {
-    mockJwtService.verifyRefreshToken.mockReturnValue(validPayload);
+  // Debería rotar y renovar los tokens con una sesión válida
+  it('should rotate and refresh tokens successfully with a valid session', async () => {
+    mockRefreshTokenService.hash.mockReturnValue('hash-1');
+    mockRefreshTokenRepository.findByTokenHash.mockResolvedValue(activeSession());
     mockUserRepository.findById.mockResolvedValue(activeUser);
     mockRoleRepository.findById.mockResolvedValue(clientRole);
     mockJwtService.generateAccessToken.mockReturnValue('new-access-token');
-    mockJwtService.generateRefreshToken.mockReturnValue('new-refresh-token');
+    mockRefreshTokenService.generate.mockReturnValue({
+      token: 'new-refresh',
+      hash: 'new-hash',
+      expiresAt: future,
+    });
+    mockRefreshTokenRepository.rotate.mockResolvedValue(
+      new RefreshTokenSession('sess-2', 'fam-id', 'user-id', 'new-hash', future, null, null, null, null, new Date()),
+    );
 
-    const result = await refreshToken.execute('valid-refresh-token');
+    const result = await refreshToken.execute('opaque-refresh');
 
     expect(result.token).toBe('new-access-token');
-    expect(result.refreshToken).toBe('new-refresh-token');
+    expect(result.refreshToken).toBe('new-refresh');
     expect(result.user.id).toBe(activeUser.id);
+    expect(mockRefreshTokenRepository.rotate).toHaveBeenCalledTimes(1);
   });
 
-  // Debería lanzar UnauthorizedError si el refresh token es inválido (propagado desde JwtTokenService)
-  it('should throw UnauthorizedError when the refresh token itself is invalid', async () => {
-    mockJwtService.verifyRefreshToken.mockImplementation(() => {
-      throw new UnauthorizedError('Invalid refresh token');
-    });
+  // Debería lanzar UnauthorizedError si no existe una sesión para ese token
+  it('should throw UnauthorizedError when no session matches the token', async () => {
+    mockRefreshTokenService.hash.mockReturnValue('unknown-hash');
+    mockRefreshTokenRepository.findByTokenHash.mockResolvedValue(null);
 
     await expect(refreshToken.execute('bad-token')).rejects.toThrow(UnauthorizedError);
   });
 
-  // Debería lanzar UnauthorizedError si el usuario no existe
-  it('should throw UnauthorizedError when user does not exist', async () => {
-    mockJwtService.verifyRefreshToken.mockReturnValue(validPayload);
-    mockUserRepository.findById.mockResolvedValue(null);
+  // Reuse: sesión ya revocada -> revoca toda la familia y rechaza (RFC 9700)
+  it('should revoke the whole family and reject when a rotated token is reused', async () => {
+    const revoked = new RefreshTokenSession(
+      'sess-id', 'fam-9', 'user-id', 'hash-1', future, new Date(), 'sess-next', null, null, past,
+    );
+    mockRefreshTokenService.hash.mockReturnValue('hash-1');
+    mockRefreshTokenRepository.findByTokenHash.mockResolvedValue(revoked);
 
-    await expect(refreshToken.execute('valid-refresh-token')).rejects.toThrow(UnauthorizedError);
+    await expect(refreshToken.execute('reused-token')).rejects.toThrow(UnauthorizedError);
+    expect(mockRefreshTokenRepository.revokeFamily).toHaveBeenCalledWith('fam-9');
+    expect(mockRefreshTokenRepository.rotate).not.toHaveBeenCalled();
   });
 
-  // Debería lanzar UnauthorizedError si el usuario está inactivo
-  it('should throw UnauthorizedError when user is inactive', async () => {
-    const inactiveUser = new User(
-      'user-id',
-      'role-id',
-      'Test User',
-      'test@example.com',
-      '+1234567890',
-      'hashed-password',
-      false,
+  // Debería lanzar UnauthorizedError si la sesión está expirada
+  it('should throw UnauthorizedError when the session is expired', async () => {
+    const expired = new RefreshTokenSession(
+      'sess-id', 'fam-id', 'user-id', 'hash-1', past, null, null, null, null, past,
     );
-    mockJwtService.verifyRefreshToken.mockReturnValue(validPayload);
+    mockRefreshTokenService.hash.mockReturnValue('hash-1');
+    mockRefreshTokenRepository.findByTokenHash.mockResolvedValue(expired);
+
+    await expect(refreshToken.execute('expired-token')).rejects.toThrow(UnauthorizedError);
+  });
+
+  // Usuario inactivo -> revoca la sesión y rechaza
+  it('should revoke the session and reject when the user is inactive', async () => {
+    const inactiveUser = new User(
+      'user-id', 'role-id', 'Test User', 'test@example.com', '+1234567890', 'hashed-password', false,
+    );
+    mockRefreshTokenService.hash.mockReturnValue('hash-1');
+    mockRefreshTokenRepository.findByTokenHash.mockResolvedValue(activeSession());
     mockUserRepository.findById.mockResolvedValue(inactiveUser);
 
-    await expect(refreshToken.execute('valid-refresh-token')).rejects.toThrow(UnauthorizedError);
+    await expect(refreshToken.execute('token')).rejects.toThrow(UnauthorizedError);
+    expect(mockRefreshTokenRepository.revokeById).toHaveBeenCalledWith('sess-id');
   });
 
-  // No debería convertir errores de base de datos en 401
+  // Usuario inexistente -> UnauthorizedError
+  it('should throw UnauthorizedError when the user does not exist', async () => {
+    mockRefreshTokenService.hash.mockReturnValue('hash-1');
+    mockRefreshTokenRepository.findByTokenHash.mockResolvedValue(activeSession());
+    mockUserRepository.findById.mockResolvedValue(null);
+
+    await expect(refreshToken.execute('token')).rejects.toThrow(UnauthorizedError);
+  });
+
+  // Rol inexistente -> NotFoundError
+  it('should propagate NotFoundError when the role is missing', async () => {
+    mockRefreshTokenService.hash.mockReturnValue('hash-1');
+    mockRefreshTokenRepository.findByTokenHash.mockResolvedValue(activeSession());
+    mockUserRepository.findById.mockResolvedValue(activeUser);
+    mockRoleRepository.findById.mockResolvedValue(null);
+
+    await expect(refreshToken.execute('token')).rejects.toThrow(NotFoundError);
+  });
+
+  // Errores de base de datos no se convierten en 401
   it('should not convert database errors into 401', async () => {
-    mockJwtService.verifyRefreshToken.mockReturnValue(validPayload);
-    mockUserRepository.findById.mockRejectedValue(new Error('db down'));
+    mockRefreshTokenService.hash.mockReturnValue('hash-1');
+    mockRefreshTokenRepository.findByTokenHash.mockRejectedValue(new Error('db down'));
 
     let caughtError: unknown;
     try {
-      await refreshToken.execute('valid-refresh-token');
+      await refreshToken.execute('token');
     } catch (error) {
       caughtError = error;
     }
@@ -129,14 +195,5 @@ describe('RefreshToken Use Case', () => {
     expect(caughtError).toBeDefined();
     expect(caughtError).not.toBeInstanceOf(UnauthorizedError);
     expect((caughtError as Error).message).toBe('db down');
-  });
-
-  // Debería propagar NotFoundError si el rol no existe
-  it('should propagate NotFoundError when role is missing', async () => {
-    mockJwtService.verifyRefreshToken.mockReturnValue(validPayload);
-    mockUserRepository.findById.mockResolvedValue(activeUser);
-    mockRoleRepository.findById.mockResolvedValue(null);
-
-    await expect(refreshToken.execute('valid-refresh-token')).rejects.toThrow(NotFoundError);
   });
 });

--- a/tests/unit/auth/RefreshToken.unit.test.ts
+++ b/tests/unit/auth/RefreshToken.unit.test.ts
@@ -196,4 +196,17 @@ describe('RefreshToken Use Case (rotacion + reuse detection)', () => {
     expect(caughtError).not.toBeInstanceOf(UnauthorizedError);
     expect((caughtError as Error).message).toBe('db down');
   });
+
+  // Carrera perdida en rotate (devuelve null) -> UnauthorizedError
+  it('should throw UnauthorizedError when rotate loses a concurrency race', async () => {
+    mockRefreshTokenService.hash.mockReturnValue('hash-1');
+    mockRefreshTokenRepository.findByTokenHash.mockResolvedValue(activeSession());
+    mockUserRepository.findById.mockResolvedValue(activeUser);
+    mockRoleRepository.findById.mockResolvedValue(clientRole);
+    mockJwtService.generateAccessToken.mockReturnValue('acc');
+    mockRefreshTokenService.generate.mockReturnValue({ token: 't', hash: 'h', expiresAt: future });
+    mockRefreshTokenRepository.rotate.mockResolvedValue(null);
+
+    await expect(refreshToken.execute('token')).rejects.toThrow(UnauthorizedError);
+  });
 });


### PR DESCRIPTION
## Resumen

Implementa sesiones seguras y revocables en el módulo `auth`, alineadas a estándares de
industria (OAuth 2.0 + RFC 9700 Security BCP, OWASP ASVS, NIST 800-63B):

- **Refresh tokens rotativos**: cada uso de `/auth/refresh-token` emite un access nuevo
  y un refresh nuevo, invalidando el anterior.
- **Detección de reuse**: presentar un refresh ya rotado revoca toda la familia de la
  sesión (fail-safe, RFC 9700 §4.14).
- **Revocación real**: `POST /auth/logout` (sesión actual) y `POST /auth/logout-all`
  (todas las sesiones del usuario).
- **Transporte por cookie httpOnly** + protección **CSRF** (double-submit), pensado para
  una SPA web.

El access token sigue siendo un JWT stateless de 15m (sin denylist); su vida corta es la
medida de revocación aceptada (ASVS V9). Se completan los claims `sub`/`jti` (RFC 9068).

## Qué incluye (por fases)

- **F1** — Modelo `RefreshToken` (opaco, hasheado SHA-256; `familyId`, `replacedById`,
  `expiresAt`, `revokedAt`, `userAgent`/`ip`) + migración aditiva.
- **F2** — Puerto `IRefreshTokenRepository` + impl Prisma; `RefreshTokenService`
  (opaco 256 bits + SHA-256, `node:crypto`).
- **F3** — Login rotativo: persiste la sesión, emite refresh opaco; claims `sub`/`jti`.
- **F4** — `/auth/refresh-token` reescrito: rotación + reuse detection + revoke-family.
- **F5** — `logout` y `logout-all` (revocación por token y global).
- **F5b** — Refresh en **cookie httpOnly**; **CSRF** double-submit (`GET /auth/csrf`);
  `cookie-parser` cableado; `LoginResponseDto` → `{ token, user }`.
- **F6** — `.env.example`, validación en `env.ts` (`REFRESH_TOKEN_TTL_DAYS`, `COOKIE_*`),
  Swagger actualizado; `JWT_REFRESH_EXPIRY` marcado como legacy.
- **F7** — Tests integration/e2e a contrato cookie+CSRF; hardening de **concurrencia**
  en `rotate()` (rotación atómica: si pierde la carrera devuelve `null` → 401 sin nukear
  la familia); test de reuse y de concurrencia.

## ⚠️ Breaking changes (contrato de API)

- El **refresh ya no viaja en el body**: se entrega en cookie httpOnly `refreshToken`.
  `login`/`refresh-token` devuelven `{ token, user }` (sin `refreshToken`).
- `/auth/refresh-token`, `/auth/logout`, `/auth/logout-all` requieren **CSRF**: cookie
  `csrfToken` + header `X-CSRF-Token` (se obtiene en login o vía `GET /auth/csrf`).
- Tras el deploy, los refresh emitidos con el esquema anterior dejan de ser válidos →
  **re-login único** (sin período de gracia).

## Endpoints

| Método | Path | Cambio |
|---|---|---|
| POST | `/auth/login` | Setea cookies `refreshToken`+`csrfToken`; body `{ token, user }` |
| POST | `/auth/refresh-token` | Refresh por cookie + header CSRF; rotación + reuse detection |
| POST | `/auth/logout` | *(nuevo)* revoca la sesión y borra cookies |
| POST | `/auth/logout-all` | *(nuevo)* revoca todas las sesiones |
| GET | `/auth/csrf` | *(nuevo)* emite la cookie/token CSRF |

## Variables de entorno nuevas

`REFRESH_TOKEN_TTL_DAYS` (default 7), `COOKIE_SECURE` (derivada de `NODE_ENV` si no se
setea), `COOKIE_SAMESITE` (default `lax`), `COOKIE_DOMAIN` (opcional). Sin dependencias
npm nuevas (`cookie-parser` ya estaba instalado; se cableó).


Suite: **1342 tests** cubriendo rotación, reuse, revocación, CSRF y concurrencia.
Colección Postman (`src/docs/postman/auth_postman_collection.json`) actualizada al
contrato cookie+CSRF.

## Notas para el frontend (cuando se implemente)

- Llamar con `credentials: 'include'`.
- Obtener el CSRF (cookie `csrfToken`, o `GET /auth/csrf`) y reenviarlo en `X-CSRF-Token`.
- No leer el refresh del body (viene por cookie httpOnly).
- Desplegar SPA y API bajo el mismo dominio registrable (`app.` + `api.`) para poder usar
  `SameSite=Lax`.

## Fuera de alcance / follow-ups

- Denylist de access por `jti`, sender-constrained tokens (DPoP), migración a un IdP
  externo (OAuth2/OIDC) — evaluados y diferidos.
- No incluido en este PR: hay un test flaky **preexistente** en `appointments`
  (`UpdateAppointment.unit.test.ts`) dependiente de la hora del día (UTC), sin relación
  con estos cambios; se trata por separado.