### PR TITLE
feat(auth): registro público seguro — verificación de email y recuperación de contraseña

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,14 +46,29 @@ COOKIE_DOMAIN=
 # CORS Configuration | Configuración de CORS
 FRONTEND_URL=http://localhost:3000
 
-# Mail Configuration -- ningun servicio de mail esta implementado todavia
-# (nodemailer esta instalado pero sin wirear), ningun codigo lee estas
-# variables por ahora. Se dejan documentadas para cuando se implemente.
+# Mail Configuration (SMTP / nodemailer) | EmailService
+# Consumidas por EmailService para verificacion de email + reset de password.
+# REQUERIDAS en produccion (el boot falla sin ellas). En development/test son
+# opcionales: el transporte es mock/log y no se envian mails reales.
 MAIL_HOST=smtp.your-mail-provider.com
 MAIL_PORT=587
 MAIL_USER=your-email@example.com
 MAIL_PASSWORD=your-mail-password
 MAIL_FROM=noreply@yourapp.com
+# MAIL_SECURE: true => TLS directo (puerto 465); false => STARTTLS (587).
+MAIL_SECURE=false
+
+# Verificacion de email + reset de password | Registro publico seguro
+# TTL de los tokens de un solo uso.
+EMAIL_VERIFICATION_TOKEN_TTL_HOURS=24
+PASSWORD_RESET_TOKEN_TTL_MINUTES=60
+# REQUIRE_EMAIL_VERIFICATION: true | false. Si true, el login se bloquea (403)
+# hasta que el usuario verifique su email.
+REQUIRE_EMAIL_VERIFICATION=true
+# EXPOSE_VERIFICATION_TOKENS: SOLO desarrollo/pruebas. Si true, la API devuelve/
+# loguea el token para probar por Postman sin frontend. PROHIBIDO en produccion
+# (el boot falla si se pone en true con NODE_ENV=production).
+EXPOSE_VERIFICATION_TOKENS=false
 
 # pgAdmin Configuration | Configuración de pdAdmin (desarrollo)
 PGADMIN_DEFAULT_EMAIL=admin@yourapp.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,12 @@ jobs:
       MAIL_USER: ci@example.com
       MAIL_PASSWORD: ci_password_not_real
       MAIL_FROM: noreply@example.com
+      MAIL_SECURE: 'false'
+      # Verificacion de email + reset de password. EXPOSE_VERIFICATION_TOKENS lo
+      # fuerza tests/setup/jest.setup.ts para la suite; aca solo el resto de config.
+      EMAIL_VERIFICATION_TOKEN_TTL_HOURS: 24
+      PASSWORD_RESET_TOKEN_TTL_MINUTES: 60
+      REQUIRE_EMAIL_VERIFICATION: 'true'
 
     steps:
       - name: Checkout repository

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,8 +48,8 @@
         "@types/swagger-ui-express": "^4.1.8",
         "@types/uuid": "^10.0.0",
         "@types/yamljs": "^0.2.34",
-        "@typescript-eslint/eslint-plugin": "^6.15.0",
-        "@typescript-eslint/parser": "^6.15.0",
+        "@typescript-eslint/eslint-plugin": "^8.65.0",
+        "@typescript-eslint/parser": "^8.65.0",
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^10.1.5",
         "jest": "^30.4.2",
@@ -62,15 +62,19 @@
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
-      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-14.0.1.tgz",
+      "integrity": "sha512-Oc96zvmxx1fqoSEdUmfmvvb59/KDOnUoJ7s2t7bISyAn0XEz57LCCw8k2Y4Pf3mwKaZLMciESALORLgfe2frCw==",
       "license": "MIT",
       "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.6",
-        "call-me-maybe": "^1.0.1",
+        "@types/json-schema": "^7.0.15",
         "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
       }
     },
     "node_modules/@apidevtools/openapi-schemas": {
@@ -89,21 +93,57 @@
       "license": "MIT"
     },
     "node_modules/@apidevtools/swagger-parser": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
-      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-12.1.0.tgz",
+      "integrity": "sha512-e5mJoswsnAX0jG+J09xHFYQXb/bUc5S3pLpMxUuRUA2H8T2kni3yEoyz2R3Dltw5f4A6j6rPNMpWTK+iVDFlng==",
       "license": "MIT",
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^9.0.6",
-        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/json-schema-ref-parser": "14.0.1",
+        "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
-        "@jsdevtools/ono": "^7.1.3",
-        "call-me-maybe": "^1.0.1",
-        "z-schema": "^5.0.1"
+        "ajv": "^8.17.1",
+        "ajv-draft-04": "^1.0.0",
+        "call-me-maybe": "^1.0.2"
       },
       "peerDependencies": {
         "openapi-types": ">=7"
       }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -1100,10 +1140,11 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
-      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
       },
@@ -1118,10 +1159,11 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -2373,16 +2415,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/@jest/reporters/node_modules/ci-info": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
@@ -2836,12 +2868,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@jsdevtools/ono": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
-      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
-      "license": "MIT"
-    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
@@ -3261,7 +3287,8 @@
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
     },
     "node_modules/@types/jsonwebtoken": {
       "version": "9.0.9",
@@ -3337,12 +3364,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true
-    },
-    "node_modules/@types/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
       "dev": true
     },
     "node_modules/@types/send": {
@@ -3447,144 +3468,159 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.15.0.tgz",
-      "integrity": "sha512-j5qoikQqPccq9QoBAupOP+CBu8BaJ8BLjaXSioDISeTZkVO3ig7oSIKh3H+rEpee7xCXtWwSB4KIL5l6hWZzpg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.15.0",
-        "@typescript-eslint/type-utils": "6.15.0",
-        "@typescript-eslint/utils": "6.15.0",
-        "@typescript-eslint/visitor-keys": "6.15.0",
-        "debug": "^4.3.4",
-        "graphemer": "^1.4.0",
-        "ignore": "^5.2.4",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
-        "eslint": "^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "@typescript-eslint/parser": "^8.65.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.15.0.tgz",
-      "integrity": "sha512-CnmHKTfX6450Bo49hPg2OkIm/D/TVYV7jO1MCfPYGwf6x3GO0VU8YMO5AYMn+u3X05lRRxA4fWCz87GFQV6yVQ==",
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
-      "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.15.0",
-        "@typescript-eslint/utils": "6.15.0",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^1.0.1"
-      },
+      "license": "MIT",
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.15.0.tgz",
-      "integrity": "sha512-eF82p0Wrrlt8fQSRL0bGXzK5nWPRV2dYQZdajcfzOD9+cQz9O7ugifrJxclB+xVOvWvagXfqS4Es7vpLP4augw==",
-      "dev": true,
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@types/json-schema": "^7.0.12",
-        "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.15.0",
-        "@typescript-eslint/types": "6.15.0",
-        "@typescript-eslint/typescript-estree": "6.15.0",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "node": ">= 4"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.15.0.tgz",
-      "integrity": "sha512-MkgKNnsjC6QwcMdlNAel24jjkEO/0hQaMDLqP4S9zq5HBAUJNQB6y+3DwLjX7b3l2b37eNAxMPLwb3/kh8VKdA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.15.0",
-        "@typescript-eslint/types": "6.15.0",
-        "@typescript-eslint/typescript-estree": "6.15.0",
-        "@typescript-eslint/visitor-keys": "6.15.0",
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
+        "debug": "^4.4.3"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.15.0.tgz",
-      "integrity": "sha512-+BdvxYBltqrmgCNu4Li+fGDIkW9n//NrruzG9X1vBzaNK+ExVXPoGB71kneaVw/Jp+4rH/vaMAGC6JfMbHstVg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "6.15.0",
-        "@typescript-eslint/visitor-keys": "6.15.0"
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/types": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.15.0.tgz",
-      "integrity": "sha512-yXjbt//E4T/ee8Ia1b5mGlbNj9fB9lJP4jqLbZualwpP2BCQ5is6BcWwxpIsY4XKAhmdv3hrW92GdtJbatC6dQ==",
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3592,47 +3628,102 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.15.0.tgz",
-      "integrity": "sha512-7mVZJN7Hd15OmGuWrp2T9UvqR2Ecg+1j/Bp1jXUEY2GZKV6FXlOIoqVDmLpBiEiq3katvj/2n2mR0SDwtloCew==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "6.15.0",
-        "@typescript-eslint/visitor-keys": "6.15.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.15.0.tgz",
-      "integrity": "sha512-1zvtdC1a9h5Tb5jU9x3ADNXO9yjP8rXlaoChu0DQX40vf5ACVpYIVIZhIMZ6d5sDXH7vq4dsZBT1fEGj8D2n2w==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "6.15.0",
-        "eslint-visitor-keys": "^3.4.1"
+        "@typescript-eslint/types": "8.65.0",
+        "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -4069,15 +4160,6 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
-    "node_modules/array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -4095,6 +4177,28 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
+    },
+    "node_modules/babel-jest": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
+      "integrity": "sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "30.4.1",
+        "@types/babel__core": "^7.20.5",
+        "babel-plugin-istanbul": "^7.0.1",
+        "babel-preset-jest": "30.4.0",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0 || ^8.0.0-0"
+      }
     },
     "node_modules/babel-plugin-istanbul": {
       "version": "7.0.1",
@@ -4114,6 +4218,19 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.4.0.tgz",
+      "integrity": "sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/babel__core": "^7.20.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/babel-preset-current-node-syntax": {
@@ -4143,11 +4260,31 @@
         "@babel/core": "^7.0.0 || ^8.0.0-0"
       }
     },
+    "node_modules/babel-preset-jest": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.4.0.tgz",
+      "integrity": "sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "30.4.0",
+        "babel-preset-current-node-syntax": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
+      }
+    },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.38",
@@ -4229,13 +4366,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -4648,12 +4787,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "license": "MIT"
-    },
     "node_modules/concat-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
@@ -4762,7 +4895,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -4897,18 +5029,6 @@
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/doctrine": {
@@ -5491,36 +5611,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
-    },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -5539,6 +5630,22 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -5652,7 +5759,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -5669,7 +5775,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -5936,26 +6041,6 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
-      },
       "engines": {
         "node": ">=10"
       },
@@ -6293,8 +6378,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -6949,68 +7033,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-config/node_modules/babel-jest": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
-      "integrity": "sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/transform": "30.4.1",
-        "@types/babel__core": "^7.20.5",
-        "babel-plugin-istanbul": "^7.0.1",
-        "babel-preset-jest": "30.4.0",
-        "chalk": "^4.1.2",
-        "graceful-fs": "^4.2.11",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.11.0 || ^8.0.0-0"
-      }
-    },
-    "node_modules/jest-config/node_modules/babel-jest/node_modules/babel-preset-jest": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.4.0.tgz",
-      "integrity": "sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-jest-hoist": "30.4.0",
-        "babel-preset-current-node-syntax": "^1.2.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
-      }
-    },
-    "node_modules/jest-config/node_modules/babel-plugin-jest-hoist": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.4.0.tgz",
-      "integrity": "sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/babel__core": "^7.20.5"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-config/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/jest-config/node_modules/ci-info": {
@@ -8103,16 +8125,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/jest-runtime/node_modules/ci-info": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
@@ -9043,13 +9055,6 @@
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
-      "license": "MIT"
-    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -9059,13 +9064,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
-    },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
-      "license": "MIT"
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
@@ -9203,15 +9201,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -9299,7 +9288,6 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -9693,7 +9681,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/parent-module": {
@@ -9756,7 +9743,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -9793,15 +9779,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/pathe": {
@@ -10297,6 +10274,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
@@ -10494,7 +10480,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -10506,7 +10491,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -10838,56 +10822,111 @@
       }
     },
     "node_modules/swagger-jsdoc": {
-      "version": "6.2.8",
-      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
-      "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.3.0.tgz",
+      "integrity": "sha512-I+iQjVGV3t28pOkQUJv2MncthvOtkEactOn8R76SvSYhxgtIn7FoqfDHwQaN+GBnQdXQLrhgDXseKitmJcHMsA==",
       "license": "MIT",
       "dependencies": {
+        "@apidevtools/swagger-parser": "^12.1.0",
         "commander": "6.2.0",
         "doctrine": "3.0.0",
-        "glob": "7.1.6",
+        "glob": "11.1.0",
         "lodash.mergewith": "^4.6.2",
-        "swagger-parser": "^10.0.3",
         "yaml": "2.0.0-1"
       },
       "bin": {
         "swagger-jsdoc": "bin/swagger-jsdoc.js"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/swagger-jsdoc/node_modules/glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "license": "ISC",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "engines": {
-        "node": "*"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/swagger-parser": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
-      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
-      "license": "MIT",
+    "node_modules/swagger-jsdoc/node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@apidevtools/swagger-parser": "10.0.3"
+        "@isaacs/cliui": "^9.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/swagger-ui-dist": {
@@ -10967,6 +11006,54 @@
         "node": ">=18"
       }
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -11004,21 +11091,22 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
-      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=16"
+        "node": ">=18.12"
       },
       "peerDependencies": {
-        "typescript": ">=4.2.0"
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.4.11",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
-      "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
+      "version": "29.4.12",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.12.tgz",
+      "integrity": "sha512-Ov6ClY53Fflh6BGAnY2DlTq1hYDrTycz2PVTXBWFW2CU+9zrEqAp9fWdGXl42EXO5RLSFAcAZ2JFKbP+zBTFfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11028,7 +11116,7 @@
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.8.0",
+        "semver": "^7.8.5",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -11364,7 +11452,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -11621,36 +11708,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/z-schema": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
-      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash.get": "^4.4.2",
-        "lodash.isequal": "^4.5.0",
-        "validator": "^13.7.0"
-      },
-      "bin": {
-        "z-schema": "bin/z-schema"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "commander": "^9.4.1"
-      }
-    },
-    "node_modules/z-schema/node_modules/commander": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "^12.20.0 || >=14"
-      }
-    },
     "node_modules/zod": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
@@ -11663,13 +11720,11 @@
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
-      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-14.0.1.tgz",
+      "integrity": "sha512-Oc96zvmxx1fqoSEdUmfmvvb59/KDOnUoJ7s2t7bISyAn0XEz57LCCw8k2Y4Pf3mwKaZLMciESALORLgfe2frCw==",
       "requires": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.6",
-        "call-me-maybe": "^1.0.1",
+        "@types/json-schema": "^7.0.15",
         "js-yaml": "^4.1.0"
       }
     },
@@ -11684,16 +11739,40 @@
       "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
     },
     "@apidevtools/swagger-parser": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
-      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-12.1.0.tgz",
+      "integrity": "sha512-e5mJoswsnAX0jG+J09xHFYQXb/bUc5S3pLpMxUuRUA2H8T2kni3yEoyz2R3Dltw5f4A6j6rPNMpWTK+iVDFlng==",
       "requires": {
-        "@apidevtools/json-schema-ref-parser": "^9.0.6",
-        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/json-schema-ref-parser": "14.0.1",
+        "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
-        "@jsdevtools/ono": "^7.1.3",
-        "call-me-maybe": "^1.0.1",
-        "z-schema": "^5.0.1"
+        "ajv": "^8.17.1",
+        "ajv-draft-04": "^1.0.0",
+        "call-me-maybe": "^1.0.2"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.20.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+          "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "fast-uri": "^3.0.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2"
+          }
+        },
+        "ajv-draft-04": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+          "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+          "requires": {}
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
       }
     },
     "@babel/code-frame": {
@@ -12265,18 +12344,18 @@
       "optional": true
     },
     "@eslint-community/eslint-utils": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
-      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^3.4.3"
       }
     },
     "@eslint-community/regexpp": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true
     },
     "@eslint/eslintrc": {
@@ -13156,15 +13235,6 @@
           "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
           "dev": true
         },
-        "brace-expansion": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-          "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
         "ci-info": {
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
@@ -13223,7 +13293,7 @@
           "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^2.0.2"
+            "brace-expansion": "^5.0.8"
           }
         },
         "picomatch": {
@@ -13501,11 +13571,6 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "@jsdevtools/ono": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
-      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
     "@napi-rs/wasm-runtime": {
       "version": "1.1.5",
@@ -13931,12 +13996,6 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true
     },
-    "@types/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
-      "dev": true
-    },
     "@types/send": {
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
@@ -14035,105 +14094,145 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.15.0.tgz",
-      "integrity": "sha512-j5qoikQqPccq9QoBAupOP+CBu8BaJ8BLjaXSioDISeTZkVO3ig7oSIKh3H+rEpee7xCXtWwSB4KIL5l6hWZzpg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
       "dev": true,
       "requires": {
-        "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.15.0",
-        "@typescript-eslint/type-utils": "6.15.0",
-        "@typescript-eslint/utils": "6.15.0",
-        "@typescript-eslint/visitor-keys": "6.15.0",
-        "debug": "^4.3.4",
-        "graphemer": "^1.4.0",
-        "ignore": "^5.2.4",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "ts-api-utils": "^2.5.0"
       },
       "dependencies": {
-        "@typescript-eslint/type-utils": {
-          "version": "6.15.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.15.0.tgz",
-          "integrity": "sha512-CnmHKTfX6450Bo49hPg2OkIm/D/TVYV7jO1MCfPYGwf6x3GO0VU8YMO5AYMn+u3X05lRRxA4fWCz87GFQV6yVQ==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/typescript-estree": "6.15.0",
-            "@typescript-eslint/utils": "6.15.0",
-            "debug": "^4.3.4",
-            "ts-api-utils": "^1.0.1"
-          }
-        },
-        "@typescript-eslint/utils": {
-          "version": "6.15.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.15.0.tgz",
-          "integrity": "sha512-eF82p0Wrrlt8fQSRL0bGXzK5nWPRV2dYQZdajcfzOD9+cQz9O7ugifrJxclB+xVOvWvagXfqS4Es7vpLP4augw==",
-          "dev": true,
-          "requires": {
-            "@eslint-community/eslint-utils": "^4.4.0",
-            "@types/json-schema": "^7.0.12",
-            "@types/semver": "^7.5.0",
-            "@typescript-eslint/scope-manager": "6.15.0",
-            "@typescript-eslint/types": "6.15.0",
-            "@typescript-eslint/typescript-estree": "6.15.0",
-            "semver": "^7.5.4"
-          }
+        "ignore": {
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+          "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+          "dev": true
         }
       }
     },
     "@typescript-eslint/parser": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.15.0.tgz",
-      "integrity": "sha512-MkgKNnsjC6QwcMdlNAel24jjkEO/0hQaMDLqP4S9zq5HBAUJNQB6y+3DwLjX7b3l2b37eNAxMPLwb3/kh8VKdA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "6.15.0",
-        "@typescript-eslint/types": "6.15.0",
-        "@typescript-eslint/typescript-estree": "6.15.0",
-        "@typescript-eslint/visitor-keys": "6.15.0",
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3"
+      }
+    },
+    "@typescript-eslint/project-service": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
+        "debug": "^4.4.3"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.15.0.tgz",
-      "integrity": "sha512-+BdvxYBltqrmgCNu4Li+fGDIkW9n//NrruzG9X1vBzaNK+ExVXPoGB71kneaVw/Jp+4rH/vaMAGC6JfMbHstVg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "6.15.0",
-        "@typescript-eslint/visitor-keys": "6.15.0"
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
+      }
+    },
+    "@typescript-eslint/tsconfig-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+      "dev": true,
+      "requires": {}
+    },
+    "@typescript-eslint/type-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.15.0.tgz",
-      "integrity": "sha512-yXjbt//E4T/ee8Ia1b5mGlbNj9fB9lJP4jqLbZualwpP2BCQ5is6BcWwxpIsY4XKAhmdv3hrW92GdtJbatC6dQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.15.0.tgz",
-      "integrity": "sha512-7mVZJN7Hd15OmGuWrp2T9UvqR2Ecg+1j/Bp1jXUEY2GZKV6FXlOIoqVDmLpBiEiq3katvj/2n2mR0SDwtloCew==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "6.15.0",
-        "@typescript-eslint/visitor-keys": "6.15.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "10.2.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+          "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^5.0.8"
+          }
+        }
+      }
+    },
+    "@typescript-eslint/utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+      "dev": true,
+      "requires": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.15.0.tgz",
-      "integrity": "sha512-1zvtdC1a9h5Tb5jU9x3ADNXO9yjP8rXlaoChu0DQX40vf5ACVpYIVIZhIMZ6d5sDXH7vq4dsZBT1fEGj8D2n2w==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "6.15.0",
-        "eslint-visitor-keys": "^3.4.1"
+        "@typescript-eslint/types": "8.65.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+          "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+          "dev": true
+        }
       }
     },
     "@ungap/structured-clone": {
@@ -14379,12 +14478,6 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
-    "array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true
-    },
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -14402,6 +14495,21 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
+    "babel-jest": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
+      "integrity": "sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==",
+      "dev": true,
+      "requires": {
+        "@jest/transform": "30.4.1",
+        "@types/babel__core": "^7.20.5",
+        "babel-plugin-istanbul": "^7.0.1",
+        "babel-preset-jest": "30.4.0",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "slash": "^3.0.0"
+      }
+    },
     "babel-plugin-istanbul": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
@@ -14413,6 +14521,15 @@
         "@istanbuljs/schema": "^0.1.3",
         "istanbul-lib-instrument": "^6.0.2",
         "test-exclude": "^6.0.0"
+      }
+    },
+    "babel-plugin-jest-hoist": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.4.0.tgz",
+      "integrity": "sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==",
+      "dev": true,
+      "requires": {
+        "@types/babel__core": "^7.20.5"
       }
     },
     "babel-preset-current-node-syntax": {
@@ -14438,10 +14555,20 @@
         "@babel/plugin-syntax-top-level-await": "^7.14.5"
       }
     },
+    "babel-preset-jest": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.4.0.tgz",
+      "integrity": "sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-jest-hoist": "30.4.0",
+        "babel-preset-current-node-syntax": "^1.2.0"
+      }
+    },
     "balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="
     },
     "baseline-browser-mapping": {
       "version": "2.10.38",
@@ -14497,12 +14624,11 @@
       }
     },
     "brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
       }
     },
     "braces": {
@@ -14772,11 +14898,6 @@
       "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
       "dev": true
     },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
-    },
     "concat-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
@@ -14862,7 +14983,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -14951,15 +15071,6 @@
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
       "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
       "dev": true
-    },
-    "dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
-      "requires": {
-        "path-type": "^4.0.0"
-      }
     },
     "doctrine": {
       "version": "3.0.0",
@@ -15368,32 +15479,7 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
-    },
-    "fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
-      "requires": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "dependencies": {
-        "glob-parent": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-          "dev": true,
-          "requires": {
-            "is-glob": "^4.0.1"
-          }
-        }
-      }
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -15412,6 +15498,11 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true
+    },
+    "fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="
     },
     "fastq": {
       "version": "1.19.1",
@@ -15503,7 +15594,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
       "requires": {
         "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
@@ -15512,8 +15602,7 @@
         "signal-exit": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-          "dev": true
+          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
         }
       }
     },
@@ -15695,20 +15784,6 @@
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
           "dev": true
         }
-      }
-    },
-    "globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
-      "requires": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
       }
     },
     "gopd": {
@@ -15925,8 +16000,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -16397,51 +16471,6 @@
           "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
           "dev": true
         },
-        "babel-jest": {
-          "version": "30.4.1",
-          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
-          "integrity": "sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==",
-          "dev": true,
-          "requires": {
-            "@jest/transform": "30.4.1",
-            "@types/babel__core": "^7.20.5",
-            "babel-plugin-istanbul": "^7.0.1",
-            "babel-preset-jest": "30.4.0",
-            "chalk": "^4.1.2",
-            "graceful-fs": "^4.2.11",
-            "slash": "^3.0.0"
-          },
-          "dependencies": {
-            "babel-preset-jest": {
-              "version": "30.4.0",
-              "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.4.0.tgz",
-              "integrity": "sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==",
-              "dev": true,
-              "requires": {
-                "babel-plugin-jest-hoist": "30.4.0",
-                "babel-preset-current-node-syntax": "^1.2.0"
-              }
-            }
-          }
-        },
-        "babel-plugin-jest-hoist": {
-          "version": "30.4.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.4.0.tgz",
-          "integrity": "sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==",
-          "dev": true,
-          "requires": {
-            "@types/babel__core": "^7.20.5"
-          }
-        },
-        "brace-expansion": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-          "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
         "ci-info": {
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
@@ -16482,7 +16511,7 @@
           "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^2.0.2"
+            "brace-expansion": "^5.0.8"
           }
         },
         "picomatch": {
@@ -17201,15 +17230,6 @@
           "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
           "dev": true
         },
-        "brace-expansion": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-          "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
         "ci-info": {
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
@@ -17268,7 +17288,7 @@
           "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^2.0.2"
+            "brace-expansion": "^5.0.8"
           }
         },
         "picomatch": {
@@ -17841,11 +17861,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
-    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -17855,11 +17870,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
-    },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
     },
     "lodash.isinteger": {
       "version": "4.0.4",
@@ -17970,12 +17980,6 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
     },
-    "merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true
-    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -18022,7 +18026,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.8"
       }
     },
     "minimist": {
@@ -18033,8 +18037,7 @@
     "minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="
     },
     "mkdirp": {
       "version": "0.5.6",
@@ -18310,8 +18313,7 @@
     "package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="
     },
     "parent-module": {
       "version": "1.0.1",
@@ -18353,8 +18355,7 @@
     "path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
     },
     "path-scurry": {
       "version": "1.11.1",
@@ -18378,12 +18379,6 @@
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="
-    },
-    "path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true
     },
     "pathe": {
       "version": "2.0.3",
@@ -18715,6 +18710,11 @@
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true
     },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+    },
     "resolve-cwd": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
@@ -18838,7 +18838,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "requires": {
         "shebang-regex": "^3.0.0"
       }
@@ -18846,8 +18845,7 @@
     "shebang-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
     "side-channel": {
       "version": "1.1.0",
@@ -19083,39 +19081,66 @@
       }
     },
     "swagger-jsdoc": {
-      "version": "6.2.8",
-      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
-      "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.3.0.tgz",
+      "integrity": "sha512-I+iQjVGV3t28pOkQUJv2MncthvOtkEactOn8R76SvSYhxgtIn7FoqfDHwQaN+GBnQdXQLrhgDXseKitmJcHMsA==",
       "requires": {
+        "@apidevtools/swagger-parser": "^12.1.0",
         "commander": "6.2.0",
         "doctrine": "3.0.0",
-        "glob": "7.1.6",
+        "glob": "11.1.0",
         "lodash.mergewith": "^4.6.2",
-        "swagger-parser": "^10.0.3",
         "yaml": "2.0.0-1"
       },
       "dependencies": {
+        "@isaacs/cliui": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+          "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg=="
+        },
         "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+          "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "foreground-child": "^3.3.1",
+            "jackspeak": "^4.1.1",
+            "minimatch": "^10.1.1",
+            "minipass": "^7.1.2",
+            "package-json-from-dist": "^1.0.0",
+            "path-scurry": "^2.0.0"
+          }
+        },
+        "jackspeak": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+          "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+          "requires": {
+            "@isaacs/cliui": "^9.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "11.5.2",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+          "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="
+        },
+        "minimatch": {
+          "version": "10.2.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+          "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+          "requires": {
+            "brace-expansion": "^5.0.8"
+          }
+        },
+        "path-scurry": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+          "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+          "requires": {
+            "lru-cache": "^11.0.0",
+            "minipass": "^7.1.2"
           }
         }
-      }
-    },
-    "swagger-parser": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
-      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
-      "requires": {
-        "@apidevtools/swagger-parser": "10.0.3"
       }
     },
     "swagger-ui-dist": {
@@ -19171,6 +19196,31 @@
       "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "devOptional": true
     },
+    "tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "requires": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "dependencies": {
+        "fdir": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+          "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+          "dev": true,
+          "requires": {}
+        },
+        "picomatch": {
+          "version": "4.0.5",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+          "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+          "dev": true
+        }
+      }
+    },
     "tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -19197,16 +19247,16 @@
       "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg=="
     },
     "ts-api-utils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
-      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "requires": {}
     },
     "ts-jest": {
-      "version": "29.4.11",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
-      "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
+      "version": "29.4.12",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.12.tgz",
+      "integrity": "sha512-Ov6ClY53Fflh6BGAnY2DlTq1hYDrTycz2PVTXBWFW2CU+9zrEqAp9fWdGXl42EXO5RLSFAcAZ2JFKbP+zBTFfw==",
       "dev": true,
       "requires": {
         "bs-logger": "^0.2.6",
@@ -19215,7 +19265,7 @@
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.8.0",
+        "semver": "^7.8.5",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -19407,7 +19457,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -19588,25 +19637,6 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
-    },
-    "z-schema": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
-      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
-      "requires": {
-        "commander": "^9.4.1",
-        "lodash.get": "^4.4.2",
-        "lodash.isequal": "^4.5.0",
-        "validator": "^13.7.0"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "9.5.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-          "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-          "optional": true
-        }
-      }
     },
     "zod": {
       "version": "4.4.3",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "docker:dev:down": "docker-compose -f docker-compose.dev.yml down",
     "docker:npm:install": "docker exec -it turnity-api-dev npm install",
     "docker:prisma:migrate:dev": "docker exec -it turnity-api-dev npx prisma migrate dev",
+    "docker:prisma:migrate:deploy": "docker exec -it turnity-api-dev npx prisma migrate deploy",
+    "docker:prisma:migrate:status": "docker exec -it turnity-api-dev npx prisma migrate status",
     "docker:generate:prisma:client": "docker exec -it turnity-api-dev npx prisma generate",
     "docker:db:prisma:seed": "docker exec -it turnity-api-dev npx prisma db seed",
     "docker:db:reset": "docker exec -it turnity-api-dev npx prisma migrate reset --force",

--- a/package.json
+++ b/package.json
@@ -85,8 +85,8 @@
     "@types/swagger-ui-express": "^4.1.8",
     "@types/uuid": "^10.0.0",
     "@types/yamljs": "^0.2.34",
-    "@typescript-eslint/eslint-plugin": "^6.15.0",
-    "@typescript-eslint/parser": "^6.15.0",
+    "@typescript-eslint/eslint-plugin": "^8.65.0",
+    "@typescript-eslint/parser": "^8.65.0",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^10.1.5",
     "jest": "^30.4.2",
@@ -99,5 +99,8 @@
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"
+  },
+  "overrides": {
+    "brace-expansion": "^5.0.8"
   }
 }

--- a/prisma/migrations/20260723120000_add_email_verification/migration.sql
+++ b/prisma/migrations/20260723120000_add_email_verification/migration.sql
@@ -1,0 +1,39 @@
+-- CreateEnum
+CREATE TYPE "VerificationTokenType" AS ENUM ('EMAIL_VERIFICATION', 'PASSWORD_RESET');
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "emailVerified" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "emailVerifiedAt" TIMESTAMP(3);
+
+-- Backfill (grandfathering): los usuarios ya existentes (previos a esta feature)
+-- se consideran verificados para no romper login/seed/smokes/colecciones Postman.
+-- Los usuarios nuevos entran con emailVerified=false (DEFAULT). Idempotente.
+-- En una DB fresca (CI) afecta 0 filas: el seed crea sus usuarios ya verificados.
+UPDATE "User" SET "emailVerified" = true, "emailVerifiedAt" = CURRENT_TIMESTAMP WHERE "emailVerified" = false;
+
+-- CreateTable
+CREATE TABLE "VerificationToken" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "type" "VerificationTokenType" NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "consumedAt" TIMESTAMP(3),
+    "ipAddress" TEXT,
+    "userAgent" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "VerificationToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "VerificationToken_tokenHash_key" ON "VerificationToken"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX "VerificationToken_userId_type_idx" ON "VerificationToken"("userId", "type");
+
+-- CreateIndex
+CREATE INDEX "VerificationToken_expiresAt_idx" ON "VerificationToken"("expiresAt");
+
+-- AddForeignKey
+ALTER TABLE "VerificationToken" ADD CONSTRAINT "VerificationToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,8 @@ model User {
   phone          String
   password       String
   isActive       Boolean        @default(true)
+  emailVerified   Boolean       @default(false)
+  emailVerifiedAt DateTime?
   profilePicture String?
   preferences    String?
   createdAt      DateTime       @default(now())
@@ -33,6 +35,7 @@ model User {
   notifications  Notification[]
   stylistServices StylistService[]
   refreshTokens  RefreshToken[]
+  verificationTokens VerificationToken[]
   role           Role           @relation(fields: [roleId], references: [id])
 }
 
@@ -55,6 +58,29 @@ model RefreshToken {
 
   @@index([userId])
   @@index([familyId])
+  @@index([expiresAt])
+}
+
+// Tokens de verificacion de email y reset de password (F-auth: registro publico
+// seguro). Mismo patron cripto que RefreshToken: valor opaco de alta entropia
+// entregado al usuario, persistido SOLO como hash SHA-256 (tokenHash). Un solo
+// uso (consumedAt) + expiracion (expiresAt). Tabla dedicada (ciclo de vida
+// distinto al de sesion: sin rotacion/familia). Al emitir uno nuevo del mismo
+// (userId, type) se invalidan los previos no consumidos.
+model VerificationToken {
+  id         String                @id @default(uuid())
+  userId     String
+  type       VerificationTokenType
+  tokenHash  String                @unique // SHA-256 del token opaco (nunca en claro)
+  expiresAt  DateTime
+  consumedAt DateTime?                      // marca single-use / invalidacion
+  ipAddress  String?                        // auditoria (RFC 6819)
+  userAgent  String?                        // auditoria (RFC 6819)
+  createdAt  DateTime              @default(now())
+
+  user       User                  @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, type])
   @@index([expiresAt])
 }
 
@@ -206,6 +232,11 @@ enum RoleName {
   ADMIN
   CLIENT
   STYLIST
+}
+
+enum VerificationTokenType {
+  EMAIL_VERIFICATION
+  PASSWORD_RESET
 }
 
 enum DayOfWeek {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -62,6 +62,8 @@ async function main() {
     data: {
       name: 'Admin Usuario',
       email: 'admin@turnity.com',
+      emailVerified: true,
+      emailVerifiedAt: new Date(),
       phone: '123456789',
       password: adminPassword,
       roleId: adminRole.id,
@@ -76,6 +78,8 @@ async function main() {
     data: {
       name: 'Maria Garcia',
       email: 'maria@example.com',
+      emailVerified: true,
+      emailVerifiedAt: new Date(),
       phone: '612345678',
       password: clientPassword,
       roleId: clientRole.id,
@@ -88,6 +92,8 @@ async function main() {
     data: {
       name: 'Juan Perez',
       email: 'juan@example.com',
+      emailVerified: true,
+      emailVerifiedAt: new Date(),
       phone: '623456789',
       password: clientPassword,
       roleId: clientRole.id,
@@ -102,6 +108,8 @@ async function main() {
     data: {
       name: 'Lucia Rodriguez',
       email: 'lucia@turnity.com',
+      emailVerified: true,
+      emailVerifiedAt: new Date(),
       phone: '634567890',
       password: stylistPassword,
       roleId: stylistRole.id,
@@ -113,6 +121,8 @@ async function main() {
     data: {
       name: 'Carlos Sanchez',
       email: 'carlos@turnity.com',
+      emailVerified: true,
+      emailVerifiedAt: new Date(),
       phone: '645678901',
       password: stylistPassword,
       roleId: stylistRole.id,

--- a/src/modules/auth/AuthContainer.ts
+++ b/src/modules/auth/AuthContainer.ts
@@ -29,6 +29,14 @@ import { PrismaRefreshTokenRepository } from './infrastructure/persistence/Prism
 import { CryptoRefreshTokenService } from './infrastructure/services/CryptoRefreshTokenService';
 import { IRefreshTokenRepository } from './domain/repositories/IRefreshTokenRepository';
 import { RefreshTokenService } from './application/services/RefreshTokenService';
+import { PrismaVerificationTokenRepository } from './infrastructure/persistence/PrismaVerificationTokenRepository';
+import { CryptoVerificationTokenService } from './infrastructure/services/CryptoVerificationTokenService';
+import { IVerificationTokenRepository } from './domain/repositories/IVerificationTokenRepository';
+import { VerificationTokenService } from './application/services/VerificationTokenService';
+import { NodemailerEmailService } from '../../shared/email/NodemailerEmailService';
+import { EmailService } from '../../shared/email/EmailService';
+import { VerifyEmail } from './application/use-cases/VerifyEmail';
+import { ResendVerification } from './application/use-cases/ResendVerification';
 
 /**
  * Contenedor de dependencias para el módulo de autenticación
@@ -97,6 +105,13 @@ export class AuthContainer {
     );
     const refreshTokenService: RefreshTokenService = new CryptoRefreshTokenService();
 
+    // Verificacion de email / reset de password
+    const verificationTokenRepository: IVerificationTokenRepository =
+      new PrismaVerificationTokenRepository(this.prisma);
+    const verificationTokenService: VerificationTokenService =
+      new CryptoVerificationTokenService(verificationTokenRepository);
+    const emailService: EmailService = new NodemailerEmailService();
+
     // Use Cases
     this._loginUser = new LoginUser(
       userRepository,
@@ -105,7 +120,13 @@ export class AuthContainer {
       refreshTokenRepository,
       refreshTokenService,
     );
-    this._registerUser = new RegisterUser(userRepository, roleRepository, hashService);
+    this._registerUser = new RegisterUser(
+      userRepository,
+      roleRepository,
+      hashService,
+      verificationTokenService,
+      emailService,
+    );
     this._refreshToken = new RefreshToken(
       userRepository,
       roleRepository,
@@ -126,6 +147,13 @@ export class AuthContainer {
     this._logoutUser = new LogoutUser(refreshTokenRepository, refreshTokenService);
     this._logoutAll = new LogoutAllSessions(refreshTokenRepository);
 
+    const verifyEmail = new VerifyEmail(userRepository, verificationTokenService);
+    const resendVerification = new ResendVerification(
+      userRepository,
+      verificationTokenService,
+      emailService,
+    );
+
     // HTTP Layer - Inyectamos los casos de uso directamente
     this._authController = new AuthController(
       this._loginUser,
@@ -137,6 +165,8 @@ export class AuthContainer {
       this._deactivateUser,
       this._logoutUser,
       this._logoutAll,
+      verifyEmail,
+      resendVerification,
     );
 
     this._authMiddleware = new AuthMiddleware(jwtService, roleRepository);

--- a/src/modules/auth/AuthContainer.ts
+++ b/src/modules/auth/AuthContainer.ts
@@ -37,6 +37,8 @@ import { NodemailerEmailService } from '../../shared/email/NodemailerEmailServic
 import { EmailService } from '../../shared/email/EmailService';
 import { VerifyEmail } from './application/use-cases/VerifyEmail';
 import { ResendVerification } from './application/use-cases/ResendVerification';
+import { ForgotPassword } from './application/use-cases/ForgotPassword';
+import { ResetPassword } from './application/use-cases/ResetPassword';
 
 /**
  * Contenedor de dependencias para el módulo de autenticación
@@ -154,6 +156,18 @@ export class AuthContainer {
       emailService,
     );
 
+    const forgotPassword = new ForgotPassword(
+      userRepository,
+      verificationTokenService,
+      emailService,
+    );
+    const resetPassword = new ResetPassword(
+      userRepository,
+      verificationTokenService,
+      hashService,
+      refreshTokenRepository,
+    );
+
     // HTTP Layer - Inyectamos los casos de uso directamente
     this._authController = new AuthController(
       this._loginUser,
@@ -167,6 +181,8 @@ export class AuthContainer {
       this._logoutAll,
       verifyEmail,
       resendVerification,
+      forgotPassword,
+      resetPassword,
     );
 
     this._authMiddleware = new AuthMiddleware(jwtService, roleRepository);

--- a/src/modules/auth/application/dto/request/ForgotPasswordDto.ts
+++ b/src/modules/auth/application/dto/request/ForgotPasswordDto.ts
@@ -1,0 +1,6 @@
+/**
+ * DTO para solicitar el reset de password: solo el email de la cuenta.
+ */
+export interface ForgotPasswordDto {
+  email: string;
+}

--- a/src/modules/auth/application/dto/request/ResendVerificationDto.ts
+++ b/src/modules/auth/application/dto/request/ResendVerificationDto.ts
@@ -1,0 +1,6 @@
+/**
+ * DTO para reenviar el email de verificacion: solo el email del destinatario.
+ */
+export interface ResendVerificationDto {
+  email: string;
+}

--- a/src/modules/auth/application/dto/request/ResetPasswordDto.ts
+++ b/src/modules/auth/application/dto/request/ResetPasswordDto.ts
@@ -1,0 +1,7 @@
+/**
+ * DTO para aplicar el reset: el token opaco del enlace + la nueva password.
+ */
+export interface ResetPasswordDto {
+  token: string;
+  password: string;
+}

--- a/src/modules/auth/application/dto/request/VerifyEmailDto.ts
+++ b/src/modules/auth/application/dto/request/VerifyEmailDto.ts
@@ -1,0 +1,6 @@
+/**
+ * DTO para verificar el email: el token opaco recibido por el enlace del email.
+ */
+export interface VerifyEmailDto {
+  token: string;
+}

--- a/src/modules/auth/application/services/AuthService.ts
+++ b/src/modules/auth/application/services/AuthService.ts
@@ -26,7 +26,10 @@ export class AuthService {
   }
 
   async registerService(registerDto: RegisterDto): Promise<UserDto> {
-    return this.registerUser.execute(registerDto);
+    // RegisterUser ahora devuelve { user, verificationToken? }; este servicio
+    // (legacy) expone solo el UserDto para no cambiar su contrato.
+    const result = await this.registerUser.execute(registerDto);
+    return result.user;
   }
 
   async refreshTokenService(refreshToken: string): Promise<LoginResponseDto> {

--- a/src/modules/auth/application/services/VerificationTokenService.ts
+++ b/src/modules/auth/application/services/VerificationTokenService.ts
@@ -1,0 +1,45 @@
+import { VerificationTokenType } from '@prisma/client';
+
+/**
+ * Resultado de emitir un token: el valor opaco en claro (para enviar por email,
+ * nunca se persiste) y su expiracion.
+ */
+export interface IssuedVerificationToken {
+  /** Token opaco en claro, para el enlace del email */
+  token: string;
+  /** Momento de expiracion calculado segun el TTL del tipo */
+  expiresAt: Date;
+}
+
+/** Metadata opcional de auditoria al emitir un token */
+export interface IssueTokenMeta {
+  ipAddress?: string | null;
+  userAgent?: string | null;
+}
+
+/**
+ * Puerto para la emision y verificacion de tokens de un solo uso (verificacion
+ * de email / reset de password). Encapsula el patron opaco + hash + expiracion
+ * + single-use, reutilizado por los use-cases (verify, resend, forgot, reset)
+ * para no duplicar esa logica en cada uno.
+ */
+export interface VerificationTokenService {
+  /**
+   * Emite un token nuevo del tipo dado para el usuario. Invalida primero los
+   * previos activos del mismo (userId, type), dejando un unico token vigente.
+   * @returns El token opaco en claro + su expiracion
+   */
+  issue(
+    userId: string,
+    type: VerificationTokenType,
+    meta?: IssueTokenMeta,
+  ): Promise<IssuedVerificationToken>;
+
+  /**
+   * Valida un token en claro contra su tipo: existencia, tipo correcto, no
+   * consumido y no expirado. Si es valido lo consume (single-use) y devuelve el
+   * `userId`. Si no, lanza `InvalidTokenError`.
+   * @returns userId dueño del token
+   */
+  verifyAndConsume(rawToken: string, type: VerificationTokenType): Promise<string>;
+}

--- a/src/modules/auth/application/use-cases/ForgotPassword.ts
+++ b/src/modules/auth/application/use-cases/ForgotPassword.ts
@@ -1,0 +1,65 @@
+import { VerificationTokenType } from '@prisma/client';
+import { IUserRepository } from '../../domain/repositories/IUserRepository';
+import { VerificationTokenService } from '../services/VerificationTokenService';
+import { EmailService } from '../../../../shared/email/EmailService';
+import { env } from '../../../../shared/config/env';
+import { logger } from '../../../../shared/logger/logger';
+
+/**
+ * Resultado del forgot-password: en no-produccion con EXPOSE_VERIFICATION_TOKENS
+ * puede traer el token en claro (solo cuando realmente se emitio uno).
+ */
+export interface ForgotPasswordResult {
+  resetToken?: string;
+}
+
+/**
+ * Caso de uso: solicitar el reset de password.
+ *
+ * Anti-enumeracion: la respuesta es SIEMPRE la misma, exista o no el email. Solo
+ * se emite/envia un token cuando el usuario existe y esta activo; en cualquier
+ * otro caso no se hace nada y se devuelve un resultado vacio.
+ */
+export class ForgotPassword {
+  constructor(
+    private userRepository: IUserRepository,
+    private verificationTokenService: VerificationTokenService,
+    private emailService: EmailService,
+  ) {}
+
+  /**
+   * @param email - Email para el que se solicita el reset
+   * @returns resultado (con token solo si se emitio y el entorno lo permite)
+   */
+  async execute(email: string): Promise<ForgotPasswordResult> {
+    const user = await this.userRepository.findByEmailWithRole(email);
+
+    // No filtrar existencia ni estado: mismo resultado si no existe o esta inactivo.
+    if (!user || !user.isActive) {
+      return {};
+    }
+
+    try {
+      const { token } = await this.verificationTokenService.issue(
+        user.id,
+        VerificationTokenType.PASSWORD_RESET,
+      );
+      const resetUrl = `${env.FRONTEND_URL}/reset-password?token=${encodeURIComponent(token)}`;
+      await this.emailService.sendPasswordResetEmail({
+        to: user.email,
+        name: user.name,
+        resetUrl,
+        expiresInMinutes: env.PASSWORD_RESET_TOKEN_TTL_MINUTES,
+      });
+      return { resetToken: token };
+    } catch (error) {
+      // best-effort: no propagamos el fallo para no filtrar informacion ni romper
+      // la respuesta uniforme; queda registrado para diagnostico.
+      logger.error('[auth] fallo al emitir/enviar el reset de password', {
+        userId: user.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return {};
+    }
+  }
+}

--- a/src/modules/auth/application/use-cases/LoginUser.ts
+++ b/src/modules/auth/application/use-cases/LoginUser.ts
@@ -10,6 +10,8 @@ import { isValidEmail } from '../../../../shared/utils/validation';
 import { generateUuid } from '../../../../shared/utils/uuid';
 import { ValidationError } from '../../../../shared/exceptions/ValidationError';
 import { UnauthorizedError } from '../../../../shared/exceptions/UnauthorizedError';
+import { EmailNotVerifiedError } from '../../../../shared/exceptions/EmailNotVerifiedError';
+import { env } from '../../../../shared/config/env';
 
 /**
  * Contexto opcional de la request para auditar la sesión (RFC 6819).
@@ -70,6 +72,13 @@ export class LoginUser {
     const role = userWithRole.role;
     if (!role) {
       throw new UnauthorizedError('Invalid credentials');
+    }
+
+    // Gating de verificacion de email (F-auth). Se chequea DESPUES de validar las
+    // credenciales para no filtrar el estado de verificacion a quien no conoce la
+    // password. Gateado por REQUIRE_EMAIL_VERIFICATION (default true).
+    if (env.REQUIRE_EMAIL_VERIFICATION && !userWithRole.emailVerified) {
+      throw new EmailNotVerifiedError();
     }
 
     // Generar tokens

--- a/src/modules/auth/application/use-cases/RegisterUser.ts
+++ b/src/modules/auth/application/use-cases/RegisterUser.ts
@@ -1,4 +1,4 @@
-import { RoleName } from '@prisma/client';
+import { RoleName, VerificationTokenType } from '@prisma/client';
 import { ConflictError } from '../../../../shared/exceptions/ConflictError';
 import { NotFoundError } from '../../../../shared/exceptions/NotFoundError';
 import { ValidationError } from '../../../../shared/exceptions/ValidationError';
@@ -10,6 +10,20 @@ import { IUserRepository } from '../../domain/repositories/IUserRepository';
 import { RegisterDto } from '../dto/request/RegisterDto';
 import { UserDto } from '../dto/response/UserDto';
 import { HashService } from '../services/HashService';
+import { VerificationTokenService } from '../services/VerificationTokenService';
+import { EmailService } from '../../../../shared/email/EmailService';
+import { env } from '../../../../shared/config/env';
+import { logger } from '../../../../shared/logger/logger';
+
+/**
+ * Resultado del registro: el usuario creado y, solo en no-produccion con el flag
+ * EXPOSE_VERIFICATION_TOKENS, el token de verificacion en claro (para pruebas por
+ * API/Postman mientras no hay frontend). El controller decide si exponerlo.
+ */
+export interface RegisterResult {
+  user: UserDto;
+  verificationToken?: string;
+}
 
 /**
  * Caso de uso para registrar nuevos usuarios en el sistema
@@ -20,6 +34,8 @@ export class RegisterUser {
     private userRepository: IUserRepository,
     private roleRepository: IRoleRepository,
     private hashService: HashService,
+    private verificationTokenService: VerificationTokenService,
+    private emailService: EmailService,
   ) {}
 
   /**
@@ -31,7 +47,7 @@ export class RegisterUser {
    * @throws NotFoundError si el rol especificado no existe
    * @description Valida datos, verifica unicidad del email, hashea contraseña y crea usuario con rol asignado
    */
-  async execute(registerDto: RegisterDto): Promise<UserDto> {
+  async execute(registerDto: RegisterDto): Promise<RegisterResult> {
     // Validaciones
     this.validateRegisterDto(registerDto);
 
@@ -62,7 +78,40 @@ export class RegisterUser {
     // Guardar usuario
     const savedUser = await this.userRepository.save(user);
 
-    return this.mapUserToDto(savedUser, role);
+    // Verificacion de email: emitir token + enviar (best-effort). El registro NO
+    // falla si esto falla; el usuario siempre puede pedir el reenvio.
+    const verificationToken = await this.issueAndSendVerification(savedUser);
+
+    return { user: this.mapUserToDto(savedUser, role), verificationToken };
+  }
+
+  /**
+   * Emite el token de verificacion de email y envia el correo (best-effort)
+   * @param user - Usuario recien creado
+   * @returns el token en claro si se emitio, o undefined si algo fallo
+   * @private
+   */
+  private async issueAndSendVerification(user: User): Promise<string | undefined> {
+    try {
+      const { token } = await this.verificationTokenService.issue(
+        user.id,
+        VerificationTokenType.EMAIL_VERIFICATION,
+      );
+      const verificationUrl = `${env.FRONTEND_URL}/verify-email?token=${encodeURIComponent(token)}`;
+      await this.emailService.sendVerificationEmail({
+        to: user.email,
+        name: user.name,
+        verificationUrl,
+        expiresInHours: env.EMAIL_VERIFICATION_TOKEN_TTL_HOURS,
+      });
+      return token;
+    } catch (error) {
+      logger.error('[auth] fallo al emitir/enviar la verificacion de email en el registro', {
+        userId: user.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return undefined;
+    }
   }
 
   /**

--- a/src/modules/auth/application/use-cases/ResendVerification.ts
+++ b/src/modules/auth/application/use-cases/ResendVerification.ts
@@ -1,0 +1,67 @@
+import { VerificationTokenType } from '@prisma/client';
+import { IUserRepository } from '../../domain/repositories/IUserRepository';
+import { VerificationTokenService } from '../services/VerificationTokenService';
+import { EmailService } from '../../../../shared/email/EmailService';
+import { env } from '../../../../shared/config/env';
+import { logger } from '../../../../shared/logger/logger';
+
+/**
+ * Resultado del reenvio: en no-produccion con EXPOSE_VERIFICATION_TOKENS puede
+ * traer el token en claro (solo cuando realmente se emitio uno). El controller
+ * decide si exponerlo.
+ */
+export interface ResendVerificationResult {
+  verificationToken?: string;
+}
+
+/**
+ * Caso de uso: reenviar el email de verificacion.
+ *
+ * Anti-enumeracion (F-auth 2.6): la respuesta es SIEMPRE la misma, exista o no
+ * el email y este verificado o no. Solo se emite/envia un token nuevo cuando el
+ * usuario existe y aun no esta verificado; en cualquier otro caso no se hace
+ * nada y se devuelve un resultado vacio.
+ */
+export class ResendVerification {
+  constructor(
+    private userRepository: IUserRepository,
+    private verificationTokenService: VerificationTokenService,
+    private emailService: EmailService,
+  ) {}
+
+  /**
+   * @param email - Email para el que se pide el reenvio
+   * @returns resultado (con token solo si se emitio y el entorno lo permite)
+   */
+  async execute(email: string): Promise<ResendVerificationResult> {
+    const user = await this.userRepository.findByEmailWithRole(email);
+
+    // No filtrar existencia ni estado: mismo resultado si no existe o ya verificado.
+    if (!user || user.emailVerified) {
+      return {};
+    }
+
+    try {
+      const { token } = await this.verificationTokenService.issue(
+        user.id,
+        VerificationTokenType.EMAIL_VERIFICATION,
+      );
+      const verificationUrl = `${env.FRONTEND_URL}/verify-email?token=${encodeURIComponent(token)}`;
+      await this.emailService.sendVerificationEmail({
+        to: user.email,
+        name: user.name,
+        verificationUrl,
+        expiresInHours: env.EMAIL_VERIFICATION_TOKEN_TTL_HOURS,
+      });
+      return { verificationToken: token };
+    } catch (error) {
+      // best-effort: no propagamos el fallo para no filtrar informacion ni romper
+      // la respuesta uniforme; queda registrado para diagnostico.
+      logger.error('[auth] fallo al reenviar la verificacion de email', {
+        userId: user.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return {};
+    }
+  }
+}

--- a/src/modules/auth/application/use-cases/ResetPassword.ts
+++ b/src/modules/auth/application/use-cases/ResetPassword.ts
@@ -1,0 +1,57 @@
+import { VerificationTokenType } from '@prisma/client';
+import { IUserRepository } from '../../domain/repositories/IUserRepository';
+import { IRefreshTokenRepository } from '../../domain/repositories/IRefreshTokenRepository';
+import { VerificationTokenService } from '../services/VerificationTokenService';
+import { HashService } from '../services/HashService';
+import { isValidPassword } from '../../../../shared/utils/validation';
+import { ValidationError } from '../../../../shared/exceptions/ValidationError';
+import { NotFoundError } from '../../../../shared/exceptions/NotFoundError';
+import { ResetPasswordDto } from '../dto/request/ResetPasswordDto';
+
+/**
+ * Caso de uso: aplicar el reset de password a partir del token del enlace.
+ *
+ * Valida la fuerza de la nueva password ANTES de consumir el token (para no
+ * gastarlo con una password invalida), luego consume el token single-use,
+ * actualiza el hash y revoca TODAS las sesiones del usuario (expulsa a un posible
+ * atacante con sesion activa).
+ */
+export class ResetPassword {
+  constructor(
+    private userRepository: IUserRepository,
+    private verificationTokenService: VerificationTokenService,
+    private hashService: HashService,
+    private refreshTokenRepository: IRefreshTokenRepository,
+  ) {}
+
+  /**
+   * @param dto - Token del enlace + nueva password
+   * @throws ValidationError si la password no cumple las reglas de fuerza
+   * @throws InvalidTokenError si el token es invalido, de otro tipo, expirado o ya usado
+   * @throws NotFoundError si el usuario del token ya no existe
+   */
+  async execute(dto: ResetPasswordDto): Promise<void> {
+    if (!isValidPassword(dto.password)) {
+      throw new ValidationError(
+        'Password must be at least 8 characters long and contain uppercase, lowercase, and number',
+      );
+    }
+
+    const userId = await this.verificationTokenService.verifyAndConsume(
+      dto.token,
+      VerificationTokenType.PASSWORD_RESET,
+    );
+
+    const user = await this.userRepository.findById(userId);
+    if (!user) {
+      throw new NotFoundError('User', userId);
+    }
+
+    const hashedPassword = await this.hashService.hash(dto.password);
+    user.updatePassword(hashedPassword);
+    await this.userRepository.update(user);
+
+    // Seguridad: invalidar todas las sesiones activas tras cambiar la password.
+    await this.refreshTokenRepository.revokeAllForUser(userId);
+  }
+}

--- a/src/modules/auth/application/use-cases/VerifyEmail.ts
+++ b/src/modules/auth/application/use-cases/VerifyEmail.ts
@@ -1,0 +1,30 @@
+import { VerificationTokenType } from '@prisma/client';
+import { IUserRepository } from '../../domain/repositories/IUserRepository';
+import { VerificationTokenService } from '../services/VerificationTokenService';
+
+/**
+ * Caso de uso: verificar el email de un usuario a partir del token del enlace.
+ *
+ * Delega en VerificationTokenService la validacion + consumo single-use (que
+ * lanza InvalidTokenError si el token es invalido/expirado/ya usado) y luego
+ * marca el email como verificado. La marca es idempotente: si el usuario ya
+ * estaba verificado, volver a marcarlo no tiene efecto adverso.
+ */
+export class VerifyEmail {
+  constructor(
+    private userRepository: IUserRepository,
+    private verificationTokenService: VerificationTokenService,
+  ) {}
+
+  /**
+   * @param token - Token opaco recibido por el enlace de verificacion
+   * @throws InvalidTokenError si el token es invalido, de otro tipo, expirado o ya usado
+   */
+  async execute(token: string): Promise<void> {
+    const userId = await this.verificationTokenService.verifyAndConsume(
+      token,
+      VerificationTokenType.EMAIL_VERIFICATION,
+    );
+    await this.userRepository.markEmailAsVerified(userId);
+  }
+}

--- a/src/modules/auth/domain/entities/VerificationToken.ts
+++ b/src/modules/auth/domain/entities/VerificationToken.ts
@@ -1,0 +1,57 @@
+import { VerificationTokenType } from '@prisma/client';
+
+/**
+ * Entidad de dominio de un token de verificacion de email o reset de password.
+ *
+ * El token en si es opaco y NUNCA se guarda en claro: esta entidad solo tiene
+ * su hash (`tokenHash`). Es de un solo uso (`consumedAt`) y con expiracion
+ * (`expiresAt`). El ciclo de vida es distinto al del refresh de sesion (sin
+ * rotacion ni familias), por eso vive en su propia tabla.
+ */
+export class VerificationToken {
+  /**
+   * @param id - Identificador del token
+   * @param userId - Usuario dueño del token
+   * @param type - Tipo (EMAIL_VERIFICATION | PASSWORD_RESET)
+   * @param tokenHash - SHA-256 del token opaco (nunca el valor en claro)
+   * @param expiresAt - Momento de expiracion
+   * @param consumedAt - Momento en que se consumio/invalido, o null si sigue activo
+   * @param ipAddress - IP del cliente al emitir (auditoria), o null
+   * @param userAgent - User-Agent del cliente al emitir (auditoria), o null
+   * @param createdAt - Momento de emision
+   */
+  constructor(
+    public readonly id: string,
+    public readonly userId: string,
+    public readonly type: VerificationTokenType,
+    public readonly tokenHash: string,
+    public readonly expiresAt: Date,
+    public readonly consumedAt: Date | null,
+    public readonly ipAddress: string | null,
+    public readonly userAgent: string | null,
+    public readonly createdAt: Date,
+  ) {}
+
+  /**
+   * Indica si el token ya expiro
+   * @param now - Momento de referencia (default: ahora)
+   */
+  isExpired(now: Date = new Date()): boolean {
+    return this.expiresAt.getTime() <= now.getTime();
+  }
+
+  /**
+   * Indica si el token ya fue consumido o invalidado
+   */
+  isConsumed(): boolean {
+    return this.consumedAt !== null;
+  }
+
+  /**
+   * Indica si el token es utilizable: ni consumido ni expirado
+   * @param now - Momento de referencia (default: ahora)
+   */
+  isUsable(now: Date = new Date()): boolean {
+    return !this.isConsumed() && !this.isExpired(now);
+  }
+}

--- a/src/modules/auth/domain/repositories/IUserRepository.ts
+++ b/src/modules/auth/domain/repositories/IUserRepository.ts
@@ -18,6 +18,11 @@ export interface IUserRepository {
   findByEmail(email: string): Promise<User | null>;
   findByEmailWithRole(email: string): Promise<UserWithRole | null>;
   existsByEmail(email: string): Promise<boolean>;
+  /**
+   * Marca el email del usuario como verificado (idempotente).
+   * Setea emailVerified=true y emailVerifiedAt=now.
+   */
+  markEmailAsVerified(userId: string): Promise<void>;
   save(user: User): Promise<User>;
   update(user: User): Promise<User>;
   delete(id: string): Promise<void>;

--- a/src/modules/auth/domain/repositories/IVerificationTokenRepository.ts
+++ b/src/modules/auth/domain/repositories/IVerificationTokenRepository.ts
@@ -1,0 +1,57 @@
+import { VerificationTokenType } from '@prisma/client';
+import { VerificationToken } from '../entities/VerificationToken';
+
+/**
+ * Datos para persistir un nuevo token de verificacion/reset.
+ * `id` es opcional: si no se provee, la base genera el uuid por default.
+ * El token ya viene hasheado en `tokenHash` (nunca en claro).
+ */
+export interface CreateVerificationTokenData {
+  id?: string;
+  userId: string;
+  type: VerificationTokenType;
+  tokenHash: string;
+  expiresAt: Date;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+}
+
+/**
+ * Contrato de persistencia para tokens de verificacion/reset.
+ * Abstrae el almacenamiento sin exponer detalles de Prisma/DB.
+ */
+export interface IVerificationTokenRepository {
+  /**
+   * Crea un nuevo token (ya hasheado)
+   */
+  create(data: CreateVerificationTokenData): Promise<VerificationToken>;
+
+  /**
+   * Busca un token por el hash de su valor opaco
+   * @param tokenHash - SHA-256 del token recibido
+   * @returns El token o null si no existe
+   */
+  findByTokenHash(tokenHash: string): Promise<VerificationToken | null>;
+
+  /**
+   * Marca un token como consumido (single-use). Idempotente y condicional:
+   * solo afecta si aun no estaba consumido.
+   * @param id - ID del token
+   */
+  consume(id: string): Promise<void>;
+
+  /**
+   * Invalida (marca como consumidos) todos los tokens aun activos de un usuario
+   * para un tipo dado. Se usa al emitir uno nuevo, para dejar un unico token
+   * vigente por (userId, type).
+   * @returns Cantidad de tokens invalidados
+   */
+  invalidateActiveByUser(userId: string, type: VerificationTokenType): Promise<number>;
+
+  /**
+   * Elimina tokens ya expirados (barrido de mantenimiento)
+   * @param now - Momento de referencia
+   * @returns Cantidad de tokens eliminados
+   */
+  deleteExpired(now: Date): Promise<number>;
+}

--- a/src/modules/auth/infrastructure/persistence/PrismaUserRepository.ts
+++ b/src/modules/auth/infrastructure/persistence/PrismaUserRepository.ts
@@ -115,6 +115,18 @@ export class PrismaUserRepository implements IUserRepository {
   }
 
   /**
+   * Marca el email de un usuario como verificado (idempotente)
+   * @param userId - ID del usuario
+   * @description Setea emailVerified=true y emailVerifiedAt=now
+   */
+  async markEmailAsVerified(userId: string): Promise<void> {
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: { emailVerified: true, emailVerifiedAt: new Date() },
+    });
+  }
+
+  /**
    * Guarda un nuevo usuario en la base de datos
    * @param user - Entidad User a persistir
    * @returns Promise con el usuario guardado

--- a/src/modules/auth/infrastructure/persistence/PrismaVerificationTokenRepository.ts
+++ b/src/modules/auth/infrastructure/persistence/PrismaVerificationTokenRepository.ts
@@ -1,0 +1,111 @@
+import {
+  PrismaClient,
+  VerificationTokenType,
+  VerificationToken as PrismaVerificationToken,
+} from '@prisma/client';
+import { VerificationToken } from '../../domain/entities/VerificationToken';
+import {
+  IVerificationTokenRepository,
+  CreateVerificationTokenData,
+} from '../../domain/repositories/IVerificationTokenRepository';
+
+/**
+ * Implementacion de IVerificationTokenRepository con Prisma.
+ */
+export class PrismaVerificationTokenRepository implements IVerificationTokenRepository {
+  /**
+   * @param prisma - Cliente Prisma inyectado
+   */
+  constructor(private prisma: PrismaClient) {}
+
+  /**
+   * Crea un nuevo token (ya hasheado)
+   */
+  async create(data: CreateVerificationTokenData): Promise<VerificationToken> {
+    const row = await this.prisma.verificationToken.create({
+      data: this.toCreateData(data),
+    });
+    return this.toDomain(row);
+  }
+
+  /**
+   * Busca un token por el hash de su valor opaco
+   */
+  async findByTokenHash(tokenHash: string): Promise<VerificationToken | null> {
+    const row = await this.prisma.verificationToken.findUnique({
+      where: { tokenHash },
+    });
+    return row ? this.toDomain(row) : null;
+  }
+
+  /**
+   * Marca un token como consumido. Condicional (solo si aun no lo estaba) para
+   * ser idempotente y evitar sobrescribir el consumedAt original.
+   */
+  async consume(id: string): Promise<void> {
+    await this.prisma.verificationToken.updateMany({
+      where: { id, consumedAt: null },
+      data: { consumedAt: new Date() },
+    });
+  }
+
+  /**
+   * Invalida todos los tokens aun activos de un usuario para un tipo dado
+   * @returns Cantidad de tokens invalidados
+   */
+  async invalidateActiveByUser(
+    userId: string,
+    type: VerificationTokenType,
+  ): Promise<number> {
+    const result = await this.prisma.verificationToken.updateMany({
+      where: { userId, type, consumedAt: null },
+      data: { consumedAt: new Date() },
+    });
+    return result.count;
+  }
+
+  /**
+   * Elimina tokens ya expirados
+   * @returns Cantidad de tokens eliminados
+   */
+  async deleteExpired(now: Date): Promise<number> {
+    const result = await this.prisma.verificationToken.deleteMany({
+      where: { expiresAt: { lt: now } },
+    });
+    return result.count;
+  }
+
+  /**
+   * Arma el objeto `data` para Prisma a partir del DTO de creacion
+   * @private
+   */
+  private toCreateData(data: CreateVerificationTokenData) {
+    return {
+      ...(data.id ? { id: data.id } : {}),
+      userId: data.userId,
+      type: data.type,
+      tokenHash: data.tokenHash,
+      expiresAt: data.expiresAt,
+      ipAddress: data.ipAddress ?? null,
+      userAgent: data.userAgent ?? null,
+    };
+  }
+
+  /**
+   * Mapea un registro Prisma a la entidad de dominio
+   * @private
+   */
+  private toDomain(row: PrismaVerificationToken): VerificationToken {
+    return new VerificationToken(
+      row.id,
+      row.userId,
+      row.type,
+      row.tokenHash,
+      row.expiresAt,
+      row.consumedAt,
+      row.ipAddress,
+      row.userAgent,
+      row.createdAt,
+    );
+  }
+}

--- a/src/modules/auth/infrastructure/services/CryptoVerificationTokenService.ts
+++ b/src/modules/auth/infrastructure/services/CryptoVerificationTokenService.ts
@@ -1,0 +1,80 @@
+import { VerificationTokenType } from '@prisma/client';
+import {
+  VerificationTokenService,
+  IssuedVerificationToken,
+  IssueTokenMeta,
+} from '../../application/services/VerificationTokenService';
+import { IVerificationTokenRepository } from '../../domain/repositories/IVerificationTokenRepository';
+import { generateOpaqueToken, hashToken } from '../../../../shared/crypto/opaqueToken';
+import { InvalidTokenError } from '../../../../shared/exceptions/InvalidTokenError';
+import { env } from '../../../../shared/config/env';
+
+/**
+ * Implementacion de VerificationTokenService.
+ *
+ * Reutiliza el helper cripto compartido (`opaqueToken`) para generar/hashear,
+ * sin tocar el `CryptoRefreshTokenService` de sesion. Orquesta la persistencia
+ * a traves del repositorio inyectado.
+ */
+export class CryptoVerificationTokenService implements VerificationTokenService {
+  /**
+   * @param repository - Repositorio de tokens de verificacion inyectado
+   */
+  constructor(private readonly repository: IVerificationTokenRepository) {}
+
+  /**
+   * Emite un token nuevo, invalidando los previos activos del mismo tipo.
+   * Solo se persiste el hash; el valor en claro se devuelve al caller.
+   */
+  async issue(
+    userId: string,
+    type: VerificationTokenType,
+    meta?: IssueTokenMeta,
+  ): Promise<IssuedVerificationToken> {
+    // Un unico token vigente por (userId, type): invalidamos los anteriores.
+    await this.repository.invalidateActiveByUser(userId, type);
+
+    const token = generateOpaqueToken();
+    const tokenHash = hashToken(token);
+    const expiresAt = this.computeExpiry(type);
+
+    await this.repository.create({
+      userId,
+      type,
+      tokenHash,
+      expiresAt,
+      ipAddress: meta?.ipAddress ?? null,
+      userAgent: meta?.userAgent ?? null,
+    });
+
+    return { token, expiresAt };
+  }
+
+  /**
+   * Valida y consume un token. Lanza InvalidTokenError si no existe, es de otro
+   * tipo, ya fue consumido o expiro (sin distinguir el motivo, a proposito).
+   */
+  async verifyAndConsume(rawToken: string, type: VerificationTokenType): Promise<string> {
+    const tokenHash = hashToken(rawToken);
+    const record = await this.repository.findByTokenHash(tokenHash);
+
+    if (!record || record.type !== type || !record.isUsable()) {
+      throw new InvalidTokenError();
+    }
+
+    await this.repository.consume(record.id);
+    return record.userId;
+  }
+
+  /**
+   * Calcula la expiracion segun el tipo, a partir de los TTL configurados en env.
+   * @private
+   */
+  private computeExpiry(type: VerificationTokenType): Date {
+    const now = Date.now();
+    if (type === 'PASSWORD_RESET') {
+      return new Date(now + env.PASSWORD_RESET_TOKEN_TTL_MINUTES * 60 * 1000);
+    }
+    return new Date(now + env.EMAIL_VERIFICATION_TOKEN_TTL_HOURS * 60 * 60 * 1000);
+  }
+}

--- a/src/modules/auth/infrastructure/services/JwtTokenService.ts
+++ b/src/modules/auth/infrastructure/services/JwtTokenService.ts
@@ -76,7 +76,7 @@ export class JwtTokenService implements JwtService {
         issuer: 'turnity-api',
         audience: 'turnity-app',
       }) as JwtPayload;
-    } catch (error) {
+    } catch {
       throw new UnauthorizedError('Invalid access token');
     }
   }
@@ -94,7 +94,7 @@ export class JwtTokenService implements JwtService {
         issuer: 'turnity-api',
         audience: 'turnity-app',
       }) as JwtPayload;
-    } catch (error) {
+    } catch {
       throw new UnauthorizedError('Invalid refresh token');
     }
   }

--- a/src/modules/auth/presentation/controllers/AuthController.ts
+++ b/src/modules/auth/presentation/controllers/AuthController.ts
@@ -9,6 +9,8 @@ import { ChangeUserPassword } from '../../application/use-cases/ChangeUserPasswo
 import { DeactivateUser } from '../../application/use-cases/DeactivateUser';
 import { LogoutUser } from '../../application/use-cases/LogoutUser';
 import { LogoutAllSessions } from '../../application/use-cases/LogoutAllSessions';
+import { VerifyEmail } from '../../application/use-cases/VerifyEmail';
+import { ResendVerification } from '../../application/use-cases/ResendVerification';
 import { AuthenticatedRequest } from '../middleware/AuthMiddleware';
 import { generateCsrfToken } from '../middleware/CsrfMiddleware';
 import {
@@ -23,7 +25,10 @@ import { RegisterDto } from '../../application/dto/request/RegisterDto';
 import { LoginDto } from '../../application/dto/request/LoginDto';
 import { UpdateProfileDto } from '../../application/dto/request/UpdateProfileDto';
 import { ChangePasswordDto } from '../../application/dto/request/ChangePasswordDto';
+import { VerifyEmailDto } from '../../application/dto/request/VerifyEmailDto';
+import { ResendVerificationDto } from '../../application/dto/request/ResendVerificationDto';
 import { UnauthorizedError } from '../../../../shared/exceptions/UnauthorizedError';
+import { devTokenField } from '../../../../shared/utils/devToken';
 
 /**
  * Controlador de autenticación que maneja peticiones HTTP
@@ -42,6 +47,8 @@ export class AuthController {
     private deactivateUserUseCase: DeactivateUser,
     private logoutUseCase: LogoutUser,
     private logoutAllUseCase: LogoutAllSessions,
+    private verifyEmailUseCase: VerifyEmail,
+    private resendVerificationUseCase: ResendVerification,
   ) {}
 
   /**
@@ -89,8 +96,49 @@ export class AuthController {
 
     return res.status(201).json({
       success: true,
-      data: result,
+      data: result.user,
       message: 'User registered successfully',
+      // devToken solo en no-produccion con EXPOSE_VERIFICATION_TOKENS (pruebas por API)
+      ...devTokenField(result.verificationToken),
+    });
+  }
+
+  /**
+   * Verifica el email de un usuario a partir del token del enlace
+   * @route POST /auth/verify-email
+   * @param req - Request con { token } en el body
+   * @param res - Response de Express
+   * @returns Promise<Response>
+   * @responseStatus 200 - Email verificado exitosamente
+   * @throws InvalidTokenError si el token es invalido, de otro tipo, expirado o ya usado
+   */
+  async verifyEmail(req: Request, res: Response): Promise<Response> {
+    const { token }: VerifyEmailDto = req.body;
+    await this.verifyEmailUseCase.execute(token);
+
+    return res.status(200).json({
+      success: true,
+      message: 'Email verified successfully',
+    });
+  }
+
+  /**
+   * Reenvia el email de verificacion. Respuesta uniforme (anti-enumeracion):
+   * identica exista o no el email y este verificado o no.
+   * @route POST /auth/resend-verification
+   * @param req - Request con { email } en el body
+   * @param res - Response de Express
+   * @returns Promise<Response>
+   * @responseStatus 200 - Respuesta generica
+   */
+  async resendVerification(req: Request, res: Response): Promise<Response> {
+    const { email }: ResendVerificationDto = req.body;
+    const result = await this.resendVerificationUseCase.execute(email);
+
+    return res.status(200).json({
+      success: true,
+      message: 'If an account exists for that email, a verification link has been sent',
+      ...devTokenField(result.verificationToken),
     });
   }
 

--- a/src/modules/auth/presentation/controllers/AuthController.ts
+++ b/src/modules/auth/presentation/controllers/AuthController.ts
@@ -11,6 +11,8 @@ import { LogoutUser } from '../../application/use-cases/LogoutUser';
 import { LogoutAllSessions } from '../../application/use-cases/LogoutAllSessions';
 import { VerifyEmail } from '../../application/use-cases/VerifyEmail';
 import { ResendVerification } from '../../application/use-cases/ResendVerification';
+import { ForgotPassword } from '../../application/use-cases/ForgotPassword';
+import { ResetPassword } from '../../application/use-cases/ResetPassword';
 import { AuthenticatedRequest } from '../middleware/AuthMiddleware';
 import { generateCsrfToken } from '../middleware/CsrfMiddleware';
 import {
@@ -27,6 +29,8 @@ import { UpdateProfileDto } from '../../application/dto/request/UpdateProfileDto
 import { ChangePasswordDto } from '../../application/dto/request/ChangePasswordDto';
 import { VerifyEmailDto } from '../../application/dto/request/VerifyEmailDto';
 import { ResendVerificationDto } from '../../application/dto/request/ResendVerificationDto';
+import { ForgotPasswordDto } from '../../application/dto/request/ForgotPasswordDto';
+import { ResetPasswordDto } from '../../application/dto/request/ResetPasswordDto';
 import { UnauthorizedError } from '../../../../shared/exceptions/UnauthorizedError';
 import { devTokenField } from '../../../../shared/utils/devToken';
 
@@ -34,7 +38,8 @@ import { devTokenField } from '../../../../shared/utils/devToken';
  * Controlador de autenticación que maneja peticiones HTTP
  * relacionadas con usuarios. Coordina las operaciones de
  * login, registro, renovación de tokens y gestión de perfiles.
- * Los errores burbujean al errorHandler global via .catch(next) en AuthRoutes.
+ * Los métodos no capturan errores: los dejan propagar para que el errorHandler
+ * global arme la respuesta uniforme.
  */
 export class AuthController {
   constructor(
@@ -49,6 +54,8 @@ export class AuthController {
     private logoutAllUseCase: LogoutAllSessions,
     private verifyEmailUseCase: VerifyEmail,
     private resendVerificationUseCase: ResendVerification,
+    private forgotPasswordUseCase: ForgotPassword,
+    private resetPasswordUseCase: ResetPassword,
   ) {}
 
   /**
@@ -139,6 +146,46 @@ export class AuthController {
       success: true,
       message: 'If an account exists for that email, a verification link has been sent',
       ...devTokenField(result.verificationToken),
+    });
+  }
+
+  /**
+   * Solicita el reset de password. Respuesta uniforme (anti-enumeracion):
+   * identica exista o no el email.
+   * @route POST /auth/forgot-password
+   * @param req - Request con { email } en el body
+   * @param res - Response de Express
+   * @returns Promise<Response>
+   * @responseStatus 200 - Respuesta generica
+   */
+  async forgotPassword(req: Request, res: Response): Promise<Response> {
+    const { email }: ForgotPasswordDto = req.body;
+    const result = await this.forgotPasswordUseCase.execute(email);
+
+    return res.status(200).json({
+      success: true,
+      message: 'If an account exists for that email, a password reset link has been sent',
+      ...devTokenField(result.resetToken),
+    });
+  }
+
+  /**
+   * Aplica el reset de password con el token del enlace. Revoca todas las sesiones.
+   * @route POST /auth/reset-password
+   * @param req - Request con { token, password } en el body
+   * @param res - Response de Express
+   * @returns Promise<Response>
+   * @responseStatus 200 - Password actualizada exitosamente
+   * @throws InvalidTokenError si el token es invalido, expirado o ya usado
+   * @throws ValidationError si la nueva password no cumple las reglas de fuerza
+   */
+  async resetPassword(req: Request, res: Response): Promise<Response> {
+    const dto: ResetPasswordDto = req.body;
+    await this.resetPasswordUseCase.execute(dto);
+
+    return res.status(200).json({
+      success: true,
+      message: 'Password reset successfully',
     });
   }
 

--- a/src/modules/auth/presentation/middleware/AuthMiddleware.ts
+++ b/src/modules/auth/presentation/middleware/AuthMiddleware.ts
@@ -66,7 +66,7 @@ export class AuthMiddleware {
       };
 
       next();
-    } catch (error) {
+    } catch {
       next(new UnauthorizedError('Invalid or expired token'));
     }
   };

--- a/src/modules/auth/presentation/routes/AuthRoutes.ts
+++ b/src/modules/auth/presentation/routes/AuthRoutes.ts
@@ -7,6 +7,7 @@ import {
   loginRateLimiter,
   registerRateLimiter,
   refreshTokenRateLimiter,
+  resendVerificationRateLimiter,
 } from '../../../../shared/middleware/RateLimiter';
 import { csrfProtection } from '../middleware/CsrfMiddleware';
 
@@ -62,6 +63,27 @@ export class AuthRoutes {
       ValidationMiddleware.handleValidationErrors,
       (req: Request, res: Response, next: NextFunction) => {
         this.authController.register(req, res).catch(next);
+      },
+    );
+
+    // POST /verify-email - Verificar email (público)
+    this.router.post(
+      '/verify-email',
+      AuthValidations.verifyEmail,
+      ValidationMiddleware.handleValidationErrors,
+      (req: Request, res: Response, next: NextFunction) => {
+        this.authController.verifyEmail(req, res).catch(next);
+      },
+    );
+
+    // POST /resend-verification - Reenviar verificación (público, rate limited, anti-enum)
+    this.router.post(
+      '/resend-verification',
+      resendVerificationRateLimiter,
+      AuthValidations.resendVerification,
+      ValidationMiddleware.handleValidationErrors,
+      (req: Request, res: Response, next: NextFunction) => {
+        this.authController.resendVerification(req, res).catch(next);
       },
     );
 

--- a/src/modules/auth/presentation/routes/AuthRoutes.ts
+++ b/src/modules/auth/presentation/routes/AuthRoutes.ts
@@ -8,6 +8,7 @@ import {
   registerRateLimiter,
   refreshTokenRateLimiter,
   resendVerificationRateLimiter,
+  forgotPasswordRateLimiter,
 } from '../../../../shared/middleware/RateLimiter';
 import { csrfProtection } from '../middleware/CsrfMiddleware';
 
@@ -84,6 +85,27 @@ export class AuthRoutes {
       ValidationMiddleware.handleValidationErrors,
       (req: Request, res: Response, next: NextFunction) => {
         this.authController.resendVerification(req, res).catch(next);
+      },
+    );
+
+    // POST /forgot-password - Solicitar reset de password (público, rate limited, anti-enum)
+    this.router.post(
+      '/forgot-password',
+      forgotPasswordRateLimiter,
+      AuthValidations.forgotPassword,
+      ValidationMiddleware.handleValidationErrors,
+      (req: Request, res: Response, next: NextFunction) => {
+        this.authController.forgotPassword(req, res).catch(next);
+      },
+    );
+
+    // POST /reset-password - Aplicar reset de password (público)
+    this.router.post(
+      '/reset-password',
+      AuthValidations.resetPassword,
+      ValidationMiddleware.handleValidationErrors,
+      (req: Request, res: Response, next: NextFunction) => {
+        this.authController.resetPassword(req, res).catch(next);
       },
     );
 

--- a/src/modules/auth/presentation/validations/AuthValidations.ts
+++ b/src/modules/auth/presentation/validations/AuthValidations.ts
@@ -52,6 +52,29 @@ export class AuthValidations {
   ];
 
   /**
+   * Validación para verificar el email
+   */
+  static verifyEmail = [
+    body('token')
+      .notEmpty()
+      .withMessage('Token is required')
+      .isString()
+      .withMessage('Token must be a string'),
+  ];
+
+  /**
+   * Validación para reenviar el email de verificación
+   */
+  static resendVerification = [
+    body('email')
+      .notEmpty()
+      .withMessage('Email is required')
+      .isEmail()
+      .withMessage('Valid email is required')
+      .normalizeEmail(),
+  ];
+
+  /**
    * Validación para el inicio de sesión
    */
   static login = [

--- a/src/modules/auth/presentation/validations/AuthValidations.ts
+++ b/src/modules/auth/presentation/validations/AuthValidations.ts
@@ -75,6 +75,37 @@ export class AuthValidations {
   ];
 
   /**
+   * Validación para solicitar el reset de password
+   */
+  static forgotPassword = [
+    body('email')
+      .notEmpty()
+      .withMessage('Email is required')
+      .isEmail()
+      .withMessage('Valid email is required')
+      .normalizeEmail(),
+  ];
+
+  /**
+   * Validación para aplicar el reset de password
+   */
+  static resetPassword = [
+    body('token')
+      .notEmpty()
+      .withMessage('Token is required')
+      .isString()
+      .withMessage('Token must be a string'),
+
+    body('password')
+      .notEmpty()
+      .withMessage('Password is required')
+      .isLength({ min: 8 })
+      .withMessage('Password must be at least 8 characters')
+      .matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/)
+      .withMessage('Password must contain at least one uppercase, one lowercase, and one number'),
+  ];
+
+  /**
    * Validación para el inicio de sesión
    */
   static login = [

--- a/src/shared/config/env.ts
+++ b/src/shared/config/env.ts
@@ -6,58 +6,118 @@ dotenv.config();
 /**
  * Schema de validacion de variables de entorno
  *
- * Solo incluye variables que el proceso Node realmente consume hoy --
- * deliberadamente excluidas: MAIL_* (nodemailer esta instalado pero no hay
- * ningun servicio de mail implementado en src/modules/notifications/, cero
- * codigo las lee), DB_HOST/DB_PORT/DB_USERNAME/DB_PASSWORD/DB_DATABASE
- * (Prisma solo lee DATABASE_URL, esas 5 solo las usa docker-compose.dev.yml
- * para configurar el contenedor de Postgres) y PGADMIN_* (config del
- * contenedor de pgAdmin, no de la app).
+ * Solo incluye variables que el proceso Node realmente consume hoy.
+ *
+ * MAIL_* el EmailService (nodemailer) las usa
+ * para verificacion de email + reset de password. Son requeridas en produccion
+ * y opcionales en development/test (donde el transporte es mock/log y no se
+ * exige SMTP a la suite/CI).
+ *
+ * Excluidas: DB_HOST/DB_PORT/DB_USERNAME/DB_PASSWORD/
+ * DB_DATABASE (Prisma solo lee DATABASE_URL, las otras 5 solo las usa
+ * docker-compose.dev.yml para configurar el contenedor de Postgres) y
+ * PGADMIN_* (config del contenedor de pgAdmin, no de la app).
  */
-const envSchema = z.object({
-  NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
-  PORT: z.coerce.number().int().min(1).max(65535).default(3000),
-  LOG_LEVEL: z.enum(['error', 'warn', 'info', 'http', 'verbose', 'debug', 'silly']).default('info'),
+const envSchema = z
+  .object({
+    NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
+    PORT: z.coerce.number().int().min(1).max(65535).default(3000),
+    LOG_LEVEL: z
+      .enum(['error', 'warn', 'info', 'http', 'verbose', 'debug', 'silly'])
+      .default('info'),
 
-  DATABASE_URL: z.url({
-    message: 'DATABASE_URL debe ser una URL valida (ej. postgresql://user:pass@host:port/db)',
-  }),
+    DATABASE_URL: z.url({
+      message: 'DATABASE_URL debe ser una URL valida (ej. postgresql://user:pass@host:port/db)',
+    }),
 
-  JWT_ACCESS_SECRET: z.string().min(32, 'JWT_ACCESS_SECRET debe tener al menos 32 caracteres'),
-  JWT_REFRESH_SECRET: z.string().min(32, 'JWT_REFRESH_SECRET debe tener al menos 32 caracteres'),
-  JWT_ACCESS_EXPIRY: z
-    .string()
-    .regex(/^\d+[smhd]$/, "JWT_ACCESS_EXPIRY debe tener formato como '15m', '1h', '7d'")
-    .default('15m'),
-  JWT_REFRESH_EXPIRY: z
-    .string()
-    .regex(/^\d+[smhd]$/, "JWT_REFRESH_EXPIRY debe tener formato como '15m', '1h', '7d'")
-    .default('7d'),
+    JWT_ACCESS_SECRET: z.string().min(32, 'JWT_ACCESS_SECRET debe tener al menos 32 caracteres'),
+    JWT_REFRESH_SECRET: z.string().min(32, 'JWT_REFRESH_SECRET debe tener al menos 32 caracteres'),
+    JWT_ACCESS_EXPIRY: z
+      .string()
+      .regex(/^\d+[smhd]$/, "JWT_ACCESS_EXPIRY debe tener formato como '15m', '1h', '7d'")
+      .default('15m'),
+    JWT_REFRESH_EXPIRY: z
+      .string()
+      .regex(/^\d+[smhd]$/, "JWT_REFRESH_EXPIRY debe tener formato como '15m', '1h', '7d'")
+      .default('7d'),
 
-  // TTL del refresh token opaco (dias). El refresh ya no es JWT: se persiste
-  // hasheado y este valor define su expiracion. JWT_REFRESH_EXPIRY queda como
-  // legacy en deprecacion. -- F3/F6
-  REFRESH_TOKEN_TTL_DAYS: z.coerce.number().int().min(1).default(7),
+    // TTL del refresh token opaco (dias). El refresh ya no es JWT: se persiste
+    // hasheado y este valor define su expiracion. JWT_REFRESH_EXPIRY queda como
+    // legacy en deprecacion. -- F3/F6
+    REFRESH_TOKEN_TTL_DAYS: z.coerce.number().int().min(1).default(7),
 
-  // Config de la cookie httpOnly del refresh (y de la cookie CSRF). -- F5b/F6
-  // COOKIE_SECURE: si no se define, se deriva de NODE_ENV (true solo en prod),
-  // para permitir pruebas por HTTP en desarrollo local.
-  // Los preprocess convierten string vacio ('') en undefined, para que dejar una
-  // COOKIE_* vacia en el .env no rompa el boot y se aplique el default/derivado.
-  COOKIE_SECURE: z
-    .preprocess(
+    // Config de la cookie httpOnly del refresh (y de la cookie CSRF). -- F5b/F6
+    // COOKIE_SECURE: si no se define, se deriva de NODE_ENV (true solo en prod),
+    // para permitir pruebas por HTTP en desarrollo local.
+    // Los preprocess convierten string vacio ('') en undefined, para que dejar una
+    // COOKIE_* vacia en el .env no rompa el boot y se aplique el default/derivado.
+    COOKIE_SECURE: z
+      .preprocess((v) => (v === '' ? undefined : v), z.enum(['true', 'false']).optional())
+      .transform((v) => (v === undefined ? undefined : v === 'true')),
+    COOKIE_SAMESITE: z.preprocess(
       (v) => (v === '' ? undefined : v),
-      z.enum(['true', 'false']).optional(),
-    )
-    .transform((v) => (v === undefined ? undefined : v === 'true')),
-  COOKIE_SAMESITE: z.preprocess(
-    (v) => (v === '' ? undefined : v),
-    z.enum(['strict', 'lax', 'none']).default('lax'),
-  ),
-  COOKIE_DOMAIN: z.preprocess((v) => (v === '' ? undefined : v), z.string().optional()),
+      z.enum(['strict', 'lax', 'none']).default('lax'),
+    ),
+    COOKIE_DOMAIN: z.preprocess((v) => (v === '' ? undefined : v), z.string().optional()),
 
-  FRONTEND_URL: z.url().default('http://localhost:3000'),
-});
+    FRONTEND_URL: z.url().default('http://localhost:3000'),
+
+    // Mail / SMTP (nodemailer) -- consumidas por EmailService (verificacion de
+    // email + reset de password). Opcionales aqui: en development/test el
+    // transporte es mock/log; el superRefine de abajo las vuelve OBLIGATORIAS en
+    // produccion. Los preprocess convierten '' en undefined para que una MAIL_*
+    // vacia en el .env no rompa el boot y aplique el default cuando corresponda.
+    MAIL_HOST: z.preprocess((v) => (v === '' ? undefined : v), z.string().optional()),
+    MAIL_PORT: z.coerce.number().int().min(1).max(65535).default(587),
+    MAIL_USER: z.preprocess((v) => (v === '' ? undefined : v), z.string().optional()),
+    MAIL_PASSWORD: z.preprocess((v) => (v === '' ? undefined : v), z.string().optional()),
+    // MAIL_FROM: puede venir como 'Nombre <noreply@app.com>', por eso string y no email.
+    MAIL_FROM: z.preprocess((v) => (v === '' ? undefined : v), z.string().optional()),
+    // MAIL_SECURE: true => TLS directo (puerto 465); false => STARTTLS (587).
+    MAIL_SECURE: z
+      .preprocess((v) => (v === '' ? undefined : v), z.enum(['true', 'false']).default('false'))
+      .transform((v) => v === 'true'),
+
+    // TTL de los tokens de un solo uso (verificacion de email / reset de password).
+    EMAIL_VERIFICATION_TOKEN_TTL_HOURS: z.coerce.number().int().min(1).default(24),
+    PASSWORD_RESET_TOKEN_TTL_MINUTES: z.coerce.number().int().min(1).default(60),
+
+    // Gatea el bloqueo de login cuando el email no esta verificado (403).
+    // Default true. Poner en false permite login sin verificar (util en algunos entornos).
+    REQUIRE_EMAIL_VERIFICATION: z
+      .preprocess((v) => (v === '' ? undefined : v), z.enum(['true', 'false']).default('true'))
+      .transform((v) => v === 'true'),
+
+    // SOLO no-produccion: expone el token de verificacion/reset en la respuesta/log
+    // para poder probar el flujo por Postman sin frontend. El superRefine prohibe
+    // que sea true en produccion (doble guarda; el codigo tambien lo re-chequea).
+    EXPOSE_VERIFICATION_TOKENS: z
+      .preprocess((v) => (v === '' ? undefined : v), z.enum(['true', 'false']).default('false'))
+      .transform((v) => v === 'true'),
+  })
+  .superRefine((val, ctx) => {
+    // MAIL_* obligatorias en produccion: sin ellas el EmailService no puede enviar.
+    if (val.NODE_ENV === 'production') {
+      const requeridas = ['MAIL_HOST', 'MAIL_USER', 'MAIL_PASSWORD', 'MAIL_FROM'] as const;
+      for (const key of requeridas) {
+        if (!val[key]) {
+          ctx.addIssue({
+            code: 'custom',
+            path: [key],
+            message: `${key} es obligatoria en produccion (el EmailService la necesita)`,
+          });
+        }
+      }
+      // Nunca filtrar tokens por API/log en produccion.
+      if (val.EXPOSE_VERIFICATION_TOKENS) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['EXPOSE_VERIFICATION_TOKENS'],
+          message: 'EXPOSE_VERIFICATION_TOKENS no puede ser true en produccion',
+        });
+      }
+    }
+  });
 
 export type Env = z.infer<typeof envSchema>;
 

--- a/src/shared/crypto/opaqueToken.ts
+++ b/src/shared/crypto/opaqueToken.ts
@@ -1,0 +1,34 @@
+import { randomBytes, createHash } from 'node:crypto';
+
+/**
+ * Utilidades para tokens opacos de un solo uso (verificacion de email, reset de
+ * password). Mismo patron que los refresh tokens de sesion: el valor en claro
+ * es de alta entropia y se entrega al usuario; en la base solo se guarda su
+ * hash SHA-256. SHA-256 (y no bcrypt/Argon2) porque el token ya es aleatorio de
+ * alta entropia: hashearlo con un KDF lento solo agregaria latencia sin ganar
+ * seguridad real.
+ *
+ * Helper compartido para no duplicar la cripto entre servicios ni acoplar el
+ * `CryptoRefreshTokenService` existente (se deja intacto).
+ */
+
+/** Bytes de entropia por defecto del token opaco (32 = 256 bits) */
+const DEFAULT_TOKEN_BYTES = 32;
+
+/**
+ * Genera un token opaco aleatorio codificado en base64url.
+ * @param bytes - Bytes de entropia (default 32 = 256 bits)
+ * @returns Token en claro, para entregar al usuario (nunca persistir)
+ */
+export function generateOpaqueToken(bytes: number = DEFAULT_TOKEN_BYTES): string {
+  return randomBytes(bytes).toString('base64url');
+}
+
+/**
+ * Calcula el hash SHA-256 (hex) de un token, para persistir y comparar.
+ * @param token - Token opaco en claro
+ * @returns Hash en hexadecimal
+ */
+export function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}

--- a/src/shared/email/EmailService.ts
+++ b/src/shared/email/EmailService.ts
@@ -1,0 +1,48 @@
+/**
+ * Puerto del servicio de email (verificacion de cuenta + reset de password).
+ *
+ * el envio de mail es transversal: hoy lo consume el
+ * modulo `auth`, y a futuro puede reutilizarlo `notifications` (que hoy solo
+ * persiste en DB) sin acoplar modulos entre si. La implementacion concreta
+ * (nodemailer) esta en `NodemailerEmailService`; el resto de la app depende
+ * solo de esta interfaz.
+ */
+
+/** Contexto para el email de verificacion de cuenta */
+export interface VerificationEmailContext {
+  /** Destinatario */
+  to: string;
+  /** Nombre del usuario, para el saludo */
+  name: string;
+  /** URL completa de verificacion (FRONTEND_URL/verify-email?token=...) */
+  verificationUrl: string;
+  /** Vigencia del enlace, en horas, para mostrar al usuario */
+  expiresInHours: number;
+}
+
+/** Contexto para el email de recuperacion de password */
+export interface PasswordResetEmailContext {
+  /** Destinatario */
+  to: string;
+  /** Nombre del usuario, para el saludo */
+  name: string;
+  /** URL completa de reset (FRONTEND_URL/reset-password?token=...) */
+  resetUrl: string;
+  /** Vigencia del enlace, en minutos, para mostrar al usuario */
+  expiresInMinutes: number;
+}
+
+/**
+ * Servicio de envio de emails transaccionales.
+ *
+ * Las implementaciones NO deben lanzar si el envio es best-effort (ver
+ * politica de registro); el caller decide como tratar los fallos. En test el
+ * transporte es un mock que no envia nada (ver `transportFactory`).
+ */
+export interface EmailService {
+  /** Envia el email con el enlace de verificacion de cuenta */
+  sendVerificationEmail(ctx: VerificationEmailContext): Promise<void>;
+
+  /** Envia el email con el enlace de recuperacion de password */
+  sendPasswordResetEmail(ctx: PasswordResetEmailContext): Promise<void>;
+}

--- a/src/shared/email/NodemailerEmailService.ts
+++ b/src/shared/email/NodemailerEmailService.ts
@@ -1,0 +1,59 @@
+import { Transporter } from 'nodemailer';
+import {
+  EmailService,
+  VerificationEmailContext,
+  PasswordResetEmailContext,
+} from './EmailService';
+import { RenderedEmail } from './templates/RenderedEmail';
+import { renderVerificationEmail } from './templates/verifyEmail';
+import { renderPasswordResetEmail } from './templates/resetPassword';
+import { createEmailTransport, isRealTransport } from './transportFactory';
+import { env } from '../config/env';
+import { logger } from '../logger/logger';
+
+/**
+ * Implementacion de EmailService con nodemailer.
+ *
+ * El transporte se resuelve por entorno (ver `transportFactory`): mock en
+ * test/dev-sin-SMTP, SMTP real en prod. El transporte es inyectable por
+ * constructor para poder testear el adapter con un mock sin tocar env.
+ */
+export class NodemailerEmailService implements EmailService {
+  private readonly transport: Transporter;
+  private readonly from: string;
+
+  constructor(transport: Transporter = createEmailTransport()) {
+    this.transport = transport;
+    // En produccion MAIL_FROM es obligatoria (env.ts); el fallback solo aplica
+    // en dev/test donde el transporte no entrega mails reales.
+    this.from = env.MAIL_FROM ?? 'no-reply@turnity.local';
+  }
+
+  async sendVerificationEmail(ctx: VerificationEmailContext): Promise<void> {
+    const rendered = renderVerificationEmail(ctx);
+    await this.deliver(ctx.to, rendered, ctx.verificationUrl);
+  }
+
+  async sendPasswordResetEmail(ctx: PasswordResetEmailContext): Promise<void> {
+    const rendered = renderPasswordResetEmail(ctx);
+    await this.deliver(ctx.to, rendered, ctx.resetUrl);
+  }
+
+  private async deliver(to: string, email: RenderedEmail, actionUrl: string): Promise<void> {
+    await this.transport.sendMail({
+      from: this.from,
+      to,
+      subject: email.subject,
+      html: email.html,
+      text: email.text,
+    });
+
+    logger.info('[email] enviado', { to, subject: email.subject });
+
+    // Fuera de produccion (o cuando el transporte no entrega de verdad) logueamos
+    // el enlace para poder probar el flujo por API/Postman sin frontend.
+    if (!isRealTransport()) {
+      logger.debug(`[email] enlace para ${to}: ${actionUrl}`);
+    }
+  }
+}

--- a/src/shared/email/templates/RenderedEmail.ts
+++ b/src/shared/email/templates/RenderedEmail.ts
@@ -1,0 +1,9 @@
+/**
+ * Resultado de renderizar una plantilla de email: asunto + cuerpo en HTML y
+ * en texto plano (los clientes que no renderizan HTML usan el `text`).
+ */
+export interface RenderedEmail {
+  subject: string;
+  html: string;
+  text: string;
+}

--- a/src/shared/email/templates/layout.ts
+++ b/src/shared/email/templates/layout.ts
@@ -1,0 +1,65 @@
+/**
+ * Layout HTML minimo y responsive para emails transaccionales de Turnity.
+ * Estilos inline (los clientes de correo ignoran <style> y CSS externo) y
+ * estructura simple para maxima compatibilidad. El enlace se muestra ademas
+ * como texto por si el boton no renderiza.
+ */
+
+/** Escapa texto para interpolarlo de forma segura dentro del HTML del email */
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+export interface LayoutOptions {
+  heading: string;
+  /** Parrafos del cuerpo (ya en texto plano; se escapan aca) */
+  paragraphs: string[];
+  buttonLabel: string;
+  url: string;
+  /** Nota al pie (ej. "si no fuiste vos, ignora este mensaje") */
+  footer: string;
+}
+
+export function baseHtml(opts: LayoutOptions): string {
+  const safeUrl = escapeHtml(opts.url);
+  const body = opts.paragraphs
+    .map((p) => `<p style="margin:0 0 16px;">${escapeHtml(p)}</p>`)
+    .join('');
+
+  return `<!DOCTYPE html>
+<html lang="es">
+  <body style="margin:0;padding:0;background:#f4f4f5;font-family:Arial,Helvetica,sans-serif;color:#18181b;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f4f4f5;padding:24px 0;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="480" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:8px;padding:32px;">
+            <tr>
+              <td>
+                <h1 style="margin:0 0 8px;font-size:20px;">Turnity</h1>
+                <h2 style="margin:0 0 24px;font-size:16px;color:#3f3f46;">${escapeHtml(opts.heading)}</h2>
+                ${body}
+                <p style="margin:24px 0;">
+                  <a href="${safeUrl}" style="display:inline-block;padding:12px 24px;background:#4f46e5;color:#ffffff;text-decoration:none;border-radius:6px;font-weight:bold;">${escapeHtml(
+                    opts.buttonLabel,
+                  )}</a>
+                </p>
+                <p style="margin:0 0 16px;font-size:12px;color:#71717a;">
+                  Si el boton no funciona, copia y pega este enlace en tu navegador:<br />
+                  <a href="${safeUrl}" style="color:#4f46e5;word-break:break-all;">${safeUrl}</a>
+                </p>
+                <hr style="border:none;border-top:1px solid #e4e4e7;margin:24px 0;" />
+                <p style="margin:0;font-size:12px;color:#a1a1aa;">${escapeHtml(opts.footer)}</p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`;
+}

--- a/src/shared/email/templates/resetPassword.ts
+++ b/src/shared/email/templates/resetPassword.ts
@@ -1,0 +1,35 @@
+import { PasswordResetEmailContext } from '../EmailService';
+import { RenderedEmail } from './RenderedEmail';
+import { baseHtml } from './layout';
+
+/**
+ * Plantilla del email de recuperacion de password. Devuelve asunto + HTML + texto.
+ * El enlace y la vigencia vienen del caller (use-case), no se calculan aca.
+ */
+export function renderPasswordResetEmail(ctx: PasswordResetEmailContext): RenderedEmail {
+  const subject = 'Recupera tu contrasena — Turnity';
+
+  const text = [
+    `Hola ${ctx.name},`,
+    '',
+    'Recibimos una solicitud para restablecer la contrasena de tu cuenta en Turnity.',
+    `Usa el siguiente enlace para elegir una nueva contrasena. Vence en ${ctx.expiresInMinutes} minutos:`,
+    ctx.resetUrl,
+    '',
+    'Si no solicitaste este cambio, ignora este mensaje: tu contrasena seguira igual.',
+  ].join('\n');
+
+  const html = baseHtml({
+    heading: 'Restablece tu contrasena',
+    paragraphs: [
+      `Hola ${ctx.name},`,
+      'Recibimos una solicitud para restablecer la contrasena de tu cuenta en Turnity.',
+      `Elegi una nueva contrasena con el boton de abajo. El enlace vence en ${ctx.expiresInMinutes} minutos.`,
+    ],
+    buttonLabel: 'Restablecer contrasena',
+    url: ctx.resetUrl,
+    footer: 'Si no solicitaste este cambio, ignora este mensaje: tu contrasena seguira igual.',
+  });
+
+  return { subject, html, text };
+}

--- a/src/shared/email/templates/verifyEmail.ts
+++ b/src/shared/email/templates/verifyEmail.ts
@@ -1,0 +1,35 @@
+import { VerificationEmailContext } from '../EmailService';
+import { RenderedEmail } from './RenderedEmail';
+import { baseHtml } from './layout';
+
+/**
+ * Plantilla del email de verificacion de cuenta. Devuelve asunto + HTML + texto.
+ * El enlace y la vigencia vienen del caller (use-case), no se calculan aca.
+ */
+export function renderVerificationEmail(ctx: VerificationEmailContext): RenderedEmail {
+  const subject = 'Verifica tu email — Turnity';
+
+  const text = [
+    `Hola ${ctx.name},`,
+    '',
+    'Gracias por registrarte en Turnity. Confirma tu direccion de email para activar tu cuenta.',
+    `El enlace vence en ${ctx.expiresInHours} horas:`,
+    ctx.verificationUrl,
+    '',
+    'Si no creaste esta cuenta, podes ignorar este mensaje.',
+  ].join('\n');
+
+  const html = baseHtml({
+    heading: 'Confirma tu email',
+    paragraphs: [
+      `Hola ${ctx.name},`,
+      'Gracias por registrarte en Turnity. Confirma tu direccion de email para activar tu cuenta.',
+      `El enlace vence en ${ctx.expiresInHours} horas.`,
+    ],
+    buttonLabel: 'Verificar mi email',
+    url: ctx.verificationUrl,
+    footer: 'Si no creaste esta cuenta, podes ignorar este mensaje.',
+  });
+
+  return { subject, html, text };
+}

--- a/src/shared/email/transportFactory.ts
+++ b/src/shared/email/transportFactory.ts
@@ -1,0 +1,48 @@
+import nodemailer, { Transporter } from 'nodemailer';
+import { env } from '../config/env';
+import { logger } from '../logger/logger';
+
+/**
+ * Crea el transporte de nodemailer segun el entorno. Mismo criterio con que
+ * morgan y el logger se auto-ajustan por NODE_ENV:
+ *
+ * - test: `jsonTransport` -> NO envia nada; serializa el mensaje a JSON para
+ *   poder inspeccionarlo. Garantiza que la suite/CI nunca manden mails reales.
+ * - development sin MAIL_HOST: mismo `jsonTransport` + aviso por log. Permite
+ *   desarrollar y probar por API/Postman sin configurar un SMTP.
+ * - development con MAIL_HOST / production: SMTP real. En produccion las MAIL_*
+ *   son obligatorias (validado en env.ts).
+ */
+export function createEmailTransport(): Transporter {
+  if (env.NODE_ENV === 'test') {
+    return nodemailer.createTransport({ jsonTransport: true });
+  }
+
+  if (env.NODE_ENV === 'development' && !env.MAIL_HOST) {
+    logger.warn(
+      '[email] MAIL_HOST no configurado en desarrollo: usando transporte de log ' +
+        '(no se envian mails reales; el enlace se loguea para pruebas por API).',
+    );
+    return nodemailer.createTransport({ jsonTransport: true });
+  }
+
+  return nodemailer.createTransport({
+    host: env.MAIL_HOST,
+    port: env.MAIL_PORT,
+    secure: env.MAIL_SECURE,
+    auth:
+      env.MAIL_USER && env.MAIL_PASSWORD
+        ? { user: env.MAIL_USER, pass: env.MAIL_PASSWORD }
+        : undefined,
+  });
+}
+
+/**
+ * Indica si el transporte activo realmente entrega mails (SMTP) o es el mock
+ * de log/test. Sirve para decidir si conviene loguear el enlace en claro.
+ */
+export function isRealTransport(): boolean {
+  if (env.NODE_ENV === 'test') return false;
+  if (env.NODE_ENV === 'development' && !env.MAIL_HOST) return false;
+  return true;
+}

--- a/src/shared/exceptions/EmailNotVerifiedError.ts
+++ b/src/shared/exceptions/EmailNotVerifiedError.ts
@@ -1,0 +1,19 @@
+import { AppError } from './AppError';
+
+/**
+ * Error para intentos de login de un usuario cuyo email todavia no fue verificado,
+ * cuando REQUIRE_EMAIL_VERIFICATION esta activo.
+ *
+ * Responde 403 con code 'EMAIL_NOT_VERIFIED' para que el cliente pueda distinguir
+ * este caso (ej. ofrecer reenviar el email de verificacion) de unas credenciales
+ * incorrectas (401). Se lanza SOLO despues de validar las credenciales, para no
+ * filtrar el estado de verificacion a quien no conoce la password.
+ */
+export class EmailNotVerifiedError extends AppError {
+  constructor(
+    message: string = 'Email not verified. Please verify your email before logging in',
+  ) {
+    super(message, 403, 'EMAIL_NOT_VERIFIED');
+    this.name = 'EmailNotVerifiedError';
+  }
+}

--- a/src/shared/exceptions/InvalidTokenError.ts
+++ b/src/shared/exceptions/InvalidTokenError.ts
@@ -1,0 +1,16 @@
+import { AppError } from './AppError';
+
+/**
+ * Error para tokens de un solo uso (verificacion de email / reset de password)
+ * que no son validos: inexistentes, de otro tipo, ya consumidos o expirados.
+ *
+ * Responde 400 con code 'INVALID_OR_EXPIRED_TOKEN' para que el cliente pueda
+ * distinguir este caso (ej. ofrecer reenviar el enlace) sin filtrar por que
+ * exactamente fallo (no se distingue inexistente de expirado, a proposito).
+ */
+export class InvalidTokenError extends AppError {
+  constructor(message: string = 'El enlace es invalido o expiro') {
+    super(message, 400, 'INVALID_OR_EXPIRED_TOKEN');
+    this.name = 'InvalidTokenError';
+  }
+}

--- a/src/shared/middleware/RateLimiter.ts
+++ b/src/shared/middleware/RateLimiter.ts
@@ -101,5 +101,8 @@ export const registerRateLimiter = rateLimit(registerRateLimiterOptions);
 /** Rate limiter para POST /auth/refresh-token, usado en AuthRoutes.ts */
 export const refreshTokenRateLimiter = rateLimit(refreshTokenRateLimiterOptions);
 
-/** Rate limiter para reenvio de verificacion / forgot-password, usado en AuthRoutes.ts */
+/** Rate limiter para reenvio de verificacion, usado en AuthRoutes.ts */
 export const resendVerificationRateLimiter = rateLimit(resendVerificationRateLimiterOptions);
+
+/** Rate limiter para forgot-password (store propio, misma config), usado en AuthRoutes.ts */
+export const forgotPasswordRateLimiter = rateLimit(resendVerificationRateLimiterOptions);

--- a/src/shared/middleware/RateLimiter.ts
+++ b/src/shared/middleware/RateLimiter.ts
@@ -76,6 +76,22 @@ export const refreshTokenRateLimiterOptions: Partial<Options> = {
   handler: rateLimitHandler('Too many token refresh attempts, please try again later'),
 };
 
+/**
+ * Configuracion del limiter de POST /auth/resend-verification y
+ * POST /auth/forgot-password -- frena el abuso de reenvio de emails (spam a la
+ * casilla de un tercero) y el sondeo de la API. Umbral bajo (3/hora por IP) a
+ * proposito: reenviar/recuperar es una accion poco frecuente para un usuario real.
+ *
+ * Store en memoria (como el resto): sirve para una sola instancia; migrar a un
+ * store distribuido queda como deuda para multi-instancia.
+ */
+export const resendVerificationRateLimiterOptions: Partial<Options> = {
+  ...baseOptions,
+  windowMs: 60 * 60 * 1000, // 60 minutos
+  limit: 3,
+  handler: rateLimitHandler('Too many requests, please try again later'),
+};
+
 /** Rate limiter para POST /auth/login, usado en AuthRoutes.ts */
 export const loginRateLimiter = rateLimit(loginRateLimiterOptions);
 
@@ -84,3 +100,6 @@ export const registerRateLimiter = rateLimit(registerRateLimiterOptions);
 
 /** Rate limiter para POST /auth/refresh-token, usado en AuthRoutes.ts */
 export const refreshTokenRateLimiter = rateLimit(refreshTokenRateLimiterOptions);
+
+/** Rate limiter para reenvio de verificacion / forgot-password, usado en AuthRoutes.ts */
+export const resendVerificationRateLimiter = rateLimit(resendVerificationRateLimiterOptions);

--- a/src/shared/utils/devToken.ts
+++ b/src/shared/utils/devToken.ts
@@ -1,0 +1,16 @@
+import { env } from '../config/env';
+
+/**
+ * Helper para exponer (o no) un token de verificacion/reset en la respuesta de
+ * la API. Solo se expone FUERA de produccion y con EXPOSE_VERIFICATION_TOKENS=true,
+ * pensado para poder probar el flujo por Postman mientras no hay frontend.
+ *
+ * En produccion NUNCA se expone (doble guarda: env.ts ademas prohibe el flag en
+ * prod). Devuelve un objeto para hacer spread directo en el JSON de respuesta:
+ *   res.json({ success: true, message, ...devTokenField(token) })
+ */
+export function devTokenField(token: string | undefined): { devToken?: string } {
+  if (!token) return {};
+  if (env.NODE_ENV === 'production' || !env.EXPOSE_VERIFICATION_TOKENS) return {};
+  return { devToken: token };
+}

--- a/tests/e2e/public-registration-flow.e2e.test.ts
+++ b/tests/e2e/public-registration-flow.e2e.test.ts
@@ -1,0 +1,124 @@
+import request from 'supertest';
+import app from '../../src/app';
+
+/**
+ * E2E del flujo completo de registro publico seguro:
+ * - registro -> verificacion de email -> login (con gating antes de verificar)
+ * - forgot-password -> reset-password -> login con la nueva password
+ * - registro -> reenvio de verificacion -> verificacion -> login
+ *
+ * En test el token viaja como devToken (EXPOSE_VERIFICATION_TOKENS) y no se
+ * envian mails reales (jsonTransport).
+ */
+describe('Public Registration Complete Flow E2E', () => {
+  const uniqueEmail = (prefix: string): string =>
+    `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}@example.com`;
+
+  // Flujo completo: registro -> (login bloqueado) -> verificar -> login -> perfil
+  it('should complete register -> verify -> login -> profile', async () => {
+    const email = uniqueEmail('e2e-verify');
+
+    // 1. Registro
+    const register = await request(app).post('/api/v1/auth/register').send({
+      name: 'E2E User',
+      email,
+      phone: '+1234567890',
+      password: 'TestPass123!',
+    });
+    expect(register.status).toBe(201);
+    const devToken = register.body.devToken;
+    expect(devToken).toBeDefined();
+
+    // 2. Login antes de verificar -> bloqueado por gating
+    const blocked = await request(app)
+      .post('/api/v1/auth/login')
+      .send({ email, password: 'TestPass123!' });
+    expect(blocked.status).toBe(403);
+    expect(blocked.body.code).toBe('EMAIL_NOT_VERIFIED');
+
+    // 3. Verificar email
+    const verify = await request(app).post('/api/v1/auth/verify-email').send({ token: devToken });
+    expect(verify.status).toBe(200);
+
+    // 4. Login ahora funciona
+    const login = await request(app)
+      .post('/api/v1/auth/login')
+      .send({ email, password: 'TestPass123!' });
+    expect(login.status).toBe(200);
+    const token = login.body.data.token;
+
+    // 5. Perfil accesible con el access token
+    const profile = await request(app)
+      .get('/api/v1/auth/profile')
+      .set('Authorization', `Bearer ${token}`);
+    expect(profile.status).toBe(200);
+    expect(profile.body.data.email).toBe(email);
+  });
+
+  // Flujo completo: forgot -> reset -> login con la nueva password
+  it('should complete forgot -> reset -> login with the new password', async () => {
+    const email = uniqueEmail('e2e-reset');
+
+    // Registro + verificacion
+    const register = await request(app).post('/api/v1/auth/register').send({
+      name: 'E2E Reset User',
+      email,
+      phone: '+1234567890',
+      password: 'TestPass123!',
+    });
+    await request(app).post('/api/v1/auth/verify-email').send({ token: register.body.devToken });
+
+    // Forgot password
+    const forgot = await request(app).post('/api/v1/auth/forgot-password').send({ email });
+    expect(forgot.status).toBe(200);
+    const resetToken = forgot.body.devToken;
+    expect(resetToken).toBeDefined();
+
+    // Reset password
+    const reset = await request(app)
+      .post('/api/v1/auth/reset-password')
+      .send({ token: resetToken, password: 'NewPass456!' });
+    expect(reset.status).toBe(200);
+
+    // La nueva password funciona; la vieja no
+    const newLogin = await request(app)
+      .post('/api/v1/auth/login')
+      .send({ email, password: 'NewPass456!' });
+    expect(newLogin.status).toBe(200);
+
+    const oldLogin = await request(app)
+      .post('/api/v1/auth/login')
+      .send({ email, password: 'TestPass123!' });
+    expect(oldLogin.status).toBe(401);
+  });
+
+  // Flujo de reenvio: registro -> resend -> verificar con el token reenviado -> login
+  it('should complete register -> resend verification -> verify -> login', async () => {
+    const email = uniqueEmail('e2e-resend');
+
+    await request(app).post('/api/v1/auth/register').send({
+      name: 'E2E Resend User',
+      email,
+      phone: '+1234567890',
+      password: 'TestPass123!',
+    });
+
+    // Reenviar verificacion (emite un token nuevo, invalida el anterior)
+    const resend = await request(app).post('/api/v1/auth/resend-verification').send({ email });
+    expect(resend.status).toBe(200);
+    const resendToken = resend.body.devToken;
+    expect(resendToken).toBeDefined();
+
+    // Verificar con el token reenviado
+    const verify = await request(app)
+      .post('/api/v1/auth/verify-email')
+      .send({ token: resendToken });
+    expect(verify.status).toBe(200);
+
+    // Login funciona
+    const login = await request(app)
+      .post('/api/v1/auth/login')
+      .send({ email, password: 'TestPass123!' });
+    expect(login.status).toBe(200);
+  });
+});

--- a/tests/integration/auth/deactivate-user.integration.test.ts
+++ b/tests/integration/auth/deactivate-user.integration.test.ts
@@ -26,6 +26,15 @@ describe('Deactivate User Integration Tests (F11)', () => {
       });
 
     expect(response.status).toBe(201);
+
+    // Verificar email (gating de login): permite loguear a estos usuarios cuando
+    // el test lo necesita. Inofensivo para los que solo son desactivados por admin.
+    if (response.body.devToken) {
+      await request(app)
+        .post('/api/v1/auth/verify-email')
+        .send({ token: response.body.devToken });
+    }
+
     return response.body.data;
   };
 

--- a/tests/integration/auth/forgot-password.integration.test.ts
+++ b/tests/integration/auth/forgot-password.integration.test.ts
@@ -1,0 +1,54 @@
+import request from 'supertest';
+import app from '../../../src/app';
+import { createTestUser } from '../../setup/helpers';
+
+/**
+ * Tests de integracion de forgot-password.
+ *
+ * El token de reset se expone como devToken en test (EXPOSE_VERIFICATION_TOKENS).
+ * El rate limiter se auto-desactiva en test. Foco: anti-enumeracion.
+ */
+describe('Forgot Password Integration Tests', () => {
+  describe('POST /api/v1/auth/forgot-password', () => {
+    // Debería emitir un token de reset para un usuario existente
+    it('should issue a reset token for an existing user', async () => {
+      const user = await createTestUser('CLIENT');
+
+      const res = await request(app)
+        .post('/api/v1/auth/forgot-password')
+        .send({ email: user.email });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.devToken).toBeDefined();
+    });
+
+    // Debería responder de forma idéntica para un email inexistente (anti-enumeración)
+    it('should respond identically for a non-existent email', async () => {
+      const user = await createTestUser('CLIENT');
+
+      const existing = await request(app)
+        .post('/api/v1/auth/forgot-password')
+        .send({ email: user.email });
+
+      const missing = await request(app)
+        .post('/api/v1/auth/forgot-password')
+        .send({ email: `ghost-${Date.now()}@example.com` });
+
+      expect(missing.status).toBe(existing.status);
+      expect(missing.body.message).toBe(existing.body.message);
+      // El email inexistente no emite token
+      expect(missing.body.devToken).toBeUndefined();
+    });
+
+    // Debería validar el formato del email
+    it('should reject an invalid email format', async () => {
+      const res = await request(app)
+        .post('/api/v1/auth/forgot-password')
+        .send({ email: 'not-an-email' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+    });
+  });
+});

--- a/tests/integration/auth/login-verification-gating.integration.test.ts
+++ b/tests/integration/auth/login-verification-gating.integration.test.ts
@@ -1,0 +1,63 @@
+import request from 'supertest';
+import app from '../../../src/app';
+
+/**
+ * Tests del gating de login por email no verificado (REQUIRE_EMAIL_VERIFICATION).
+ *
+ * En test el flag esta activo, asi que un usuario recien registrado (sin verificar)
+ * no puede loguear hasta confirmar su email. Estos tests registran directo (sin el
+ * helper createTestUser, que ya verifica) para ejercitar el camino sin verificar.
+ */
+describe('Login Email Verification Gating', () => {
+  const registerRaw = async () => {
+    const email = `gating-${Date.now()}-${Math.random().toString(36).slice(2)}@example.com`;
+    const res = await request(app).post('/api/v1/auth/register').send({
+      name: 'Gating User',
+      email,
+      phone: '+1234567890',
+      password: 'TestPass123!',
+    });
+    return { email, devToken: res.body.devToken as string };
+  };
+
+  describe('POST /api/v1/auth/login (unverified)', () => {
+    // Debería bloquear el login con 403 si el email no está verificado
+    it('should block login with 403 when the email is not verified', async () => {
+      const { email } = await registerRaw();
+
+      const res = await request(app)
+        .post('/api/v1/auth/login')
+        .send({ email, password: 'TestPass123!' });
+
+      expect(res.status).toBe(403);
+      expect(res.body.success).toBe(false);
+      expect(res.body.code).toBe('EMAIL_NOT_VERIFIED');
+    });
+
+    // Debería permitir el login luego de verificar el email
+    it('should allow login after verifying the email', async () => {
+      const { email, devToken } = await registerRaw();
+
+      await request(app).post('/api/v1/auth/verify-email').send({ token: devToken });
+
+      const res = await request(app)
+        .post('/api/v1/auth/login')
+        .send({ email, password: 'TestPass123!' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toHaveProperty('token');
+    });
+
+    // Debería devolver 401 (no 403) con password incorrecta, aun sin verificar:
+    // las credenciales se validan ANTES del chequeo de verificación
+    it('should return 401 (not 403) for a wrong password on an unverified user', async () => {
+      const { email } = await registerRaw();
+
+      const res = await request(app)
+        .post('/api/v1/auth/login')
+        .send({ email, password: 'WrongPass123!' });
+
+      expect(res.status).toBe(401);
+    });
+  });
+});

--- a/tests/integration/auth/profile.integration.test.ts
+++ b/tests/integration/auth/profile.integration.test.ts
@@ -1,39 +1,48 @@
 import request from 'supertest';
 import app from '../../../src/app';
 
+/**
+ * Helper: registra un CLIENT, verifica su email (gating de login activo en test,
+ * usando el devToken expuesto) y loguea. Devuelve el token y el email.
+ */
+const registerVerifiedAndLogin = async (name: string, emailPrefix: string) => {
+  const email = `${emailPrefix}-${Date.now()}@example.com`;
+
+  const registerResponse = await request(app).post('/api/v1/auth/register').send({
+    name,
+    email,
+    phone: '+1234567890',
+    password: 'TestPass123!',
+    roleName: 'CLIENT',
+  });
+  expect(registerResponse.status).toBe(201);
+
+  await request(app)
+    .post('/api/v1/auth/verify-email')
+    .send({ token: registerResponse.body.devToken });
+
+  const loginResponse = await request(app).post('/api/v1/auth/login').send({
+    email,
+    password: 'TestPass123!',
+  });
+  expect(loginResponse.status).toBe(200);
+
+  return { token: loginResponse.body.data.token as string, email };
+};
+
 describe('Profile Integration Tests', () => {
   describe('GET /api/v1/auth/profile', () => {
     // Debería obtener el perfil del usuario con token válido
     it('should get user profile with valid token', async () => {
-      const registerResponse = await request(app)
-        .post('/api/v1/auth/register')
-        .send({
-          name: 'Profile Test User',
-          email: `profile-test-${Date.now()}@example.com`,
-          phone: '+1234567890',
-          password: 'TestPass123!',
-          roleName: 'CLIENT',
-        });
+      const { token, email } = await registerVerifiedAndLogin('Profile Test User', 'profile-test');
 
-      expect(registerResponse.status).toBe(201);
-
-      // Login para obtener token
-      const loginResponse = await request(app).post('/api/v1/auth/login').send({
-        email: registerResponse.body.data.email,
-        password: 'TestPass123!',
-      });
-
-      expect(loginResponse.status).toBe(200);
-      const validToken = loginResponse.body.data.token;
-
-      // Obtener perfil
       const response = await request(app)
         .get('/api/v1/auth/profile')
-        .set('Authorization', `Bearer ${validToken}`);
+        .set('Authorization', `Bearer ${token}`);
 
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
-      expect(response.body.data.email).toBe(registerResponse.body.data.email);
+      expect(response.body.data.email).toBe(email);
       expect(response.body.data.name).toBe('Profile Test User');
       expect(response.body.data.role.name).toBe('CLIENT');
       expect(response.body.data).toHaveProperty('id');
@@ -68,25 +77,8 @@ describe('Profile Integration Tests', () => {
   describe('PUT /api/v1/auth/profile', () => {
     // Debería actualizar el perfil del usuario exitosamente
     it('should update user profile successfully', async () => {
-      const registerResponse = await request(app)
-        .post('/api/v1/auth/register')
-        .send({
-          name: 'Update Test User',
-          email: `update-test-${Date.now()}@example.com`,
-          phone: '+1234567890',
-          password: 'TestPass123!',
-          roleName: 'CLIENT',
-        });
+      const { token, email } = await registerVerifiedAndLogin('Update Test User', 'update-test');
 
-      // Login
-      const loginResponse = await request(app).post('/api/v1/auth/login').send({
-        email: registerResponse.body.data.email,
-        password: 'TestPass123!',
-      });
-
-      const validToken = loginResponse.body.data.token;
-
-      // Actualizar perfil
       const updateData = {
         name: 'Updated Name',
         phone: '+9876543210',
@@ -94,39 +86,23 @@ describe('Profile Integration Tests', () => {
 
       const updateResponse = await request(app)
         .put('/api/v1/auth/profile')
-        .set('Authorization', `Bearer ${validToken}`)
+        .set('Authorization', `Bearer ${token}`)
         .send(updateData);
 
       expect(updateResponse.status).toBe(200);
       expect(updateResponse.body.success).toBe(true);
       expect(updateResponse.body.data.name).toBe('Updated Name');
       expect(updateResponse.body.data.phone).toBe('+9876543210');
-      expect(updateResponse.body.data.email).toBe(registerResponse.body.data.email);
+      expect(updateResponse.body.data.email).toBe(email);
     });
 
     // Debería obtener el perfil actualizado después de la actualización
     it('should get updated profile after update', async () => {
-      const registerResponse = await request(app)
-        .post('/api/v1/auth/register')
-        .send({
-          name: 'Get Updated Test User',
-          email: `get-updated-${Date.now()}@example.com`,
-          phone: '+1234567890',
-          password: 'TestPass123!',
-          roleName: 'CLIENT',
-        });
-
-      // Login
-      const loginResponse = await request(app).post('/api/v1/auth/login').send({
-        email: registerResponse.body.data.email,
-        password: 'TestPass123!',
-      });
-
-      const validToken = loginResponse.body.data.token;
+      const { token } = await registerVerifiedAndLogin('Get Updated Test User', 'get-updated');
 
       await request(app)
         .put('/api/v1/auth/profile')
-        .set('Authorization', `Bearer ${validToken}`)
+        .set('Authorization', `Bearer ${token}`)
         .send({
           name: 'Finally Updated Name',
           phone: '+9876543210',
@@ -134,7 +110,7 @@ describe('Profile Integration Tests', () => {
 
       const response = await request(app)
         .get('/api/v1/auth/profile')
-        .set('Authorization', `Bearer ${validToken}`);
+        .set('Authorization', `Bearer ${token}`);
 
       expect(response.status).toBe(200);
       expect(response.body.data.name).toBe('Finally Updated Name');
@@ -143,27 +119,11 @@ describe('Profile Integration Tests', () => {
 
     // Debería actualizar el perfil con datos parciales
     it('should update profile with partial data', async () => {
-      const registerResponse = await request(app)
-        .post('/api/v1/auth/register')
-        .send({
-          name: 'Partial Test User',
-          email: `partial-${Date.now()}@example.com`,
-          phone: '+1234567890',
-          password: 'TestPass123!',
-          roleName: 'CLIENT',
-        });
-
-      // Login
-      const loginResponse = await request(app).post('/api/v1/auth/login').send({
-        email: registerResponse.body.data.email,
-        password: 'TestPass123!',
-      });
-
-      const validToken = loginResponse.body.data.token;
+      const { token } = await registerVerifiedAndLogin('Partial Test User', 'partial');
 
       const response = await request(app)
         .put('/api/v1/auth/profile')
-        .set('Authorization', `Bearer ${validToken}`)
+        .set('Authorization', `Bearer ${token}`)
         .send({
           name: 'Partial Update Name',
         });
@@ -183,27 +143,11 @@ describe('Profile Integration Tests', () => {
 
     // Debería rechazar la actualización del perfil con datos inválidos
     it('should reject profile update with invalid data', async () => {
-      const registerResponse = await request(app)
-        .post('/api/v1/auth/register')
-        .send({
-          name: 'Invalid Test User',
-          email: `invalid-${Date.now()}@example.com`,
-          phone: '+1234567890',
-          password: 'TestPass123!',
-          roleName: 'CLIENT',
-        });
-
-      // Login
-      const loginResponse = await request(app).post('/api/v1/auth/login').send({
-        email: registerResponse.body.data.email,
-        password: 'TestPass123!',
-      });
-
-      const validToken = loginResponse.body.data.token;
+      const { token } = await registerVerifiedAndLogin('Invalid Test User', 'invalid');
 
       const response = await request(app)
         .put('/api/v1/auth/profile')
-        .set('Authorization', `Bearer ${validToken}`)
+        .set('Authorization', `Bearer ${token}`)
         .send({
           name: '',
           phone: 'invalid-phone',

--- a/tests/integration/auth/resend-verification.integration.test.ts
+++ b/tests/integration/auth/resend-verification.integration.test.ts
@@ -1,0 +1,81 @@
+import request from 'supertest';
+import app from '../../../src/app';
+
+/**
+ * Tests de integracion del reenvio de verificacion.
+ *
+ * El rate limiter se auto-desactiva en NODE_ENV=test (igual que login/register),
+ * por eso no se testea el 429 aca. El foco esta en la anti-enumeracion: misma
+ * respuesta exista o no el email, y token emitido solo cuando corresponde.
+ */
+describe('Resend Verification Integration Tests', () => {
+  const registerUnverified = async (): Promise<string> => {
+    const email = `resend-${Date.now()}-${Math.random().toString(36).slice(2)}@example.com`;
+    await request(app).post('/api/v1/auth/register').send({
+      name: 'Resend User',
+      email,
+      phone: '+1234567890',
+      password: 'TestPass123!',
+    });
+    return email;
+  };
+
+  describe('POST /api/v1/auth/resend-verification', () => {
+    // Debería reenviar la verificación a un usuario existente no verificado
+    it('should resend verification for an existing unverified user', async () => {
+      const email = await registerUnverified();
+
+      const res = await request(app).post('/api/v1/auth/resend-verification').send({ email });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      // Se emitió un token nuevo (expuesto en test)
+      expect(res.body.devToken).toBeDefined();
+    });
+
+    // Debería responder de forma idéntica para un email inexistente (anti-enumeración)
+    it('should respond identically for a non-existent email (no enumeration)', async () => {
+      const existingEmail = await registerUnverified();
+
+      const existing = await request(app)
+        .post('/api/v1/auth/resend-verification')
+        .send({ email: existingEmail });
+
+      const missing = await request(app)
+        .post('/api/v1/auth/resend-verification')
+        .send({ email: `ghost-${Date.now()}@example.com` });
+
+      // Mismo status y mismo mensaje: no se puede inferir si el email existe
+      expect(missing.status).toBe(existing.status);
+      expect(missing.body.message).toBe(existing.body.message);
+      // El email inexistente no emite token
+      expect(missing.body.devToken).toBeUndefined();
+    });
+
+    // No debería emitir token si el usuario ya está verificado
+    it('should not issue a token if the user is already verified', async () => {
+      const email = await registerUnverified();
+
+      // Emitir + verificar primero
+      const first = await request(app).post('/api/v1/auth/resend-verification').send({ email });
+      await request(app).post('/api/v1/auth/verify-email').send({ token: first.body.devToken });
+
+      const res = await request(app).post('/api/v1/auth/resend-verification').send({ email });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      // Ya verificado -> no se emite ni expone token
+      expect(res.body.devToken).toBeUndefined();
+    });
+
+    // Debería validar que el email tiene formato válido
+    it('should reject an invalid email format', async () => {
+      const res = await request(app)
+        .post('/api/v1/auth/resend-verification')
+        .send({ email: 'not-an-email' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+    });
+  });
+});

--- a/tests/integration/auth/reset-password.integration.test.ts
+++ b/tests/integration/auth/reset-password.integration.test.ts
@@ -1,0 +1,106 @@
+import request from 'supertest';
+import app from '../../../src/app';
+import { createTestUser, loginTestUser } from '../../setup/helpers';
+
+/**
+ * Tests de integracion de reset-password.
+ *
+ * El token de reset se obtiene via forgot-password (devToken expuesto en test).
+ * Cubre: cambio efectivo de password, revocacion de sesiones, single-use,
+ * token invalido y validacion de fuerza.
+ */
+describe('Reset Password Integration Tests', () => {
+  const requestReset = async (email: string): Promise<string> => {
+    const res = await request(app).post('/api/v1/auth/forgot-password').send({ email });
+    return res.body.devToken as string;
+  };
+
+  describe('POST /api/v1/auth/reset-password', () => {
+    // Debería resetear la password: la nueva funciona y la vieja no
+    it('should reset the password (new works, old fails)', async () => {
+      const user = await createTestUser('CLIENT'); // password inicial: TestPass123!
+      const token = await requestReset(user.email);
+
+      const reset = await request(app)
+        .post('/api/v1/auth/reset-password')
+        .send({ token, password: 'NewPass456!' });
+      expect(reset.status).toBe(200);
+      expect(reset.body.success).toBe(true);
+
+      const newLogin = await request(app)
+        .post('/api/v1/auth/login')
+        .send({ email: user.email, password: 'NewPass456!' });
+      expect(newLogin.status).toBe(200);
+
+      const oldLogin = await request(app)
+        .post('/api/v1/auth/login')
+        .send({ email: user.email, password: 'TestPass123!' });
+      expect(oldLogin.status).toBe(401);
+    });
+
+    // Debería revocar las sesiones activas al resetear
+    it('should revoke active sessions on reset', async () => {
+      const session = await loginTestUser(); // { token, refreshToken, csrfToken, user }
+      const token = await requestReset(session.user.email);
+
+      await request(app).post('/api/v1/auth/reset-password').send({ token, password: 'NewPass456!' });
+
+      // La sesión previa quedó revocada: el refresh con la cookie vieja falla (401)
+      const refresh = await request(app)
+        .post('/api/v1/auth/refresh-token')
+        .set('Cookie', [
+          `refreshToken=${session.refreshToken}`,
+          `csrfToken=${session.csrfToken}`,
+        ])
+        .set('X-CSRF-Token', session.csrfToken as string);
+
+      expect(refresh.status).toBe(401);
+    });
+
+    // Debería rechazar un token inválido
+    it('should reject an invalid token', async () => {
+      const res = await request(app)
+        .post('/api/v1/auth/reset-password')
+        .send({ token: 'this-is-not-a-real-token', password: 'NewPass456!' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('INVALID_OR_EXPIRED_TOKEN');
+    });
+
+    // Debería rechazar un token ya usado (single-use)
+    it('should reject a token that was already used', async () => {
+      const user = await createTestUser('CLIENT');
+      const token = await requestReset(user.email);
+      await request(app).post('/api/v1/auth/reset-password').send({ token, password: 'NewPass456!' });
+
+      const res = await request(app)
+        .post('/api/v1/auth/reset-password')
+        .send({ token, password: 'AnotherPass789!' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('INVALID_OR_EXPIRED_TOKEN');
+    });
+
+    // Debería rechazar una password débil (regla de fuerza reutilizada)
+    it('should reject a weak password', async () => {
+      const user = await createTestUser('CLIENT');
+      const token = await requestReset(user.email);
+
+      const res = await request(app)
+        .post('/api/v1/auth/reset-password')
+        .send({ token, password: '123' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+    });
+
+    // Debería validar que el token es requerido
+    it('should require the token', async () => {
+      const res = await request(app)
+        .post('/api/v1/auth/reset-password')
+        .send({ password: 'NewPass456!' });
+
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/tests/integration/auth/verify-email.integration.test.ts
+++ b/tests/integration/auth/verify-email.integration.test.ts
@@ -1,0 +1,80 @@
+import request from 'supertest';
+import app from '../../../src/app';
+import { testPrisma } from '../../setup/database';
+
+/**
+ * Tests de integracion de verificacion de email.
+ *
+ * El token de verificacion se obtiene del campo devToken de la respuesta de
+ * /register, que solo se expone en test/dev con EXPOSE_VERIFICATION_TOKENS=true
+ * (forzado en jest.setup.ts). En test no se envian mails reales (jsonTransport).
+ */
+describe('Verify Email Integration Tests', () => {
+  const registerUser = async () => {
+    const email = `verify-${Date.now()}-${Math.random().toString(36).slice(2)}@example.com`;
+    const res = await request(app).post('/api/v1/auth/register').send({
+      name: 'Verify User',
+      email,
+      phone: '+1234567890',
+      password: 'TestPass123!',
+    });
+    return res.body; // { success, data, message, devToken }
+  };
+
+  describe('POST /api/v1/auth/verify-email', () => {
+    // Debería exponer el token de verificación en el registro (test/dev)
+    it('should expose the verification token on register (dev/test)', async () => {
+      const body = await registerUser();
+      expect(body.devToken).toBeDefined();
+      expect(typeof body.devToken).toBe('string');
+    });
+
+    // Debería verificar el email con un token válido y marcarlo como verificado
+    it('should verify the email with a valid token', async () => {
+      const body = await registerUser();
+
+      const res = await request(app)
+        .post('/api/v1/auth/verify-email')
+        .send({ token: body.devToken });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+
+      const user = await testPrisma.user.findUnique({ where: { id: body.data.id } });
+      expect(user?.emailVerified).toBe(true);
+      expect(user?.emailVerifiedAt).not.toBeNull();
+    });
+
+    // Debería rechazar un token ya usado (single-use)
+    it('should reject a token that was already used', async () => {
+      const body = await registerUser();
+      await request(app).post('/api/v1/auth/verify-email').send({ token: body.devToken });
+
+      const res = await request(app)
+        .post('/api/v1/auth/verify-email')
+        .send({ token: body.devToken });
+
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+      expect(res.body.code).toBe('INVALID_OR_EXPIRED_TOKEN');
+    });
+
+    // Debería rechazar un token inexistente/inválido
+    it('should reject an invalid token', async () => {
+      const res = await request(app)
+        .post('/api/v1/auth/verify-email')
+        .send({ token: 'this-is-not-a-real-token' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('INVALID_OR_EXPIRED_TOKEN');
+    });
+
+    // Debería validar que el token es requerido
+    it('should require the token', async () => {
+      const res = await request(app).post('/api/v1/auth/verify-email').send({});
+
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+    });
+  });
+});

--- a/tests/setup/database.ts
+++ b/tests/setup/database.ts
@@ -14,7 +14,7 @@ export const cleanupTestUsers = async () => {
         },
       },
     });
-  } catch (error) {
+  } catch {
     // Ignorar errores de limpieza
   }
 };

--- a/tests/setup/helpers.ts
+++ b/tests/setup/helpers.ts
@@ -51,6 +51,13 @@ export const createTestUser = async (roleType: 'CLIENT' | 'ADMIN' | 'STYLIST' = 
     throw new Error(`Registro falló: ${response.status}`);
   }
 
+  // Gating de login activo en test: verificamos el email con el devToken (expuesto
+  // en test via EXPOSE_VERIFICATION_TOKENS) para que el usuario pueda loguear.
+  const devToken = response.body.devToken;
+  if (devToken) {
+    await request(app).post('/api/v1/auth/verify-email').send({ token: devToken });
+  }
+
   return response.body.data;
 };
 

--- a/tests/setup/jest.setup.ts
+++ b/tests/setup/jest.setup.ts
@@ -7,6 +7,11 @@
 // app.ts, el logger de Winston) nunca se activa durante la suite de tests.
 process.env.NODE_ENV = 'test';
 
+// Exponer el token de verificacion/reset en las respuestas para que los tests de
+// integracion puedan leerlo (mismo mecanismo que en dev por Postman). Se setea
+// antes de dotenv/env.ts; en produccion el flag esta prohibido (validado en env.ts).
+process.env.EXPOSE_VERIFICATION_TOKENS = 'true';
+
 import dotenv from 'dotenv';
 
 // dotenv.config() no sobreescribe variables ya presentes en process.env por defecto,

--- a/tests/setup/services-helpers.ts
+++ b/tests/setup/services-helpers.ts
@@ -147,6 +147,12 @@ export const createTestStylist = async (): Promise<{
     throw new Error(`Failed to create test stylist user: ${userResponse.status}`);
   }
 
+  // Gating de login activo en test: verificar el email con el devToken (expuesto en test)
+  const devToken = userResponse.body.devToken;
+  if (devToken) {
+    await request(app).post('/api/v1/auth/verify-email').send({ token: devToken });
+  }
+
   const user = userResponse.body.data;
 
   // StylistService.stylistId ahora es User.id directamente, no se necesita tabla Stylist

--- a/tests/unit/auth/AuthService.unit.test.ts
+++ b/tests/unit/auth/AuthService.unit.test.ts
@@ -137,7 +137,8 @@ describe('AuthService Unit Tests', () => {
         updatedAt: new Date(),
       };
 
-      mockRegisterUser.execute.mockResolvedValue(expectedUser);
+      // RegisterUser.execute devuelve { user, verificationToken? }
+      mockRegisterUser.execute.mockResolvedValue({ user: expectedUser });
 
       const result = await authService.registerService(registerDto);
 
@@ -173,7 +174,7 @@ describe('AuthService Unit Tests', () => {
         updatedAt: new Date(),
       };
 
-      mockRegisterUser.execute.mockResolvedValue(expectedUser);
+      mockRegisterUser.execute.mockResolvedValue({ user: expectedUser });
 
       const result = await authService.registerService(registerDto);
 

--- a/tests/unit/auth/CryptoVerificationTokenService.unit.test.ts
+++ b/tests/unit/auth/CryptoVerificationTokenService.unit.test.ts
@@ -1,0 +1,169 @@
+import { VerificationTokenType } from '@prisma/client';
+import { CryptoVerificationTokenService } from '../../../src/modules/auth/infrastructure/services/CryptoVerificationTokenService';
+import {
+  IVerificationTokenRepository,
+  CreateVerificationTokenData,
+} from '../../../src/modules/auth/domain/repositories/IVerificationTokenRepository';
+import { VerificationToken } from '../../../src/modules/auth/domain/entities/VerificationToken';
+import { InvalidTokenError } from '../../../src/shared/exceptions/InvalidTokenError';
+import { hashToken } from '../../../src/shared/crypto/opaqueToken';
+
+/** Repo fake en memoria que respeta el contrato IVerificationTokenRepository */
+class FakeVerificationTokenRepository implements IVerificationTokenRepository {
+  public rows: VerificationToken[] = [];
+  private seq = 0;
+
+  async create(data: CreateVerificationTokenData): Promise<VerificationToken> {
+    const row = new VerificationToken(
+      data.id ?? `id-${++this.seq}`,
+      data.userId,
+      data.type,
+      data.tokenHash,
+      data.expiresAt,
+      null,
+      data.ipAddress ?? null,
+      data.userAgent ?? null,
+      new Date(),
+    );
+    this.rows.push(row);
+    return row;
+  }
+
+  async findByTokenHash(tokenHash: string): Promise<VerificationToken | null> {
+    return this.rows.find((r) => r.tokenHash === tokenHash) ?? null;
+  }
+
+  async consume(id: string): Promise<void> {
+    this.rows = this.rows.map((r) =>
+      r.id === id && r.consumedAt === null ? this.withConsumedAt(r, new Date()) : r,
+    );
+  }
+
+  async invalidateActiveByUser(userId: string, type: VerificationTokenType): Promise<number> {
+    let count = 0;
+    this.rows = this.rows.map((r) => {
+      if (r.userId === userId && r.type === type && r.consumedAt === null) {
+        count++;
+        return this.withConsumedAt(r, new Date());
+      }
+      return r;
+    });
+    return count;
+  }
+
+  async deleteExpired(now: Date): Promise<number> {
+    const before = this.rows.length;
+    this.rows = this.rows.filter((r) => r.expiresAt.getTime() >= now.getTime());
+    return before - this.rows.length;
+  }
+
+  /** Helper de test para insertar un token ya armado (ej. uno expirado) */
+  seed(row: VerificationToken): void {
+    this.rows.push(row);
+  }
+
+  private withConsumedAt(r: VerificationToken, consumedAt: Date): VerificationToken {
+    return new VerificationToken(
+      r.id,
+      r.userId,
+      r.type,
+      r.tokenHash,
+      r.expiresAt,
+      consumedAt,
+      r.ipAddress,
+      r.userAgent,
+      r.createdAt,
+    );
+  }
+}
+
+describe('CryptoVerificationTokenService', () => {
+  let repo: FakeVerificationTokenRepository;
+  let service: CryptoVerificationTokenService;
+
+  beforeEach(() => {
+    repo = new FakeVerificationTokenRepository();
+    service = new CryptoVerificationTokenService(repo);
+  });
+
+  describe('issue', () => {
+    // Debería devolver un token opaco y persistir solo su hash, con expiración futura
+    it('should return an opaque token and persist only its hash, with a future expiry', async () => {
+      const { token, expiresAt } = await service.issue('user-1', VerificationTokenType.EMAIL_VERIFICATION);
+
+      expect(typeof token).toBe('string');
+      expect(expiresAt.getTime()).toBeGreaterThan(Date.now());
+      expect(repo.rows).toHaveLength(1);
+      // se persiste el hash, nunca el token en claro
+      expect(repo.rows[0].tokenHash).toBe(hashToken(token));
+      expect(repo.rows[0].tokenHash).not.toBe(token);
+    });
+
+    // Debería invalidar los tokens activos previos del mismo (user, type)
+    it('should invalidate previous active tokens of the same (user, type)', async () => {
+      const first = await service.issue('user-1', VerificationTokenType.EMAIL_VERIFICATION);
+      await service.issue('user-1', VerificationTokenType.EMAIL_VERIFICATION);
+
+      // el primero quedo consumido/invalidado
+      const firstRow = repo.rows.find((r) => r.tokenHash === hashToken(first.token));
+      expect(firstRow?.isConsumed()).toBe(true);
+      // el primer token ya no sirve para verificar
+      await expect(
+        service.verifyAndConsume(first.token, VerificationTokenType.EMAIL_VERIFICATION),
+      ).rejects.toBeInstanceOf(InvalidTokenError);
+    });
+  });
+
+  describe('verifyAndConsume', () => {
+    // Debería devolver el userId y consumir el token cuando es válido
+    it('should return the userId and consume the token when valid', async () => {
+      const { token } = await service.issue('user-42', VerificationTokenType.EMAIL_VERIFICATION);
+
+      const userId = await service.verifyAndConsume(token, VerificationTokenType.EMAIL_VERIFICATION);
+
+      expect(userId).toBe('user-42');
+      // single-use: un segundo intento falla
+      await expect(
+        service.verifyAndConsume(token, VerificationTokenType.EMAIL_VERIFICATION),
+      ).rejects.toBeInstanceOf(InvalidTokenError);
+    });
+
+    // Debería rechazar un token de otro tipo
+    it('should reject a token of a different type', async () => {
+      const { token } = await service.issue('user-1', VerificationTokenType.EMAIL_VERIFICATION);
+
+      await expect(
+        service.verifyAndConsume(token, VerificationTokenType.PASSWORD_RESET),
+      ).rejects.toBeInstanceOf(InvalidTokenError);
+    });
+
+    // Debería rechazar un token inexistente
+    it('should reject a non-existent token', async () => {
+      await expect(
+        service.verifyAndConsume('does-not-exist', VerificationTokenType.EMAIL_VERIFICATION),
+      ).rejects.toBeInstanceOf(InvalidTokenError);
+    });
+
+    // Debería rechazar un token expirado
+    it('should reject an expired token', async () => {
+      const raw = 'expired-raw-token';
+      repo.seed(
+        new VerificationToken(
+          'id-exp',
+          'user-1',
+          VerificationTokenType.EMAIL_VERIFICATION,
+          hashToken(raw),
+          new Date(Date.now() - 1000),
+          null,
+          null,
+          null,
+          new Date(),
+        ),
+      );
+
+      await expect(
+        service.verifyAndConsume(raw, VerificationTokenType.EMAIL_VERIFICATION),
+      ).rejects.toBeInstanceOf(InvalidTokenError);
+    });
+  });
+});

--- a/tests/unit/auth/DeactivateUser.unit.test.ts
+++ b/tests/unit/auth/DeactivateUser.unit.test.ts
@@ -86,6 +86,7 @@ describe('DeactivateUser Use Case', () => {
       findByEmail: jest.fn(),
       findByEmailWithRole: jest.fn(),
       existsByEmail: jest.fn(),
+      markEmailAsVerified: jest.fn(),
       save: jest.fn(),
       update: jest.fn(),
       delete: jest.fn(),

--- a/tests/unit/auth/RefreshToken.unit.test.ts
+++ b/tests/unit/auth/RefreshToken.unit.test.ts
@@ -45,6 +45,7 @@ describe('RefreshToken Use Case (rotacion + reuse detection)', () => {
       findByEmail: jest.fn(),
       findByEmailWithRole: jest.fn(),
       existsByEmail: jest.fn(),
+      markEmailAsVerified: jest.fn(),
       save: jest.fn(),
       update: jest.fn(),
       delete: jest.fn(),

--- a/tests/unit/auth/VerificationToken.unit.test.ts
+++ b/tests/unit/auth/VerificationToken.unit.test.ts
@@ -1,0 +1,57 @@
+import { VerificationTokenType } from '@prisma/client';
+import { VerificationToken } from '../../../src/modules/auth/domain/entities/VerificationToken';
+
+/**
+ * Tests de la entidad de dominio VerificationToken.
+ *
+ * La entidad no toca la base ni la cripto: solo encapsula las reglas de estado
+ * del token (expiracion, consumo y usabilidad). Por eso alcanza con construirla
+ * a mano y ejercitar sus metodos, sin mocks ni repositorio.
+ */
+
+/**
+ * Helper para construir una entidad valida por default (activa y sin expirar),
+ * permitiendo sobreescribir solo `expiresAt`/`consumedAt`, que son los campos
+ * que gobiernan el estado que queremos probar.
+ */
+const make = (overrides: { expiresAt?: Date; consumedAt?: Date | null } = {}) =>
+  new VerificationToken(
+    'id-1',
+    'user-1',
+    VerificationTokenType.EMAIL_VERIFICATION,
+    'hash',
+    // Por default expira en 60s (futuro) para que el token nazca utilizable
+    overrides.expiresAt ?? new Date(Date.now() + 60_000),
+    overrides.consumedAt ?? null,
+    null,
+    null,
+    new Date(),
+  );
+
+describe('VerificationToken entity', () => {
+  // isExpired debería ser true cuando expiresAt está en el pasado
+  it('isExpired should be true when expiresAt is in the past', () => {
+    expect(make({ expiresAt: new Date(Date.now() - 1000) }).isExpired()).toBe(true);
+  });
+
+  // isExpired debería ser false cuando expiresAt está en el futuro
+  it('isExpired should be false when expiresAt is in the future', () => {
+    expect(make({ expiresAt: new Date(Date.now() + 60_000) }).isExpired()).toBe(false);
+  });
+
+  // isConsumed debería reflejar consumedAt: null = activo, fecha = consumido
+  it('isConsumed should reflect consumedAt', () => {
+    expect(make({ consumedAt: null }).isConsumed()).toBe(false);
+    expect(make({ consumedAt: new Date() }).isConsumed()).toBe(true);
+  });
+
+  // isUsable debería ser true solo cuando no fue consumido ni expiró
+  it('isUsable should be true only when neither consumed nor expired', () => {
+    // Caso feliz: activo y vigente
+    expect(make().isUsable()).toBe(true);
+    // Consumido -> no usable, aunque no haya expirado
+    expect(make({ consumedAt: new Date() }).isUsable()).toBe(false);
+    // Expirado -> no usable, aunque no haya sido consumido
+    expect(make({ expiresAt: new Date(Date.now() - 1000) }).isUsable()).toBe(false);
+  });
+});

--- a/tests/unit/services/StylistServiceUseCases.unit.test.ts
+++ b/tests/unit/services/StylistServiceUseCases.unit.test.ts
@@ -62,6 +62,7 @@ describe('StylistService Use Cases', () => {
       update: jest.fn(),
       delete: jest.fn(),
       existsByEmail: jest.fn(),
+      markEmailAsVerified: jest.fn(),
     };
 
     // Mock de UserRoleValidationService (reemplaza el chequeo manual de rol via IUserRepository

--- a/tests/unit/shared/email/NodemailerEmailService.unit.test.ts
+++ b/tests/unit/shared/email/NodemailerEmailService.unit.test.ts
@@ -1,0 +1,70 @@
+import { Transporter } from 'nodemailer';
+import { NodemailerEmailService } from '../../../../src/shared/email/NodemailerEmailService';
+
+describe('NodemailerEmailService', () => {
+  const makeTransport = () => {
+    const sendMail = jest.fn().mockResolvedValue({ messageId: 'test-id' });
+    const transport = { sendMail } as unknown as Transporter;
+    return { transport, sendMail };
+  };
+
+  it('should send the verification email through the injected transport', async () => {
+    const { transport, sendMail } = makeTransport();
+    const service = new NodemailerEmailService(transport);
+
+    await service.sendVerificationEmail({
+      to: 'user@example.com',
+      name: 'Maria',
+      verificationUrl: 'https://turnity.com/verify-email?token=abc',
+      expiresInHours: 24,
+    });
+
+    expect(sendMail).toHaveBeenCalledTimes(1);
+    expect(sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: 'user@example.com',
+        subject: expect.stringContaining('Verifica'),
+        html: expect.stringContaining('token=abc'),
+        text: expect.stringContaining('token=abc'),
+        from: expect.any(String),
+      }),
+    );
+  });
+
+  it('should send the password reset email through the injected transport', async () => {
+    const { transport, sendMail } = makeTransport();
+    const service = new NodemailerEmailService(transport);
+
+    await service.sendPasswordResetEmail({
+      to: 'user@example.com',
+      name: 'Lucia',
+      resetUrl: 'https://turnity.com/reset-password?token=xyz',
+      expiresInMinutes: 60,
+    });
+
+    expect(sendMail).toHaveBeenCalledTimes(1);
+    expect(sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: 'user@example.com',
+        subject: expect.stringContaining('Recupera'),
+        html: expect.stringContaining('token=xyz'),
+        text: expect.stringContaining('token=xyz'),
+      }),
+    );
+  });
+
+  it('should propagate transport errors (caller decides how to handle them)', async () => {
+    const sendMail = jest.fn().mockRejectedValue(new Error('smtp down'));
+    const transport = { sendMail } as unknown as Transporter;
+    const service = new NodemailerEmailService(transport);
+
+    await expect(
+      service.sendVerificationEmail({
+        to: 'user@example.com',
+        name: 'Maria',
+        verificationUrl: 'https://turnity.com/verify-email?token=abc',
+        expiresInHours: 24,
+      }),
+    ).rejects.toThrow('smtp down');
+  });
+});

--- a/tests/unit/shared/email/NodemailerEmailService.unit.test.ts
+++ b/tests/unit/shared/email/NodemailerEmailService.unit.test.ts
@@ -8,6 +8,7 @@ describe('NodemailerEmailService', () => {
     return { transport, sendMail };
   };
 
+  // Debería enviar el email de verificación a través del transporte inyectado
   it('should send the verification email through the injected transport', async () => {
     const { transport, sendMail } = makeTransport();
     const service = new NodemailerEmailService(transport);
@@ -31,6 +32,7 @@ describe('NodemailerEmailService', () => {
     );
   });
 
+  // Debería enviar el email de reset de password a través del transporte inyectado
   it('should send the password reset email through the injected transport', async () => {
     const { transport, sendMail } = makeTransport();
     const service = new NodemailerEmailService(transport);
@@ -53,6 +55,7 @@ describe('NodemailerEmailService', () => {
     );
   });
 
+  // Debería propagar los errores del transporte (el caller decide cómo manejarlos)
   it('should propagate transport errors (caller decides how to handle them)', async () => {
     const sendMail = jest.fn().mockRejectedValue(new Error('smtp down'));
     const transport = { sendMail } as unknown as Transporter;

--- a/tests/unit/shared/email/templates.unit.test.ts
+++ b/tests/unit/shared/email/templates.unit.test.ts
@@ -1,0 +1,51 @@
+import { renderVerificationEmail } from '../../../../src/shared/email/templates/verifyEmail';
+import { renderPasswordResetEmail } from '../../../../src/shared/email/templates/resetPassword';
+
+describe('email templates', () => {
+  describe('renderVerificationEmail', () => {
+    const ctx = {
+      to: 'user@example.com',
+      name: 'Maria',
+      verificationUrl: 'https://turnity.com/verify-email?token=abc123',
+      expiresInHours: 24,
+    };
+
+    it('should include subject, the verification url and the TTL in both html and text', () => {
+      const { subject, html, text } = renderVerificationEmail(ctx);
+
+      expect(subject).toContain('Turnity');
+      expect(text).toContain(ctx.verificationUrl);
+      expect(text).toContain('24');
+      expect(text).toContain(ctx.name);
+      expect(html).toContain(ctx.verificationUrl);
+      expect(html).toContain('24');
+    });
+
+    it('should escape html-sensitive characters in interpolated values', () => {
+      const { html } = renderVerificationEmail({ ...ctx, name: '<script>x</script>' });
+
+      expect(html).not.toContain('<script>x</script>');
+      expect(html).toContain('&lt;script&gt;');
+    });
+  });
+
+  describe('renderPasswordResetEmail', () => {
+    const ctx = {
+      to: 'user@example.com',
+      name: 'Lucia',
+      resetUrl: 'https://turnity.com/reset-password?token=xyz789',
+      expiresInMinutes: 60,
+    };
+
+    it('should include subject, the reset url and the TTL in both html and text', () => {
+      const { subject, html, text } = renderPasswordResetEmail(ctx);
+
+      expect(subject).toContain('Turnity');
+      expect(text).toContain(ctx.resetUrl);
+      expect(text).toContain('60');
+      expect(text).toContain(ctx.name);
+      expect(html).toContain(ctx.resetUrl);
+      expect(html).toContain('60');
+    });
+  });
+});

--- a/tests/unit/shared/email/templates.unit.test.ts
+++ b/tests/unit/shared/email/templates.unit.test.ts
@@ -10,6 +10,7 @@ describe('email templates', () => {
       expiresInHours: 24,
     };
 
+    // Debería incluir el asunto, la URL de verificación y el TTL tanto en html como en texto
     it('should include subject, the verification url and the TTL in both html and text', () => {
       const { subject, html, text } = renderVerificationEmail(ctx);
 
@@ -21,6 +22,7 @@ describe('email templates', () => {
       expect(html).toContain('24');
     });
 
+    // Debería escapar los caracteres sensibles de html en los valores interpolados
     it('should escape html-sensitive characters in interpolated values', () => {
       const { html } = renderVerificationEmail({ ...ctx, name: '<script>x</script>' });
 
@@ -37,6 +39,7 @@ describe('email templates', () => {
       expiresInMinutes: 60,
     };
 
+    // Debería incluir el asunto, la URL de reset y el TTL tanto en html como en texto
     it('should include subject, the reset url and the TTL in both html and text', () => {
       const { subject, html, text } = renderPasswordResetEmail(ctx);
 

--- a/tests/unit/shared/email/transportFactory.unit.test.ts
+++ b/tests/unit/shared/email/transportFactory.unit.test.ts
@@ -3,6 +3,7 @@ import { createEmailTransport, isRealTransport } from '../../../../src/shared/em
 // NODE_ENV=test se fuerza en tests/setup/jest.setup.ts, asi que el factory
 // debe devolver siempre el transporte mock (jsonTransport), que NO envia mails.
 describe('createEmailTransport (NODE_ENV=test)', () => {
+  // Debería devolver un jsonTransport que no envía emails reales
   it('should return a jsonTransport that does not send real emails', async () => {
     const transport = createEmailTransport();
 
@@ -23,6 +24,7 @@ describe('createEmailTransport (NODE_ENV=test)', () => {
     expect((info as unknown as { message: string }).message).toContain('cuerpo de prueba');
   });
 
+  // isRealTransport debería ser false en test
   it('isRealTransport should be false in test', () => {
     expect(isRealTransport()).toBe(false);
   });

--- a/tests/unit/shared/email/transportFactory.unit.test.ts
+++ b/tests/unit/shared/email/transportFactory.unit.test.ts
@@ -1,0 +1,29 @@
+import { createEmailTransport, isRealTransport } from '../../../../src/shared/email/transportFactory';
+
+// NODE_ENV=test se fuerza en tests/setup/jest.setup.ts, asi que el factory
+// debe devolver siempre el transporte mock (jsonTransport), que NO envia mails.
+describe('createEmailTransport (NODE_ENV=test)', () => {
+  it('should return a jsonTransport that does not send real emails', async () => {
+    const transport = createEmailTransport();
+
+    // El transporte subyacente de nodemailer para jsonTransport se identifica asi
+    expect((transport as unknown as { transporter: { name: string } }).transporter.name).toBe(
+      'JSONTransport',
+    );
+
+    const info = await transport.sendMail({
+      from: 'no-reply@turnity.local',
+      to: 'user@example.com',
+      subject: 'Hola',
+      text: 'cuerpo de prueba',
+    });
+
+    // jsonTransport serializa el mensaje en vez de entregarlo
+    expect(typeof (info as unknown as { message: string }).message).toBe('string');
+    expect((info as unknown as { message: string }).message).toContain('cuerpo de prueba');
+  });
+
+  it('isRealTransport should be false in test', () => {
+    expect(isRealTransport()).toBe(false);
+  });
+});

--- a/tests/unit/shared/env.unit.test.ts
+++ b/tests/unit/shared/env.unit.test.ts
@@ -52,6 +52,11 @@ describe('validateEnv', () => {
         LOG_LEVEL: 'debug',
         JWT_ACCESS_EXPIRY: '1h',
         FRONTEND_URL: 'https://turnity.com',
+        // MAIL_* son obligatorias cuando NODE_ENV=production (superRefine)
+        MAIL_HOST: 'smtp.turnity.com',
+        MAIL_USER: 'noreply@turnity.com',
+        MAIL_PASSWORD: 'secret',
+        MAIL_FROM: 'noreply@turnity.com',
       });
 
       expect(result.NODE_ENV).toBe('production');
@@ -64,6 +69,28 @@ describe('validateEnv', () => {
 
   // con variables requeridas faltantes o inválidas
   describe('with missing or invalid required variables', () => {
+    // Debería llamar a process.exit(1) si faltan las MAIL_* en produccion
+    it('should call process.exit(1) if MAIL_* are missing in production', () => {
+      validateEnv({ ...validEnv, NODE_ENV: 'production' });
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    // Debería llamar a process.exit(1) si EXPOSE_VERIFICATION_TOKENS es true en produccion
+    it('should call process.exit(1) if EXPOSE_VERIFICATION_TOKENS is true in production', () => {
+      validateEnv({
+        ...validEnv,
+        NODE_ENV: 'production',
+        MAIL_HOST: 'smtp.turnity.com',
+        MAIL_USER: 'noreply@turnity.com',
+        MAIL_PASSWORD: 'secret',
+        MAIL_FROM: 'noreply@turnity.com',
+        EXPOSE_VERIFICATION_TOKENS: 'true',
+      });
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
     // Debería llamar a process.exit(1) si falta JWT_ACCESS_SECRET
     it('should call process.exit(1) if JWT_ACCESS_SECRET is missing', () => {
       const { JWT_ACCESS_SECRET, ...rest } = validEnv;

--- a/tests/unit/shared/opaqueToken.unit.test.ts
+++ b/tests/unit/shared/opaqueToken.unit.test.ts
@@ -1,0 +1,30 @@
+import { generateOpaqueToken, hashToken } from '../../../src/shared/crypto/opaqueToken';
+
+describe('opaqueToken', () => {
+  describe('generateOpaqueToken', () => {
+    // Debería generar tokens url-safe (base64url)
+    it('should generate url-safe (base64url) tokens', () => {
+      const token = generateOpaqueToken();
+      expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+    });
+
+    // Debería generar un token distinto en cada llamada
+    it('should generate a different token on each call', () => {
+      expect(generateOpaqueToken()).not.toBe(generateOpaqueToken());
+    });
+  });
+
+  describe('hashToken', () => {
+    // Debería ser determinístico (mismo input -> mismo hash)
+    it('should be deterministic (same input -> same hash)', () => {
+      expect(hashToken('abc')).toBe(hashToken('abc'));
+    });
+
+    // Debería producir un SHA-256 hex de 64 caracteres distinto del input
+    it('should produce a 64-char hex SHA-256 that differs from the input', () => {
+      const hash = hashToken('some-opaque-token');
+      expect(hash).toMatch(/^[a-f0-9]{64}$/);
+      expect(hash).not.toBe('some-opaque-token');
+    });
+  });
+});


### PR DESCRIPTION
## Resumen
 
Habilita el registro público seguro en Turnity: verificación de email tras el registro y recuperación de contraseña por email, cableando el envío real de correos con nodemailer. La feature reutiliza el patrón de tokens opacos ya presente en las sesiones de refresh (opaco entregado al usuario, solo el hash SHA-256 persistido, single-use + expiración).
 
Implementado en 7 fases, cada una en su propio conjunto de commits y con tests verdes.
 
## Qué incluye
 
**Datos y config**
- `User.emailVerified` / `emailVerifiedAt` + nuevo modelo `VerificationToken` (`type: EMAIL_VERIFICATION | PASSWORD_RESET`).
- Migración aditiva y reversible con backfill (los usuarios previos quedan verificados; los nuevos entran sin verificar).
- `env.ts` valida `MAIL_*` (obligatorias en producción, opcionales en dev/test), TTLs y flags.
**EmailService (nodemailer)**
- Puerto `EmailService` en `shared/email` + adapter `NodemailerEmailService`.
- Transporte por entorno: mock (`jsonTransport`) en test y en dev sin SMTP, SMTP real en prod.
- Plantillas HTML + texto para verificación y reset (con escape de HTML).
**Tokens de verificación / reset**
- Entidad `VerificationToken`, repo Prisma y `VerificationTokenService` (`issue` / `verifyAndConsume`).
- Helper cripto compartido `opaqueToken` (256 bits + SHA-256), sin tocar el servicio de sesión existente.
- Al emitir un token nuevo se invalidan los previos del mismo `(userId, type)`.
**Flujos**
- Registro emite token + envía email (best-effort: el registro no falla si el envío falla).
- Verificación de email + reenvío (anti-enumeración, rate limited).
- Login bloqueado (`403 EMAIL_NOT_VERIFIED`) si el email no está verificado, gateado por `REQUIRE_EMAIL_VERIFICATION`.
- Forgot / reset password (anti-enumeración, reutiliza las reglas de fuerza de password; el reset **revoca todas las sesiones**).
## Endpoints nuevos (públicos)
 
| Método | Path | Descripción |
|---|---|---|
| `POST` | `/api/v1/auth/verify-email` | Verifica el email con el token del enlace |
| `POST` | `/api/v1/auth/resend-verification` | Reenvía la verificación (anti-enum, rate limited) |
| `POST` | `/api/v1/auth/forgot-password` | Solicita el reset (anti-enum, rate limited) |
| `POST` | `/api/v1/auth/reset-password` | Aplica la nueva contraseña y revoca sesiones |
 
`POST /register` y `POST /login` quedan modificados (emisión de token / gating), manteniendo su contrato.
 
## Base de datos
 
- 1 migración aditiva: columnas en `User` + tabla `VerificationToken` (índices y FK con `onDelete: Cascade`).
- Backfill idempotente; reversible por drops. Seed siembra los usuarios con `emailVerified=true`.
## Configuración (env)
 
Nuevas: `MAIL_HOST/PORT/USER/PASSWORD/FROM/SECURE`, `EMAIL_VERIFICATION_TOKEN_TTL_HOURS` (24), `PASSWORD_RESET_TOKEN_TTL_MINUTES` (60), `REQUIRE_EMAIL_VERIFICATION` (true), `EXPOSE_VERIFICATION_TOKENS` (false, **prohibido en producción**). Documentadas en `.env.example` y en el CI.
 
## Seguridad
 
- Tokens opacos de alta entropía; en la base solo el hash SHA-256. Single-use + expiración corta.
- Anti-enumeración de usuarios (misma respuesta) en forgot-password y resend-verification.
- El reset de password revoca todas las sesiones activas.
- El gating de login se evalúa **después** de validar credenciales (no filtra el estado de verificación).
- `EXPOSE_VERIFICATION_TOKENS` con doble guarda: `env.ts` falla el boot si se activa en producción.
## Tests
 
- Unit: EmailService (factory, plantillas, adapter), tokens (helper cripto, entidad, service), env.
- Integración: verify-email, resend, forgot, reset, gating de login.
- E2E: register → verify → login → profile; forgot → reset → login; register → resend → verify → login.
- Suite completa en verde (unit + integración + e2e). En test no se envían mails reales.
## Notas / deuda conocida
 
- Rate limiters con store en memoria (sirve para una instancia; migrar a store distribuido queda pendiente para multi-instancia).
- Sin frontend todavía: en dev/test el token se expone como `devToken` para poder probar por API/Postman.