### PR TITLE
feat: despliegue a produccion reproducible (Docker, CD y health checks)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,7 @@ dist
 *.md
 docker-compose*
 Dockerfile*
+tests
+coverage
+logs
+.github

--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,11 @@ DB_DATABASE=turnity
 # Database URL (Alternative connection string) | Cadena de coneccion a la base de datos
 DATABASE_URL="postgresql://username:password@host:port/database?schema=public"
 
+# DIRECT_URL: conexion directa para prisma migrate/db push (ver comentario en
+# schema.prisma). En local, contra el Postgres de docker-compose.dev.yml (sin
+# pooler), puede ser identica a DATABASE_URL.
+DIRECT_URL="postgresql://username:password@host:port/database?schema=public"
+
 # Test Database URL (usada solo por Jest, ver tests/setup/jest.setup.ts) | Base de datos separada para tests, nunca la misma que DATABASE_URL
 TEST_DATABASE_URL="postgresql://username:password@host:port/database_test?schema=public"
 

--- a/.env.production.example
+++ b/.env.production.example
@@ -31,6 +31,15 @@ POSTGRES_DB=turnity_prod
 # usando las MISMAS credenciales de las tres variables de arriba.
 DATABASE_URL=postgresql://turnity_prod:cambiar-esta-clave@db:5432/turnity_prod?schema=public
 
+# DIRECT_URL: conexion directa para prisma migrate deploy (lo usa el servicio
+# "migrate"). El Postgres de este compose no tiene pooler -- misma URL que
+# DATABASE_URL. IMPORTANTE: en Render, con Neon como base, esto NO es igual a
+# DATABASE_URL -- Neon da dos connection strings distintos (uno "pooled" con
+# "-pooler" en el host para DATABASE_URL, y uno "direct" sin "-pooler" para
+# DIRECT_URL). Sin esta separacion, el Pre-Deploy Command de Render
+# (prisma migrate deploy) falla contra el pooler de Neon.
+DIRECT_URL=postgresql://turnity_prod:cambiar-esta-clave@db:5432/turnity_prod?schema=public
+
 # --- JWT ---------------------------------------------------------------------
 JWT_ACCESS_SECRET=cambiar-por-una-clave-de-al-menos-32-caracteres
 JWT_REFRESH_SECRET=cambiar-por-otra-clave-de-al-menos-32-caracteres

--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,68 @@
+# =============================================================================
+# .env.production.example
+# =============================================================================
+# Plantilla para .env.production -- usado SOLO por el docker-compose.yml de
+# referencia local (self-hosted) de este repo, para validar la imagen de
+# produccion antes de pushear.
+#
+# Esto NO es lo que usa Render: alli las mismas variables de la app (todo
+# menos las de POSTGRES_* de mas abajo, que son solo del Postgres de este
+# compose local) se cargan directo en el dashboard de Render, no desde
+# ningun archivo.
+#
+# Uso: copiar este archivo a .env.production y completar con valores reales
+# o de prueba. .env.production esta en .gitignore -- nunca commitear ese
+# archivo con valores reales, y nunca reusar aqui los secretos reales de
+# Render/produccion (esto corre en tu maquina, no hace falta que sean los
+# mismos).
+
+NODE_ENV=production
+PORT=3000
+
+# --- Postgres del contenedor local (servicio "db" de este compose) --------
+# Solo los usa ese servicio. Render no usa esto -- ahi la base es Neon,
+# gestionada aparte y con su propia connection string.
+POSTGRES_USER=turnity_prod
+POSTGRES_PASSWORD=cambiar-esta-clave
+POSTGRES_DB=turnity_prod
+
+# DATABASE_URL: debe apuntar al servicio "db" de este mismo compose (host
+# "db", puerto 5432 -- se resuelven por nombre dentro de la red de Docker),
+# usando las MISMAS credenciales de las tres variables de arriba.
+DATABASE_URL=postgresql://turnity_prod:cambiar-esta-clave@db:5432/turnity_prod?schema=public
+
+# --- JWT ---------------------------------------------------------------------
+JWT_ACCESS_SECRET=cambiar-por-una-clave-de-al-menos-32-caracteres
+JWT_REFRESH_SECRET=cambiar-por-otra-clave-de-al-menos-32-caracteres
+JWT_ACCESS_EXPIRY=15m
+REFRESH_TOKEN_TTL_DAYS=7
+
+# --- Cookies de autenticacion (refresh httpOnly + CSRF) -----------------------
+# COOKIE_SECURE=true requiere HTTPS -- probando solo local por HTTP, poner
+# false aca (a diferencia de Render, donde SI va true).
+COOKIE_SECURE=false
+COOKIE_SAMESITE=lax
+COOKIE_DOMAIN=
+
+# --- CORS ----------------------------------------------------------------
+FRONTEND_URL=http://localhost:5173
+
+# --- Mail / SMTP ---------------------------------------------------------
+# Obligatorias en produccion: env.ts aborta el boot si faltan (NODE_ENV=
+# production mas arriba). Podes apuntar a un SMTP real de prueba o a uno
+# que trague todo (ej. Mailtrap) para no mandar mails reales al validar.
+MAIL_HOST=smtp.tu-proveedor.com
+MAIL_PORT=587
+MAIL_USER=tu-email@ejemplo.com
+MAIL_PASSWORD=tu-clave-de-mail
+MAIL_FROM=noreply@turnity.com
+MAIL_SECURE=false
+
+# --- Verificacion de email / reset de password --------------------------------
+EMAIL_VERIFICATION_TOKEN_TTL_HOURS=24
+PASSWORD_RESET_TOKEN_TTL_MINUTES=60
+REQUIRE_EMAIL_VERIFICATION=true
+
+# NUNCA en true con NODE_ENV=production -- env.ts aborta el boot si lo
+# detecta (doble guarda, ya lo probamos en la Fase 0/F2).
+EXPOSE_VERIFICATION_TOKENS=false

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,95 @@
+name: CD
+
+# Se dispara cuando el workflow "CI" (ci.yml) termina en la rama main --
+# no en cada push, y no en PRs. Asi el build+push de la imagen y el
+# deploy solo pasan si el commit ya paso lint/build/tests en CI.
+on:
+  workflow_run:
+    workflows: ['CI']
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    name: Build y publicar imagen en GHCR
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Checkout del commit que paso el CI
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Login a GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Los nombres de imagen OCI/Docker tienen que ser todo minuscula --
+      # github.repository preserva mayusculas (FernandoAMoyano/Ty-backend),
+      # asi que se normaliza antes de armar el tag.
+      - name: Nombre de imagen en minuscula
+        id: image
+        run: echo "name=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      # Build del stage "runtime" del Dockerfile (Fase 1) -- la misma
+      # imagen que se valido localmente con docker-compose.yml (Fase 3).
+      # Se taggea :latest (la que Render sigue) + :sha-<commit completo>
+      # (inmutable, para poder volver atras a un commit puntual).
+      - name: Build y push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: runtime
+          push: true
+          tags: |
+            ghcr.io/${{ steps.image.outputs.name }}:latest
+            ghcr.io/${{ steps.image.outputs.name }}:sha-${{ github.event.workflow_run.head_sha }}
+
+  deploy:
+    name: Deploy a Render
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    # El contexto "secrets" no esta permitido dentro de "if:" (solo en
+    # env/with/run) -- por eso se vuelcan a variables de entorno del job
+    # aqui, y los "if:" de abajo comparan contra "env.*" en vez de
+    # "secrets.*" directamente.
+    env:
+      RENDER_DEPLOY_HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
+      RENDER_APP_URL: ${{ secrets.RENDER_APP_URL }}
+    steps:
+      # Condicionado a que el secret exista: la primera vez que corre este
+      # workflow (antes de crear el servicio en Render) todavia no hay
+      # Deploy Hook -- el build+push de arriba igual se completa, y este
+      # step se saltea en vez de fallar.
+      - name: Disparar el Deploy Hook de Render
+        if: ${{ env.RENDER_DEPLOY_HOOK_URL != '' }}
+        run: curl -fsS -X POST "$RENDER_DEPLOY_HOOK_URL"
+
+      # Espera hasta 5 minutos a que la nueva version quede realmente
+      # operativa (no solo "arrancada") -- pega a /ready, que consulta la
+      # base de verdad (Fase 2).
+      - name: Esperar a que /ready responda 200
+        if: ${{ env.RENDER_DEPLOY_HOOK_URL != '' && env.RENDER_APP_URL != '' }}
+        run: |
+          for i in $(seq 1 20); do
+            if curl -fsS "$RENDER_APP_URL/ready"; then
+              echo ""
+              echo "La app respondio /ready correctamente."
+              exit 0
+            fi
+            echo "Intento $i/20: todavia no responde, esperando 15s..."
+            sleep 15
+          done
+          echo "Se agoto el tiempo de espera sin que /ready respondiera 200."
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       DB_PASSWORD: turnity_ci
       DB_DATABASE: turnity_ci
       DATABASE_URL: postgresql://turnity_ci:turnity_ci@localhost:5432/turnity_ci?schema=public
+      # Sin pooler en el Postgres de CI -- misma URL que DATABASE_URL. Ver
+      # comentario en schema.prisma / .env.production.example (F3).
+      DIRECT_URL: postgresql://turnity_ci:turnity_ci@localhost:5432/turnity_ci?schema=public
       TEST_DATABASE_URL: postgresql://turnity_ci:turnity_ci@localhost:5432/turnity_ci?schema=public
       JWT_ACCESS_SECRET: ci_access_secret_for_testing_only
       JWT_REFRESH_SECRET: ci_refresh_secret_for_testing_only

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,3 +90,9 @@ jobs:
 
       - name: Run test suite
         run: npm test -- --coverage
+
+      # Sanity check de la imagen de produccion (F3): sin push, solo
+      # confirma que el Dockerfile sigue buildeando -- detecta un Dockerfile
+      # roto en el PR, en vez de recien en el deploy (cd.yml).
+      - name: Docker build sanity check (imagen de produccion)
+        run: docker build --target runtime -t turnity-backend:ci .

--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,10 @@ web_modules/
 .env.production.local
 .env.local
 
+# .env.production: usado por el docker-compose.yml de referencia local (F3).
+# Contiene secretos reales (aunque sean de prueba) -- nunca commitear.
+.env.production
+
 # parcel-bundler cache (https://parceljs.org/)
 .cache
 .parcel-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,74 @@
+# syntax=docker/dockerfile:1
+
+# ---------------------------------------------------------------------------
+# Stage 1: builder
+# Instala TODAS las dependencias (incl. devDependencies, necesarias para
+# tsc/prisma generate), genera el cliente de Prisma y compila a dist/.
+# ---------------------------------------------------------------------------
+FROM node:20-alpine AS builder
+
+# openssl/libstdc++/libc6-compat: requeridos por el motor de Prisma en Alpine
+# (mismo paquete que ya usa Dockerfile.dev).
+RUN apk add --no-cache openssl libstdc++ libc6-compat
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+# .dockerignore excluye node_modules/dist/tests/coverage/logs/.git/.env, asi
+# que este COPY no pisa lo instalado arriba ni arrastra artefactos locales.
+COPY . .
+
+RUN npx prisma generate
+
+# Build de solo src/ (sin tests/ ni prisma/), ver tsconfig.build.json.
+# Genera dist/server.js -- coincide con el "start" de package.json.
+RUN npm run build:prod
+
+# ---------------------------------------------------------------------------
+# Stage 2: runtime
+# Imagen final que corre 24/7. Sin devDependencies, sin tests, sin codigo
+# fuente TS. Incluye el CLI de prisma (ahora en "dependencies") porque el
+# Pre-Deploy Command de Render corre "npx prisma migrate deploy" dentro de
+# esta misma imagen.
+# ---------------------------------------------------------------------------
+FROM node:20-alpine AS runtime
+
+RUN apk add --no-cache openssl libstdc++ libc6-compat
+
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+# Motor de Prisma ya generado en el builder (evita depender de que el
+# postinstall de @prisma/client encuentre el schema en este punto).
+COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
+
+COPY --from=builder /app/dist ./dist
+
+# Solo schema + migrations: ni seed.ts ni seedGuard.ts viajan a produccion
+# (el seed no debe poder correr ahi ni por accidente).
+COPY --from=builder /app/prisma/schema.prisma ./prisma/schema.prisma
+COPY --from=builder /app/prisma/migrations ./prisma/migrations
+
+# src/shared/logger/logger.ts crea/escribe en ./logs al importarse (siempre,
+# salvo NODE_ENV=test). El resto de /app (node_modules, dist, prisma) el
+# proceso solo lo LEE -- los permisos por defecto (root:root, 644/755) ya
+# alcanzan para que el usuario no-root pueda leerlos, no hace falta un
+# chown -R sobre todo node_modules (con miles de archivos, eso agregaba
+# ~3-4 min al build). Solo logs/ necesita ser escribible por "node".
+# Nota: en Render (filesystem efimero en el free tier) esos archivos se
+# pierden en cada restart/redeploy; el log que persiste es el de stdout,
+# que Render si captura.
+RUN mkdir -p logs && chown node:node logs
+USER node
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD node -e "require('http').get('http://localhost:'+(process.env.PORT||3000)+'/health',res=>{process.exit(res.statusCode===200?0:1)}).on('error',()=>process.exit(1))"
+
+CMD ["node", "dist/server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,89 @@
+# docker-compose.yml -- REFERENCIA LOCAL / self-hosted.
+#
+# Esto NO es lo que usa el deploy real (Render + Neon, ver Fase 4). Render
+# corre la imagen "runtime" del Dockerfile directamente, con su propio
+# Pre-Deploy Command (prisma migrate deploy) y su propia base (Neon) -- no
+# levanta este compose en ningun lado.
+#
+# Para que sirve entonces:
+#   - Validar de punta a punta, en tu maquina, que la imagen de produccion
+#     funciona (build -> migrate -> api) antes de pushear.
+#   - Dejar documentado un camino self-hosted alternativo si en el futuro
+#     hiciera falta correr esto fuera de un PaaS.
+#
+# Variables: todas se leen desde .env.production (no versionado). Copiar
+# .env.production.example a .env.production y completar. NUNCA reusar ahi
+# los secretos reales de Render/produccion.
+
+# Nombre de proyecto propio: por defecto Compose usa el nombre de la carpeta
+# como "proyecto", y como docker-compose.dev.yml corre en la misma carpeta,
+# sin esto Compose trata a los contenedores de dev y de este compose como
+# parte del mismo proyecto -- y reinicia los de dev al levantar este.
+name: turnity-backend-prod-local
+
+services:
+  db:
+    image: postgres:14-alpine
+    container_name: turnity-db-prod-local
+    restart: unless-stopped
+    env_file:
+      - .env.production
+    volumes:
+      - postgres_data_prod_local:/var/lib/postgresql/data
+    healthcheck:
+      # $$POSTGRES_USER (con doble $$) se resuelve DENTRO del contenedor,
+      # leyendo la variable que el propio env_file ya inyecto -- no es
+      # sustitucion de docker-compose, evita que este valor se desincronice
+      # de lo que de verdad tiene .env.production.
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - turnity-network-prod-local
+
+  # Job de un solo uso: aplica las migraciones antes de levantar la api.
+  # Mismo patron "release phase" que el Pre-Deploy Command de Render (ver
+  # decision 2b del plan) -- separado del servicio api a proposito, para
+  # que las migraciones nunca corran desde cada replica de la app.
+  migrate:
+    build:
+      context: .
+      target: runtime
+    container_name: turnity-migrate-prod-local
+    env_file:
+      - .env.production
+    command: ['npx', 'prisma', 'migrate', 'deploy']
+    depends_on:
+      db:
+        condition: service_healthy
+    networks:
+      - turnity-network-prod-local
+    restart: 'no'
+
+  api:
+    build:
+      context: .
+      target: runtime
+    container_name: turnity-api-prod-local
+    restart: unless-stopped
+    env_file:
+      - .env.production
+    # 3001 en el host (no 3000) para poder correr esto a la vez que
+    # docker-compose.dev.yml sin que compitan por el mismo puerto.
+    ports:
+      - '3001:3000'
+    depends_on:
+      db:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    networks:
+      - turnity-network-prod-local
+
+networks:
+  turnity-network-prod-local:
+    driver: bridge
+
+volumes:
+  postgres_data_prod_local:

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "multer": "^1.4.5-lts.2",
         "nodemailer": "^9.0.1",
         "pg": "^8.15.6",
+        "prisma": "^6.19.3",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1",
         "uuid": "^11.1.0",
@@ -54,7 +55,6 @@
         "eslint-config-prettier": "^10.1.5",
         "jest": "^30.4.2",
         "prettier": "^3.5.3",
-        "prisma": "^6.19.3",
         "supertest": "^7.1.0",
         "ts-jest": "^29.4.11",
         "tsx": "^4.20.1",
@@ -2993,7 +2993,6 @@
       "version": "6.19.3",
       "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.3.tgz",
       "integrity": "sha512-CBPT44BjlQxEt8kiMEauji2WHTDoVBOKl7UlewXmUgBPnr/oPRZC3psci5chJnYmH0ivEIog2OU9PGWoki3DLQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "c12": "3.1.0",
@@ -3006,14 +3005,12 @@
       "version": "6.19.3",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.3.tgz",
       "integrity": "sha512-ljkJ+SgpXNktLG0Q/n4JGYCkKf0f8oYLyjImS2I8e2q2WCfdRRtWER062ZV/ixaNP2M2VKlWXVJiGzZaUgbKZw==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
       "version": "6.19.3",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.19.3.tgz",
       "integrity": "sha512-RSYxtlYFl5pJ8ZePgMv0lZ9IzVCOdTPOegrs2qcbAEFrBI1G33h6wyC9kjQvo0DnYEhEVY0X4LsuFHXLKQk88g==",
-      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3027,14 +3024,12 @@
       "version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7.tgz",
       "integrity": "sha512-03bgb1VD5gvuumNf+7fVGBzfpJPjmqV423l/WxsWk2cNQ42JD0/SsFBPhN6z8iAvdHs07/7ei77SKu7aZfq8bA==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
       "version": "6.19.3",
       "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.19.3.tgz",
       "integrity": "sha512-tKtl/qco9Nt7LU5iKhpultD8O4vMCZcU2CHjNTnRrL1QvSUr5W/GcyFPjNL87GtRrwBc7ubXXD9xy4EvLvt8JA==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "6.19.3",
@@ -3046,7 +3041,6 @@
       "version": "6.19.3",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.19.3.tgz",
       "integrity": "sha512-xFj1VcJ1N3MKooOQAGO0W5tsd0W2QzIvW7DD7c/8H14Zmp4jseeWAITm+w2LLoLrlhoHdPPh0NMZ8mfL6puoHA==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "6.19.3"
@@ -3099,7 +3093,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
@@ -4366,9 +4359,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -4479,7 +4472,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
       "integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.3",
@@ -4607,7 +4599,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -4638,7 +4629,6 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
       "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "consola": "^3.2.3"
@@ -4805,14 +4795,12 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
       "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/consola": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
       "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
@@ -4965,7 +4953,6 @@
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
       "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
-      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16.0.0"
@@ -4975,7 +4962,6 @@
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
       "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/delayed-stream": {
@@ -4999,7 +4985,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
       "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/detect-newline": {
@@ -5091,7 +5076,6 @@
       "version": "3.21.0",
       "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.0.tgz",
       "integrity": "sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -5129,7 +5113,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
       "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -5582,14 +5565,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
       "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/fast-check": {
       "version": "3.23.2",
       "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
       "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
-      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -5632,9 +5613,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -5975,7 +5956,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
       "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "citty": "^0.1.6",
@@ -6271,9 +6251,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -8865,7 +8845,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -9447,7 +9426,6 @@
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/node-gyp-build": {
@@ -9513,7 +9491,6 @@
       "version": "0.6.7",
       "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.7.tgz",
       "integrity": "sha512-s3ds97SD5pd1dULE+tHUk1DrV0cSHOnsfpcdGATJ8JpBo21DoKqN9exTH4/2nhPQNOLomBdTFMicN94S4DrZrQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "citty": "^0.2.2",
@@ -9531,7 +9508,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
       "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/object-assign": {
@@ -9557,7 +9533,6 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/on-finished": {
@@ -9785,14 +9760,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
       "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/pg": {
@@ -9978,7 +9951,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
       "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "confbox": "^0.2.4",
@@ -10075,7 +10047,6 @@
       "version": "6.19.3",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.3.tgz",
       "integrity": "sha512-++ZJ0ijLrDJF6hNB4t4uxg2br3fC4H9Yc9tcbjr2fcNFP3rh/SBNrAgjhsqBU4Ght8JPrVofG/ZkXfnSfnYsFg==",
-      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -10127,7 +10098,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
       "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
-      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -10202,7 +10172,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
       "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "defu": "^6.1.4",
@@ -10254,7 +10223,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -11000,7 +10968,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
       "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -11757,7 +11724,7 @@
           "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
           "requires": {
             "fast-deep-equal": "^3.1.3",
-            "fast-uri": "^3.0.1",
+            "fast-uri": "^3.1.5",
             "json-schema-traverse": "^1.0.0",
             "require-from-string": "^2.0.2"
           }
@@ -13293,7 +13260,7 @@
           "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^5.0.8"
+            "brace-expansion": "^5.0.9"
           }
         },
         "picomatch": {
@@ -13646,7 +13613,6 @@
       "version": "6.19.3",
       "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.3.tgz",
       "integrity": "sha512-CBPT44BjlQxEt8kiMEauji2WHTDoVBOKl7UlewXmUgBPnr/oPRZC3psci5chJnYmH0ivEIog2OU9PGWoki3DLQ==",
-      "devOptional": true,
       "requires": {
         "c12": "3.1.0",
         "deepmerge-ts": "7.1.5",
@@ -13657,14 +13623,12 @@
     "@prisma/debug": {
       "version": "6.19.3",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.3.tgz",
-      "integrity": "sha512-ljkJ+SgpXNktLG0Q/n4JGYCkKf0f8oYLyjImS2I8e2q2WCfdRRtWER062ZV/ixaNP2M2VKlWXVJiGzZaUgbKZw==",
-      "devOptional": true
+      "integrity": "sha512-ljkJ+SgpXNktLG0Q/n4JGYCkKf0f8oYLyjImS2I8e2q2WCfdRRtWER062ZV/ixaNP2M2VKlWXVJiGzZaUgbKZw=="
     },
     "@prisma/engines": {
       "version": "6.19.3",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.19.3.tgz",
       "integrity": "sha512-RSYxtlYFl5pJ8ZePgMv0lZ9IzVCOdTPOegrs2qcbAEFrBI1G33h6wyC9kjQvo0DnYEhEVY0X4LsuFHXLKQk88g==",
-      "devOptional": true,
       "requires": {
         "@prisma/debug": "6.19.3",
         "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
@@ -13675,14 +13639,12 @@
     "@prisma/engines-version": {
       "version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7.tgz",
-      "integrity": "sha512-03bgb1VD5gvuumNf+7fVGBzfpJPjmqV423l/WxsWk2cNQ42JD0/SsFBPhN6z8iAvdHs07/7ei77SKu7aZfq8bA==",
-      "devOptional": true
+      "integrity": "sha512-03bgb1VD5gvuumNf+7fVGBzfpJPjmqV423l/WxsWk2cNQ42JD0/SsFBPhN6z8iAvdHs07/7ei77SKu7aZfq8bA=="
     },
     "@prisma/fetch-engine": {
       "version": "6.19.3",
       "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.19.3.tgz",
       "integrity": "sha512-tKtl/qco9Nt7LU5iKhpultD8O4vMCZcU2CHjNTnRrL1QvSUr5W/GcyFPjNL87GtRrwBc7ubXXD9xy4EvLvt8JA==",
-      "devOptional": true,
       "requires": {
         "@prisma/debug": "6.19.3",
         "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
@@ -13693,7 +13655,6 @@
       "version": "6.19.3",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.19.3.tgz",
       "integrity": "sha512-xFj1VcJ1N3MKooOQAGO0W5tsd0W2QzIvW7DD7c/8H14Zmp4jseeWAITm+w2LLoLrlhoHdPPh0NMZ8mfL6puoHA==",
-      "devOptional": true,
       "requires": {
         "@prisma/debug": "6.19.3"
       }
@@ -13739,8 +13700,7 @@
     "@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "devOptional": true
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="
     },
     "@tybys/wasm-util": {
       "version": "0.10.2",
@@ -14200,7 +14160,7 @@
           "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^5.0.8"
+            "brace-expansion": "^5.0.9"
           }
         }
       }
@@ -14624,9 +14584,9 @@
       }
     },
     "brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "requires": {
         "balanced-match": "^4.0.2"
       }
@@ -14698,7 +14658,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
       "integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
-      "devOptional": true,
       "requires": {
         "chokidar": "^4.0.3",
         "confbox": "^0.2.2",
@@ -14775,7 +14734,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "devOptional": true,
       "requires": {
         "readdirp": "^4.0.1"
       }
@@ -14790,7 +14748,6 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
       "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
-      "devOptional": true,
       "requires": {
         "consola": "^3.2.3"
       }
@@ -14912,14 +14869,12 @@
     "confbox": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
-      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
-      "devOptional": true
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ=="
     },
     "consola": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
-      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
-      "devOptional": true
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="
     },
     "content-disposition": {
       "version": "1.0.0",
@@ -15024,14 +14979,12 @@
     "deepmerge-ts": {
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
-      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
-      "devOptional": true
+      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw=="
     },
     "defu": {
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
-      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
-      "devOptional": true
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -15047,8 +15000,7 @@
     "destr": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
-      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
-      "devOptional": true
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -15118,7 +15070,6 @@
       "version": "3.21.0",
       "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.0.tgz",
       "integrity": "sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==",
-      "devOptional": true,
       "requires": {
         "@standard-schema/spec": "^1.0.0",
         "fast-check": "^3.23.1"
@@ -15145,8 +15096,7 @@
     "empathic": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
-      "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
-      "devOptional": true
+      "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA=="
     },
     "enabled": {
       "version": "2.0.0",
@@ -15449,7 +15399,7 @@
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
       "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "requires": {
-        "ip-address": "^10.2.0"
+        "ip-address": "^10.3.1"
       }
     },
     "express-validator": {
@@ -15464,14 +15414,12 @@
     "exsolve": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
-      "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
-      "devOptional": true
+      "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw=="
     },
     "fast-check": {
       "version": "3.23.2",
       "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
       "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
-      "devOptional": true,
       "requires": {
         "pure-rand": "^6.1.0"
       }
@@ -15500,9 +15448,9 @@
       "dev": true
     },
     "fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="
     },
     "fastq": {
       "version": "1.19.1",
@@ -15737,7 +15685,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
       "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
-      "devOptional": true,
       "requires": {
         "citty": "^0.1.6",
         "consola": "^3.4.0",
@@ -15928,9 +15875,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ=="
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -16511,7 +16458,7 @@
           "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^5.0.8"
+            "brace-expansion": "^5.0.9"
           }
         },
         "picomatch": {
@@ -17288,7 +17235,7 @@
           "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^5.0.8"
+            "brace-expansion": "^5.0.9"
           }
         },
         "picomatch": {
@@ -17722,8 +17669,7 @@
     "jiti": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
-      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "devOptional": true
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -18026,7 +17972,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "requires": {
-        "brace-expansion": "^5.0.8"
+        "brace-expansion": "^5.0.9"
       }
     },
     "minimist": {
@@ -18153,8 +18099,7 @@
     "node-fetch-native": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
-      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
-      "devOptional": true
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="
     },
     "node-gyp-build": {
       "version": "4.8.4",
@@ -18197,7 +18142,6 @@
       "version": "0.6.7",
       "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.7.tgz",
       "integrity": "sha512-s3ds97SD5pd1dULE+tHUk1DrV0cSHOnsfpcdGATJ8JpBo21DoKqN9exTH4/2nhPQNOLomBdTFMicN94S4DrZrQ==",
-      "devOptional": true,
       "requires": {
         "citty": "^0.2.2",
         "pathe": "^2.0.3",
@@ -18207,8 +18151,7 @@
         "citty": {
           "version": "0.2.2",
           "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
-          "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
-          "devOptional": true
+          "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w=="
         }
       }
     },
@@ -18225,8 +18168,7 @@
     "ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
-      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-      "devOptional": true
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="
     },
     "on-finished": {
       "version": "2.4.1",
@@ -18383,14 +18325,12 @@
     "pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "devOptional": true
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="
     },
     "perfect-debounce": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
-      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
-      "devOptional": true
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA=="
     },
     "pg": {
       "version": "8.15.6",
@@ -18522,7 +18462,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
       "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
-      "devOptional": true,
       "requires": {
         "confbox": "^0.2.4",
         "exsolve": "^1.0.8",
@@ -18587,7 +18526,6 @@
       "version": "6.19.3",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.3.tgz",
       "integrity": "sha512-++ZJ0ijLrDJF6hNB4t4uxg2br3fC4H9Yc9tcbjr2fcNFP3rh/SBNrAgjhsqBU4Ght8JPrVofG/ZkXfnSfnYsFg==",
-      "devOptional": true,
       "requires": {
         "@prisma/config": "6.19.3",
         "@prisma/engines": "6.19.3"
@@ -18616,8 +18554,7 @@
     "pure-rand": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
-      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
-      "devOptional": true
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="
     },
     "qs": {
       "version": "6.15.2",
@@ -18653,7 +18590,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
       "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
-      "devOptional": true,
       "requires": {
         "defu": "^6.1.4",
         "destr": "^2.0.3"
@@ -18701,8 +18637,7 @@
     "readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "devOptional": true
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="
     },
     "require-directory": {
       "version": "2.1.1",
@@ -19129,7 +19064,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
           "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
           "requires": {
-            "brace-expansion": "^5.0.8"
+            "brace-expansion": "^5.0.9"
           }
         },
         "path-scurry": {
@@ -19193,8 +19128,7 @@
     "tinyexec": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
-      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
-      "devOptional": true
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="
     },
     "tinyglobby": {
       "version": "0.2.17",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1380,9 +1380,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8857,9 +8857,9 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -11692,7 +11692,7 @@
       "integrity": "sha512-Oc96zvmxx1fqoSEdUmfmvvb59/KDOnUoJ7s2t7bISyAn0XEz57LCCw8k2Y4Pf3mwKaZLMciESALORLgfe2frCw==",
       "requires": {
         "@types/json-schema": "^7.0.15",
-        "js-yaml": "^4.1.0"
+        "js-yaml": "^4.3.1"
       }
     },
     "@apidevtools/openapi-schemas": {
@@ -12337,7 +12337,7 @@
         "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.3.1",
         "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       }
@@ -12445,7 +12445,7 @@
         "camelcase": "^5.3.1",
         "find-up": "^4.1.0",
         "get-package-type": "^0.1.0",
-        "js-yaml": "^3.13.1",
+        "js-yaml": "^3.15.1",
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
@@ -12469,9 +12469,9 @@
           }
         },
         "js-yaml": {
-          "version": "3.15.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-          "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+          "version": "3.15.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+          "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
           "dev": true,
           "requires": {
             "argparse": "^1.0.7",
@@ -15232,7 +15232,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "is-path-inside": "^3.0.3",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.3.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
@@ -17678,9 +17678,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "requires": {
         "argparse": "^2.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "@prisma/client": "^6.19.3",
+    "prisma": "^6.19.3",
     "bcrypt": "^6.0.0",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
@@ -92,7 +93,6 @@
     "eslint-config-prettier": "^10.1.5",
     "jest": "^30.4.2",
     "prettier": "^3.5.3",
-    "prisma": "^6.19.3",
     "supertest": "^7.1.0",
     "ts-jest": "^29.4.11",
     "tsx": "^4.20.1",
@@ -102,6 +102,8 @@
     "seed": "tsx prisma/seed.ts"
   },
   "overrides": {
-    "brace-expansion": "^5.0.8"
+    "brace-expansion": "^5.0.9",
+    "fast-uri": "^3.1.5",
+    "ip-address": "^10.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev": "tsx watch src/server.ts",
     "build": "tsc",
     "build:prod": "tsc -p tsconfig.build.json",
+    "postbuild:prod": "mkdir -p dist/docs && cp src/docs/swagger.yaml dist/docs/swagger.yaml",
     "prisma:studio": "prisma studio",
     "prisma:format": "prisma format",
     "prisma:generate": "prisma generate",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,10 @@
   "overrides": {
     "brace-expansion": "^5.0.9",
     "fast-uri": "^3.1.5",
-    "ip-address": "^10.3.1"
+    "ip-address": "^10.3.1",
+    "js-yaml": "^4.3.1",
+    "@istanbuljs/load-nyc-config": {
+      "js-yaml": "^3.15.1"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start": "node dist/server.js",
     "dev": "tsx watch src/server.ts",
     "build": "tsc",
+    "build:prod": "tsc -p tsconfig.build.json",
     "prisma:studio": "prisma studio",
     "prisma:format": "prisma format",
     "prisma:generate": "prisma generate",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4,7 +4,13 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url = env("DATABASE_URL")
+  url       = env("DATABASE_URL")
+  // Conexion directa (sin pooler/PgBouncer), usada SOLO por prisma migrate/db
+  // push -- el motor de migraciones necesita locks y estado de sesion que no
+  // sobreviven a traves de un connection pooler (ej. el -pooler de Neon).
+  // En un Postgres sin pooler (dev, CI, docker-compose) puede ser igual a
+  // DATABASE_URL. -- F3
+  directUrl = env("DIRECT_URL")
 }
 
 model Role {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,10 +1,15 @@
 import { PrismaClient, RoleName } from '@prisma/client';
 import * as bcrypt from 'bcrypt';
 import { addDays, subDays, addHours, format, setHours, setMinutes } from 'date-fns';
+import { assertSeedIsAllowed } from './seedGuard';
 
 const prisma = new PrismaClient();
 
 async function main() {
+  // Nunca debe correr contra produccion (borra todos los datos y crea
+  // usuarios con contraseñas conocidas). -- F3
+  assertSeedIsAllowed(process.env.NODE_ENV);
+
   console.log('Iniciando el sembrado de la base de datos...');
 
   const existingUsers = await prisma.user.count();

--- a/prisma/seedGuard.ts
+++ b/prisma/seedGuard.ts
@@ -1,0 +1,19 @@
+/**
+ * Guarda de seguridad para el script de sembrado (`prisma/seed.ts`).
+ *
+ * El seed borra TODOS los datos existentes y crea usuarios con contraseñas
+ * conocidas (admin@turnity.com/admin123, etc.). Nunca debe correr contra una
+ * base de datos de producción. Se extrae a un módulo aparte para poder
+ * testearla sin conectar a una base de datos real ni ejecutar `main()`.
+ *
+ * @param nodeEnv Valor actual de `process.env.NODE_ENV`.
+ * @throws Error si `nodeEnv` es `'production'`.
+ */
+export const assertSeedIsAllowed = (nodeEnv: string | undefined): void => {
+  if (nodeEnv === 'production') {
+    throw new Error(
+      'El seed de desarrollo no puede correr con NODE_ENV=production: borra todos los ' +
+        'datos existentes y crea usuarios con contraseñas conocidas. Abortando.',
+    );
+  }
+};

--- a/src/app.ts
+++ b/src/app.ts
@@ -12,6 +12,7 @@ import cookieParser from 'cookie-parser';
 import { errorHandler } from './shared/middleware/ErrorHandler';
 import { requestIdMiddleware } from './shared/middleware/RequestIdMiddleware';
 import { prisma } from './shared/config/Prisma';
+import { checkDatabaseReadiness } from './shared/health/ReadinessService';
 import { AuthContainer } from './modules/auth/AuthContainer';
 import { ServicesContainer } from './modules/services/ServicesContainer';
 import { AppointmentContainer } from './modules/appointments/AppointmentContainer';
@@ -90,6 +91,27 @@ class App {
         message: 'Turnity API is running',
         timestamp: new Date().toISOString(),
         version: process.env.npm_package_version || '1.0.0',
+      });
+    });
+
+    // Readiness probe: a diferencia de /health, esta si consulta la base de
+    // datos (SELECT 1). Usado por el smoke check del CD, no como HEALTHCHECK
+    // de Docker -- ver ReadinessService.ts para el detalle de esa decision.
+    this.app.get('/ready', async (req, res) => {
+      const isReady = await checkDatabaseReadiness(prisma);
+
+      if (isReady) {
+        res.status(200).json({
+          success: true,
+          checks: { database: 'up' },
+        });
+        return;
+      }
+
+      res.status(503).json({
+        success: false,
+        checks: { database: 'down' },
+        code: 'NOT_READY',
       });
     });
 

--- a/src/shared/health/ReadinessService.ts
+++ b/src/shared/health/ReadinessService.ts
@@ -1,0 +1,28 @@
+import { PrismaClient } from '@prisma/client';
+
+/**
+ * Verifica que la base de datos este accesible, ejecutando una consulta
+ * minima (SELECT 1).
+ *
+ * Se usa desde el endpoint /ready (readiness probe) -- a diferencia de
+ * /health (liveness, no toca la base), este chequeo responde la pregunta
+ * "¿esta la app en condiciones de recibir trafico real ahora mismo?".
+ * No se usa como HEALTHCHECK de Docker a proposito: un blip transitorio
+ * de la base no deberia disparar un reinicio del contenedor.
+ *
+ * Recibe solo la porcion de PrismaClient que necesita (Pick) para poder
+ * testear la funcion con un mock minimo, sin mockear el cliente completo.
+ *
+ * @param prisma Cliente de Prisma (o un mock con $queryRaw) a verificar.
+ * @returns true si la base respondio, false si la consulta fallo o tiro error.
+ */
+export const checkDatabaseReadiness = async (
+  prisma: Pick<PrismaClient, '$queryRaw'>,
+): Promise<boolean> => {
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    return true;
+  } catch {
+    return false;
+  }
+};

--- a/tests/integration/health.integration.test.ts
+++ b/tests/integration/health.integration.test.ts
@@ -1,0 +1,28 @@
+import request from 'supertest';
+import app from '../../src/app';
+
+describe('Health & Readiness Integration Tests', () => {
+  describe('GET /health', () => {
+    // Debería responder 200 sin depender de la base de datos
+    it('should respond 200 without depending on the database', async () => {
+      const response = await request(app).get('/health');
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.message).toBe('Turnity API is running');
+    });
+  });
+
+  describe('GET /ready', () => {
+    // Debería responder 200 cuando la base de datos esta disponible
+    it('should respond 200 when the database is available', async () => {
+      const response = await request(app).get('/ready');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        success: true,
+        checks: { database: 'up' },
+      });
+    });
+  });
+});

--- a/tests/unit/prisma/seedGuard.unit.test.ts
+++ b/tests/unit/prisma/seedGuard.unit.test.ts
@@ -1,0 +1,31 @@
+import { assertSeedIsAllowed } from '../../../prisma/seedGuard';
+
+describe('assertSeedIsAllowed', () => {
+  // con NODE_ENV=production
+  describe('with NODE_ENV=production', () => {
+    // Debería lanzar un error y no dejar continuar el seed
+    it('should throw and prevent the seed from continuing', () => {
+      expect(() => assertSeedIsAllowed('production')).toThrow(
+        /no puede correr con NODE_ENV=production/,
+      );
+    });
+  });
+
+  // con NODE_ENV distinto de production
+  describe('with NODE_ENV other than production', () => {
+    // Debería no lanzar cuando NODE_ENV es development
+    it('should not throw when NODE_ENV is development', () => {
+      expect(() => assertSeedIsAllowed('development')).not.toThrow();
+    });
+
+    // Debería no lanzar cuando NODE_ENV es test
+    it('should not throw when NODE_ENV is test', () => {
+      expect(() => assertSeedIsAllowed('test')).not.toThrow();
+    });
+
+    // Debería no lanzar cuando NODE_ENV es undefined
+    it('should not throw when NODE_ENV is undefined', () => {
+      expect(() => assertSeedIsAllowed(undefined)).not.toThrow();
+    });
+  });
+});

--- a/tests/unit/shared/health/ReadinessService.unit.test.ts
+++ b/tests/unit/shared/health/ReadinessService.unit.test.ts
@@ -1,0 +1,30 @@
+import { checkDatabaseReadiness } from '../../../../src/shared/health/ReadinessService';
+
+describe('checkDatabaseReadiness', () => {
+  // cuando la base de datos responde
+  describe('when the database responds', () => {
+    // Debería devolver true
+    it('should return true', async () => {
+      const mockPrisma = { $queryRaw: jest.fn().mockResolvedValue([{ '?column?': 1 }]) };
+
+      const result = await checkDatabaseReadiness(mockPrisma as never);
+
+      expect(result).toBe(true);
+      expect(mockPrisma.$queryRaw).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // cuando la base de datos no responde
+  describe('when the database does not respond', () => {
+    // Debería devolver false en vez de propagar el error
+    it('should return false instead of throwing', async () => {
+      const mockPrisma = {
+        $queryRaw: jest.fn().mockRejectedValue(new Error('connection refused')),
+      };
+
+      const result = await checkDatabaseReadiness(mockPrisma as never);
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests", "prisma"]
+}


### PR DESCRIPTION
## Que hace

Prepara el backend para desplegarse en produccion de forma reproducible:
imagen Docker versionada, health checks reales, y un pipeline de CD que
construye, publica y despliega automaticamente cada vez que CI pasa en
verde sobre main.

Hosting elegido: Render (imagen Docker) + Neon (Postgres serverless).

## Fase 0 - Base para produccion
- tsconfig.build.json + script build:prod (build sin tests, separado del
  build de desarrollo con type-check completo).
- prisma movido de devDependencies a dependencies (lo necesita el runtime,
  no solo el build).
- Guard que bloquea correr el seed si NODE_ENV=production.

## Fase 1 - Imagen Docker de produccion
- Dockerfile multi-stage (builder + runtime), usuario no-root, healthcheck
  embebido.
- .dockerignore actualizado para no llevar tests/coverage/logs a la imagen.

## Fase 2 - Health checks reales
- GET /health: liveness (el proceso esta arriba).
- GET /ready: readiness (la conexion a la base responde). Usado por Render
  para no enrutar trafico hasta que la app este realmente operativa.

## Fase 3 - Referencia local de produccion
- docker-compose.yml (solo para validar la imagen de produccion en local,
  no es lo que usa Render) con servicios db, migrate y api.
- .env.production.example documentando todas las variables necesarias.

## Fase 4 - CD hacia Render
- cd.yml: se dispara cuando CI termina en verde sobre main. Construye el
  stage runtime, lo publica en GHCR (:latest y :sha-<commit>), dispara el
  Deploy Hook de Render y espera a que /ready responda 200.
- Sanity check de build Docker agregado a ci.yml.
- Fix: se agrego DIRECT_URL al datasource de Prisma. Las migraciones
  necesitan una conexion directa (sin pooler) porque el motor de
  migraciones usa locks y estado de sesion que no sobreviven a traves de
  PgBouncer/el pooler de Neon.

## Pendiente despues de este merge
- Release develop -> main para que el CD corra por primera vez y publique
  la imagen en GHCR.
- Cambiar la visibilidad del paquete en GHCR a publica (paso manual unico).
- Crear el servicio en Render y cargar los secrets
  RENDER_DEPLOY_HOOK_URL / RENDER_APP_URL en GitHub.