### PR TITLE
Fix/render docker entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,6 +223,9 @@ $RECYCLE.BIN/
 
 # Scripts de automatización - no incluir en repositorio
 *.sh
+# Excepcion: lo copia el Dockerfile (stage runtime) y lo necesita Render
+# para migrar antes de arrancar -- tiene que viajar en el repo.
+!docker-entrypoint.sh
 src/docs/INTERVENTION_PLAN.md
 src/docs/session-handoff-v*.md
 src/docs/SKILL.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,15 @@ COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/prisma/schema.prisma ./prisma/schema.prisma
 COPY --from=builder /app/prisma/migrations ./prisma/migrations
 
+# Script opcional (no es el CMD por defecto -- docker-compose.yml sigue
+# usando su propio servicio "migrate" separado). Lo usa Render como Docker
+# Command: ahi no existe el Pre-Deploy Command (feature paga), asi que la
+# migracion se corre en el mismo arranque del contenedor, antes de node.
+# Se resuelve como un script en vez de "sh -c \"a && b\"" en el campo de
+# Render porque ese campo no siempre respeta las comillas al tokenizar.
+COPY --from=builder /app/docker-entrypoint.sh ./docker-entrypoint.sh
+RUN chmod +x ./docker-entrypoint.sh
+
 # src/shared/logger/logger.ts crea/escribe en ./logs al importarse (siempre,
 # salvo NODE_ENV=test). El resto de /app (node_modules, dist, prisma) el
 # proceso solo lo LEE -- los permisos por defecto (root:root, 644/755) ya

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+echo "Aplicando migraciones de Prisma..."
+npx prisma migrate deploy
+
+echo "Iniciando servidor..."
+exec node dist/server.js


### PR DESCRIPTION
El campo Docker Command de Render no siempre respeta las comillas al tokenizar el comando, asi que sh -c "a && b" le llegaba roto (exit 127, comando no encontrado). Se resuelve moviendo esa logica a un script dentro de la imagen (migra y despues arranca el server), asi el campo de Render solo necesita apuntar a un path simple, sin comillas ni operadores de shell. Se agrega tambien una excepcion en .gitignore, porque la regla *.sh (pensada para scripts locales) estaba dejando este archivo fuera del repositorio -- y el Dockerfile lo necesita para poder copiarlo durante el build.