### PR TITLE
fix: entrypoint de Docker para migrar antes de arrancar en Render

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,6 +223,9 @@ $RECYCLE.BIN/
 
 # Scripts de automatización - no incluir en repositorio
 *.sh
+# Excepcion: lo copia el Dockerfile (stage runtime) y lo necesita Render
+# para migrar antes de arrancar -- tiene que viajar en el repo.
+!docker-entrypoint.sh
 src/docs/INTERVENTION_PLAN.md
 src/docs/session-handoff-v*.md
 src/docs/SKILL.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,15 @@ COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/prisma/schema.prisma ./prisma/schema.prisma
 COPY --from=builder /app/prisma/migrations ./prisma/migrations
 
+# Script opcional (no es el CMD por defecto -- docker-compose.yml sigue
+# usando su propio servicio "migrate" separado). Lo usa Render como Docker
+# Command: ahi no existe el Pre-Deploy Command (feature paga), asi que la
+# migracion se corre en el mismo arranque del contenedor, antes de node.
+# Se resuelve como un script en vez de "sh -c \"a && b\"" en el campo de
+# Render porque ese campo no siempre respeta las comillas al tokenizar.
+COPY --from=builder /app/docker-entrypoint.sh ./docker-entrypoint.sh
+RUN chmod +x ./docker-entrypoint.sh
+
 # src/shared/logger/logger.ts crea/escribe en ./logs al importarse (siempre,
 # salvo NODE_ENV=test). El resto de /app (node_modules, dist, prisma) el
 # proceso solo lo LEE -- los permisos por defecto (root:root, 644/755) ya

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+echo "Aplicando migraciones de Prisma..."
+npx prisma migrate deploy
+
+echo "Iniciando servidor..."
+exec node dist/server.js


### PR DESCRIPTION
## Que hace

Corrige el arranque del contenedor en Render. El plan Free no tiene
Pre-Deploy Command (es una feature paga), asi que la migracion de Prisma
tiene que correr en el mismo arranque del contenedor, antes de levantar
el servidor.

El primer intento fue usar el campo "Docker Command" de Render con
`sh -c "npx prisma migrate deploy && node dist/server.js"`, pero ese campo
no siempre respeta las comillas al partir el texto en tokens, y el
contenedor fallaba con exit 127 ("command not found").

## Cambios

- Nuevo `docker-entrypoint.sh`: migra y despues arranca el server. Al
  quedar como un script con un solo path, el campo de Render no necesita
  interpretar comillas ni operadores de shell (&&).
- Dockerfile (stage runtime): copia el script y lo hace ejecutable. El
  CMD por defecto no cambia (sigue siendo `node dist/server.js`), asi que
  docker-compose.yml local no se ve afectado -- este script es opcional,
  lo usa Render explicitamente via su Docker Command.
- .gitignore: se agrega una excepcion para este archivo. La regla `*.sh`
  (pensada para scripts locales) lo estaba dejando fuera del repositorio.